### PR TITLE
Minor: log configuration improvements

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/Service.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/Service.java
@@ -82,7 +82,7 @@ public class Service {
   /**
    * The log4J2 console configuration
    */
-  private static final String CONSOLE_LOG_CONFIG = "log4j2-console-json.json";
+  private static final String CONSOLE_LOG_CONFIG = "log4j2-console-plain.json";
 
   /**
    * The entry point to the Vert.x core API.

--- a/xyz-hub-service/src/main/resources/log4j2-console-json.json
+++ b/xyz-hub-service/src/main/resources/log4j2-console-json.json
@@ -19,7 +19,7 @@
         "name": "STDOUT",
         "PatternLayout": {
           "MarkerPatternSelector": {
-            "defaultPattern": "{\"t\":\"%p\",\"time\":\"%d{ISO8601}\",\"unixtime\":\"%d{UNIX_MILLIS}\",\"msg\":\"%enc{%.-4096msg}{JSON}\",\"streamId\":\"%marker\"}%n%xEx{none}",
+            "defaultPattern": "{\"t\":\"%p\",\"time\":\"%d{ISO8601}\",\"unixtime\":\"%d{UNIX_MILLIS}\",\"msg\":\"%enc{%.-4096msg%ex}{JSON} \",\"streamId\":\"%marker\"}%n%xEx{none}",
             "PatternMatch": {
               "key": "ACCESS",
               "pattern": "%m%n"

--- a/xyz-hub-service/src/main/resources/log4j2-console-plain.json
+++ b/xyz-hub-service/src/main/resources/log4j2-console-plain.json
@@ -18,7 +18,7 @@
       "Console": {
         "name": "STDOUT",
         "PatternLayout": {
-          "pattern": "%d %-5p %c{1} %.-4096msg%throwable%n%xEx{none}"
+          "pattern": "%d %-5p %c{1} %.-4096msg %enc{%ex}{JSON}%n%xEx{none}"
         }
       }
     },

--- a/xyz-hub-service/src/main/resources/log4j2-docker-debug.json
+++ b/xyz-hub-service/src/main/resources/log4j2-docker-debug.json
@@ -20,7 +20,7 @@
         "fileName": "${env:LOG_PATH}/trace.log.0",
         "filePattern": "${env:LOG_PATH}/trace.log.%i",
         "PatternLayout": {
-          "pattern": "{\"t\":\"%p\",\"time\":\"%d{ISO8601}\",\"unixtime\":\"%d{UNIX_MILLIS}\",\"src\":\"%C{1}:%L\",\"msg\":\"%replace{%replace{%.-4096msg%throwable}{[\n]}{\\\\n}}{[\\\"]}{\\\\\"}\",\"streamId\":\"%marker\"}%n%xEx{none}"
+          "pattern": "{\"t\":\"%p\",\"time\":\"%d{ISO8601}\",\"unixtime\":\"%d{UNIX_MILLIS}\",\"src\":\"%C{1}:%L\",\"msg\":\"%replace{%replace{%.-4096msg%ex}{[\n]}{\\\\n}}{[\\\"]}{\\\\\"}\",\"streamId\":\"%marker\"}%n%xEx{none}"
         },
 
         "Policies": {

--- a/xyz-hub-service/src/main/resources/log4j2-docker.json
+++ b/xyz-hub-service/src/main/resources/log4j2-docker.json
@@ -21,7 +21,7 @@
         "filePattern": "${env:LOG_PATH}/trace.log.%i",
         "PatternLayout": {
           "MarkerPatternSelector": {
-            "defaultPattern": "{\"t\":\"%p\",\"time\":\"%d{ISO8601}\",\"unixtime\":\"%d{UNIX_MILLIS}\",\"msg\":\"%enc{%.-4096msg}{JSON}\",\"streamId\":\"%marker\"}%n%xEx{none}",
+            "defaultPattern": "{\"t\":\"%p\",\"time\":\"%d{ISO8601}\",\"unixtime\":\"%d{UNIX_MILLIS}\",\"msg\":\"%enc{%.-4096msg%ex}{JSON} \",\"streamId\":\"%marker\"}%n%xEx{none}",
             "PatternMatch": {
               "key": "ACCESS",
               "pattern": "%m%n"

--- a/xyz-hub-service/src/main/resources/log4j2.component.properties
+++ b/xyz-hub-service/src/main/resources/log4j2.component.properties
@@ -20,5 +20,5 @@
 log4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector
 log4j2.asyncLoggerRingBufferSize=65536
 log4j2.asyncQueueFullPolicy=Discard
-log4j2.discardThreshold=WARN
+log4j2.discardThreshold=INFO
 log4j2.clock=CachedClock


### PR DESCRIPTION
Change the discard level when the log queue is full to INFO.
Change the default logging config file  to log4j2-console-plain.json
Add the exception stack trace in the log.

Signed-off-by: Dimitar Goshev <dimitar.goshev@here.com>