### PR TITLE
Switch to RollingRandomAccessFile appender

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/Service.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/Service.java
@@ -263,8 +263,6 @@ public class Service implements Logging {
     public String JWT_PUB_KEY;
     public Authorization.AuthorizationType XYZ_HUB_AUTH;
     public String LOG_CONFIG;
-    public String LOGGING_TYPE;
-    public String LOG_PATH;
     public boolean INSERT_LOCAL_CONNECTORS;
     public String PSQL_HOST;
 

--- a/xyz-hub-service/src/main/resources/config.json
+++ b/xyz-hub-service/src/main/resources/config.json
@@ -11,8 +11,7 @@
   "XYZ_HUB_REDIS_HOST": "localhost",
 
   "LOG_CONFIG": "log4j2-console-plain.json",
-  "LOGGING_TYPE": "Console",
-  "LOG_PATH": "/var/log/xyzhub",
+
   "INSERT_LOCAL_CONNECTORS": true,
 
   "STORAGE_DB_URL": "jdbc:postgresql://localhost/postgres",

--- a/xyz-hub-service/src/main/resources/log4j2-docker-debug.json
+++ b/xyz-hub-service/src/main/resources/log4j2-docker-debug.json
@@ -9,7 +9,7 @@
       "level": "info"
     },
     "appenders": {
-      "RollingFile": {
+      "RollingRandomAccessFile": {
         "name": "RollingFile-Appender",
         "fileName": "${env:LOG_PATH}/trace.log.0",
         "filePattern": "${env:LOG_PATH}/trace.log.%i",
@@ -29,11 +29,11 @@
         },
         "Policies": {
           "SizeBasedTriggeringPolicy": {
-            "size": "100 MB"
+            "size": "64 MB"
           }
         },
         "DefaultRolloverStrategy": {
-          "max": "1"
+          "max": "2"
         }
       }
     },

--- a/xyz-hub-service/src/main/resources/log4j2-docker.json
+++ b/xyz-hub-service/src/main/resources/log4j2-docker.json
@@ -9,7 +9,7 @@
       "level": "info"
     },
     "appenders": {
-      "RollingFile": {
+      "RollingRandomAccessFile": {
         "name": "RollingFile-Appender",
         "fileName": "${env:LOG_PATH}/trace.log.0",
         "filePattern": "${env:LOG_PATH}/trace.log.%i",
@@ -29,11 +29,11 @@
         },
         "Policies": {
           "SizeBasedTriggeringPolicy": {
-            "size": "100 MB"
+            "size": "64 MB"
           }
         },
         "DefaultRolloverStrategy": {
-          "max": "1"
+          "max": "2"
         }
       }
     },

--- a/xyz-hub-service/src/main/resources/log4j2.component.properties
+++ b/xyz-hub-service/src/main/resources/log4j2.component.properties
@@ -18,7 +18,7 @@
 #
 
 log4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector
-log4j2.asyncLoggerRingBufferSize=16384
+log4j2.asyncLoggerRingBufferSize=65536
 log4j2.asyncQueueFullPolicy=Discard
 log4j2.discardThreshold=WARN
-AsyncLogger.SynchronizeEnqueueWhenQueueFull=false
+log4j2.clock=CachedClock


### PR DESCRIPTION
Switch the default appender type to RollingRandomAccessFile and other minor improvements in the log configuration.
Remove the obsolete configuration parameters LOG_PATH and LOGGING_TYPE

Signed-off-by: Dimitar Goshev <dimitar.goshev@here.com>