### PR TITLE
Fix DynamoClient to work with real AWS region IDs instead of enum names

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/config/DynamoClient.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/config/DynamoClient.java
@@ -57,7 +57,7 @@ public class DynamoClient {
     final ARN arn = new ARN(tableArn);
 
     final AmazonDynamoDBAsyncClientBuilder builder = AmazonDynamoDBAsyncClientBuilder.standard();
-    if (Arrays.stream(Region.values()).noneMatch(r -> r.name().equals(arn.getRegion()))) {
+    if (Arrays.stream(Region.values()).noneMatch(r -> r.toAWSRegion().getName().equals(arn.getRegion()))) {
       builder.setCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials("dummy", "dummy")));
       final String endpoint = String.format("http://%s:%s", arn.getRegion(), Integer.parseInt(arn.getAccountId()));
       builder.setEndpointConfiguration(new EndpointConfiguration(endpoint, "US-WEST-1"));


### PR DESCRIPTION
Signed-off-by: Benjamin Rögner <benjamin.roegner@here.com>