### PR TITLE
Extend the list of error codes in the ErrorResponse event

### DIFF
--- a/xyz-connectors/src/main/java/com/here/xyz/connectors/AbstractConnectorHandler.java
+++ b/xyz-connectors/src/main/java/com/here/xyz/connectors/AbstractConnectorHandler.java
@@ -27,7 +27,7 @@ import com.here.xyz.Typed;
 import com.here.xyz.XyzSerializable;
 import com.here.xyz.events.Event;
 import com.here.xyz.events.RelocatedEvent;
-import com.here.xyz.models.geojson.implementation.XyzError;
+import com.here.xyz.responses.XyzError;
 import com.here.xyz.responses.ErrorResponse;
 import com.here.xyz.responses.NotModifiedResponse;
 import java.io.ByteArrayOutputStream;

--- a/xyz-connectors/src/main/java/com/here/xyz/connectors/ErrorResponseException.java
+++ b/xyz-connectors/src/main/java/com/here/xyz/connectors/ErrorResponseException.java
@@ -19,7 +19,7 @@
 
 package com.here.xyz.connectors;
 
-import com.here.xyz.models.geojson.implementation.XyzError;
+import com.here.xyz.responses.XyzError;
 import com.here.xyz.responses.ErrorResponse;
 
 /**

--- a/xyz-connectors/src/main/java/com/here/xyz/connectors/ListenerConnector.java
+++ b/xyz-connectors/src/main/java/com/here/xyz/connectors/ListenerConnector.java
@@ -35,7 +35,7 @@ import com.here.xyz.events.ModifyFeaturesEvent;
 import com.here.xyz.events.ModifySpaceEvent;
 import com.here.xyz.events.SearchForFeaturesEvent;
 import com.here.xyz.models.geojson.implementation.FeatureCollection;
-import com.here.xyz.models.geojson.implementation.XyzError;
+import com.here.xyz.responses.XyzError;
 import com.here.xyz.responses.ErrorResponse;
 import com.here.xyz.responses.StatisticsResponse;
 import com.here.xyz.responses.SuccessResponse;

--- a/xyz-connectors/src/main/java/com/here/xyz/connectors/ProcessorConnector.java
+++ b/xyz-connectors/src/main/java/com/here/xyz/connectors/ProcessorConnector.java
@@ -34,7 +34,7 @@ import com.here.xyz.events.ModifyFeaturesEvent;
 import com.here.xyz.events.ModifySpaceEvent;
 import com.here.xyz.events.SearchForFeaturesEvent;
 import com.here.xyz.models.geojson.implementation.FeatureCollection;
-import com.here.xyz.models.geojson.implementation.XyzError;
+import com.here.xyz.responses.XyzError;
 import com.here.xyz.responses.ErrorResponse;
 import com.here.xyz.responses.HealthStatus;
 import com.here.xyz.responses.ModifiedEventResponse;

--- a/xyz-connectors/src/main/java/com/here/xyz/connectors/RelocationClient.java
+++ b/xyz-connectors/src/main/java/com/here/xyz/connectors/RelocationClient.java
@@ -26,7 +26,7 @@ import com.amazonaws.services.s3.AmazonS3URI;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.here.xyz.Payload;
 import com.here.xyz.events.RelocatedEvent;
-import com.here.xyz.models.geojson.implementation.XyzError;
+import com.here.xyz.responses.XyzError;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;

--- a/xyz-connectors/src/main/java/com/here/xyz/connectors/StorageConnector.java
+++ b/xyz-connectors/src/main/java/com/here/xyz/connectors/StorageConnector.java
@@ -35,7 +35,7 @@ import com.here.xyz.events.LoadFeaturesEvent;
 import com.here.xyz.events.ModifyFeaturesEvent;
 import com.here.xyz.events.ModifySpaceEvent;
 import com.here.xyz.events.SearchForFeaturesEvent;
-import com.here.xyz.models.geojson.implementation.XyzError;
+import com.here.xyz.responses.XyzError;
 import com.here.xyz.responses.ErrorResponse;
 import com.here.xyz.responses.HealthStatus;
 import com.here.xyz.responses.XyzResponse;

--- a/xyz-connectors/src/main/java/com/here/xyz/connectors/mocks/MockedProcessor.java
+++ b/xyz-connectors/src/main/java/com/here/xyz/connectors/mocks/MockedProcessor.java
@@ -23,7 +23,7 @@ import com.here.xyz.connectors.ErrorResponseException;
 import com.here.xyz.connectors.NotificationParams;
 import com.here.xyz.connectors.ProcessorConnector;
 import com.here.xyz.events.ModifySpaceEvent;
-import com.here.xyz.models.geojson.implementation.XyzError;
+import com.here.xyz.responses.XyzError;
 
 @SuppressWarnings("unused")
 public class MockedProcessor extends ProcessorConnector {

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/test/ErrorPreProcessor.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/test/ErrorPreProcessor.java
@@ -23,7 +23,7 @@ import com.here.xyz.connectors.ErrorResponseException;
 import com.here.xyz.connectors.NotificationParams;
 import com.here.xyz.connectors.ProcessorConnector;
 import com.here.xyz.events.ModifyFeaturesEvent;
-import com.here.xyz.models.geojson.implementation.XyzError;
+import com.here.xyz.responses.XyzError;
 
 public class ErrorPreProcessor extends ProcessorConnector {
     @Override

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/test/TestStorageConnector.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/test/TestStorageConnector.java
@@ -39,7 +39,7 @@ import com.here.xyz.models.geojson.implementation.Feature;
 import com.here.xyz.models.geojson.implementation.FeatureCollection;
 import com.here.xyz.models.geojson.implementation.Point;
 import com.here.xyz.models.geojson.implementation.Properties;
-import com.here.xyz.models.geojson.implementation.XyzError;
+import com.here.xyz.responses.XyzError;
 import com.here.xyz.models.geojson.implementation.XyzNamespace;
 import com.here.xyz.responses.SuccessResponse;
 import com.here.xyz.responses.XyzResponse;

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/Api.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/Api.java
@@ -46,7 +46,7 @@ import com.here.xyz.hub.task.Task;
 import com.here.xyz.hub.util.logging.AccessLog;
 import com.here.xyz.hub.util.logging.Logging;
 import com.here.xyz.models.geojson.implementation.FeatureCollection;
-import com.here.xyz.models.geojson.implementation.XyzError;
+import com.here.xyz.responses.XyzError;
 import com.here.xyz.models.hub.Space.Internal;
 import com.here.xyz.models.hub.Space.Public;
 import com.here.xyz.models.hub.Space.WithConnectors;

--- a/xyz-models/src/main/java/com/here/xyz/XyzSerializable.java
+++ b/xyz-models/src/main/java/com/here/xyz/XyzSerializable.java
@@ -19,8 +19,8 @@
 
 package com.here.xyz;
 
-import static com.here.xyz.models.geojson.implementation.XyzError.EXCEPTION;
-import static com.here.xyz.models.geojson.implementation.XyzError.TIMEOUT;
+import static com.here.xyz.responses.XyzError.EXCEPTION;
+import static com.here.xyz.responses.XyzError.TIMEOUT;
 
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/xyz-models/src/main/java/com/here/xyz/responses/ErrorResponse.java
+++ b/xyz-models/src/main/java/com/here/xyz/responses/ErrorResponse.java
@@ -21,7 +21,6 @@ package com.here.xyz.responses;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.here.xyz.models.geojson.implementation.XyzError;
 
 /**
  * An error response.

--- a/xyz-models/src/main/java/com/here/xyz/responses/XyzError.java
+++ b/xyz-models/src/main/java/com/here/xyz/responses/XyzError.java
@@ -17,11 +17,10 @@
  * License-Filename: LICENSE
  */
 
-package com.here.xyz.models.geojson.implementation;
+package com.here.xyz.responses;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonValue;
-import com.here.xyz.responses.ErrorResponse;
 
 /**
  * An enumeration of all possible error codes that can happen while processing a request. Be aware that the XYZ Hub itself will respond
@@ -29,21 +28,41 @@ import com.here.xyz.responses.ErrorResponse;
  */
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public enum XyzError {
+
   /**
-   * An event that was sent to a remote function which is required to process the request failed, because it does not support this event.
-   * Details may be found in the {@link ErrorResponse#getErrorMessage()}.
+   * An unexpected error (not further specified) happened while processing the request.
    *
-   * This will lead to a HTTP 502 Bad Gateway response.
+   * This can result in a 502 Bad Gateway.
+   */
+  EXCEPTION("Exception"),
+
+  /**
+   * An event that was sent to the connector failed, because the connector cannot process it.
+   *
+   * This will result in an 501 Not Implemented response.
    */
   NOT_IMPLEMENTED("NotImplemented"),
 
   /**
-   * The tile level is not supported by a remove function required to process the request (for example the storage connector) or it is
-   * generally invalid (for example less than zero or not well formed).
+   * A conflict occurred when updating a feature.
    *
-   * This will lead to a HTTP 400 Bad Request response.
+   * This will result in an 409 Conflict response.
    */
-  INVALID_TILE_LEVEL("InvalidTileLevel"),
+  CONFLICT("Conflict"),
+
+   /**
+   * Indicates an authorization error.
+   *
+   * This will result in an 401 Forbidden response.
+   */
+  FORBIDDEN("Forbidden"),
+
+  /**
+   * The connector cannot handle the request due to a processing limitation in an upstream service or a database.
+   *
+   * This will result in an 429 Too Many Requests response.
+   */
+  TOO_MANY_REQUESTS("TooManyRequests"),
 
   /**
    * A provided argument is invalid or missing.
@@ -53,28 +72,18 @@ public enum XyzError {
   ILLEGAL_ARGUMENT("IllegalArgument"),
 
   /**
-   * Any service or remote function required to process the request was not reachable. Details about which remote function failed will be
-   * found in the {@link ErrorResponse#getErrorMessage()}.
+   * Any service or remote function required to process the request was not reachable.
    *
-   * This will lead to a HTTP 502 Bad Gateway response.
+   * This will result in a 502 Bad Gateway response.
    */
   BAD_GATEWAY("BadGateway"),
 
   /**
    * The request was aborted due to a timeout.
    *
-   * This will lead to a HTTP 504 Gateway Timeout response.
+   * This will result in a HTTP 504 Gateway Timeout response.
    */
-  TIMEOUT("Timeout"),
-
-  /**
-   * An unexpected error (not further specified) happened while processing the request. Details will be found in the {@link
-   * ErrorResponse#getErrorMessage()}.
-   *
-   * This can lead to different HTTP status codes, for example 500 Internal Server Error or 502 Bad Gateway, dependent on what was the
-   * source of the error.
-   */
-  EXCEPTION("Exception");
+  TIMEOUT("Timeout");
 
   /**
    * The error code.

--- a/xyz-models/src/test/java/com/here/xyz/JsonMappingTest.java
+++ b/xyz-models/src/test/java/com/here/xyz/JsonMappingTest.java
@@ -32,7 +32,7 @@ import com.here.xyz.events.CountFeaturesEvent;
 import com.here.xyz.events.EventNotification;
 import com.here.xyz.events.ModifyFeaturesEvent;
 import com.here.xyz.models.geojson.implementation.Feature;
-import com.here.xyz.models.geojson.implementation.XyzError;
+import com.here.xyz.responses.XyzError;
 import com.here.xyz.models.hub.Space;
 import com.here.xyz.responses.ErrorResponse;
 import java.io.IOException;

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/PSQLRequestStreamHandler.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/PSQLRequestStreamHandler.java
@@ -25,7 +25,7 @@ import com.here.xyz.connectors.StorageConnector;
 import com.here.xyz.events.Event;
 import com.here.xyz.events.HealthCheckEvent;
 import com.here.xyz.events.QueryEvent;
-import com.here.xyz.models.geojson.implementation.XyzError;
+import com.here.xyz.responses.XyzError;
 import com.here.xyz.responses.CountResponse;
 import com.here.xyz.responses.ErrorResponse;
 import com.here.xyz.responses.HealthStatus;
@@ -49,7 +49,6 @@ import org.apache.commons.dbutils.ResultSetHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.mchange.v2.c3p0.ComboPooledDataSource;
-import com.mchange.v2.c3p0.C3P0Registry;
 
 
 @SuppressWarnings("SqlDialectInspection")

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/PSQLXyzConnector.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/PSQLXyzConnector.java
@@ -50,7 +50,7 @@ import com.here.xyz.models.geojson.implementation.Feature;
 import com.here.xyz.models.geojson.implementation.FeatureCollection;
 import com.here.xyz.models.geojson.implementation.FeatureCollection.ModificationFailure;
 import com.here.xyz.models.geojson.implementation.Geometry;
-import com.here.xyz.models.geojson.implementation.XyzError;
+import com.here.xyz.responses.XyzError;
 import com.here.xyz.responses.CountResponse;
 import com.here.xyz.responses.ErrorResponse;
 import com.here.xyz.responses.StatisticsResponse;

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/QuadClustering.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/QuadClustering.java
@@ -3,7 +3,7 @@ package com.here.xyz.psql;
 import com.here.xyz.connectors.ErrorResponseException;
 import com.here.xyz.events.GetFeaturesByBBoxEvent;
 import com.here.xyz.models.geojson.WebMercatorTile;
-import com.here.xyz.models.geojson.implementation.XyzError;
+import com.here.xyz.responses.XyzError;
 
 public class QuadClustering {
     public static final String QUAD = "quad";


### PR DESCRIPTION
Add new XyzError types CONFLICT, FORBIDDEN and TOO_MANY_REQUEST.
Remove INVALID_TILE_LEVEL - ILLEGAL_ARGUMENT should be used instead.
The XyzError class is moved to the com.here.xyz.responses package.

Signed-off-by: Dimitar Goshev <dimitar.goshev@here.com>