### PR TITLE
Minor: Move copying/installing artifacts to end of Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,10 @@ ENV STORAGE_DB_URL jdbc:postgresql://postgres/postgres
 ENV PSQL_HOST postgres
 ENV XYZ_HUB_REDIS_HOST redis
 
-COPY xyz-hub-service/target/xyz-hub-service.jar .
-
 EXPOSE 8080 8181
 
 CMD java -jar xyz-hub-service.jar
 
 ADD Dockerfile /
+
+COPY xyz-hub-service/target/xyz-hub-service.jar .

--- a/Dockerfile-postgres
+++ b/Dockerfile-postgres
@@ -4,7 +4,7 @@ MAINTAINER Benjamin Rögner "benjamin.roegner@here.com"
 MAINTAINER Lucas Ceni "lucas.ceni@here.com"
 MAINTAINER Dimitar Goshev "dimitar.goshev@here.com"
 
+ENV POSTGRES_PASSWORD password
+
 RUN apt-get update && \
     apt-get -y install postgresql-9.6-postgis-2.5
-
-ENV POSTGRES_PASSWORD password


### PR DESCRIPTION
Moved copying/installing of artifacts to the end of the Dockerfiles. That way all non-changing steps are cached.