### PR TITLE
Improve documentation for the service configuration parameters.

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/Service.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/Service.java
@@ -270,6 +270,16 @@ public class Service {
     public String HOST_NAME;
 
     /**
+     * The initial number of instances.
+     */
+    public int INSTANCE_COUNT;
+
+    /**
+     *  The S3 Bucket, which connectors with transfer limitations, could use to relocate responses.
+     */
+    public String XYZ_HUB_S3_BUCKET;
+
+    /**
      * The public endpoint.
      */
     public String XYZ_HUB_PUBLIC_ENDPOINT;
@@ -378,10 +388,5 @@ public class Service {
      * The value of the health check header to instruct for additional health status information.
      */
     public String HEALTH_CHECK_HEADER_VALUE;
-
-    /**
-     *  The S3 Bucket, which connectors with transfer limitations, could use to relocate responses.
-     */
-    public String XYZ_HUB_S3_BUCKET;
   }
 }

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/Service.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/Service.java
@@ -80,14 +80,14 @@ public class Service {
   public static final String HOST_ID = UUID.randomUUID().toString();
 
   /**
-   * The LOGJ2 configuration file.
+   * The LOG4J configuration file.
    */
   private static final String CONSOLE_LOG_CONFIG = "log4j2-console-plain.json";
 
   /**
    * The entry point to the Vert.x core API.
    */
-  public static Vertx  vertx;
+  public static Vertx vertx;
 
   /**
    * The service configuration.

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/Service.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/Service.java
@@ -80,14 +80,14 @@ public class Service {
   public static final String HOST_ID = UUID.randomUUID().toString();
 
   /**
-   * The log4J2 console configuration
+   * The LOGJ2 configuration file.
    */
   private static final String CONSOLE_LOG_CONFIG = "log4j2-console-plain.json";
 
   /**
    * The entry point to the Vert.x core API.
    */
-  public static Vertx vertx;
+  public static Vertx  vertx;
 
   /**
    * The service configuration.
@@ -258,45 +258,130 @@ public class Service {
    */
   @JsonIgnoreProperties(ignoreUnknown = true)
   public static class Config {
+
+    /**
+     * The port of the HTTP server.
+     */
     public int HTTP_PORT;
-    public String XYZ_HUB_REDIS_HOST;
-    public int XYZ_HUB_REDIS_PORT;
-    public String XYZ_HUB_S3_BUCKET;
 
-    public String JWT_PUB_KEY;
-    public Authorization.AuthorizationType XYZ_HUB_AUTH;
-    public String LOG_CONFIG;
-    public boolean INSERT_LOCAL_CONNECTORS;
-    public String PSQL_HOST;
-
-    public String DEFAULT_STORAGE_ID;
-
-    public String STORAGE_DB_URL;
-    public String STORAGE_DB_USER;
-    public String STORAGE_DB_PASSWORD;
-
-    public String SPACES_DYNAMODB_TABLE_ARN;
-    public String CONNECTORS_DYNAMODB_TABLE_ARN;
-    public String PACKAGES_DYNAMODB_TABLE_ARN;
-
-    public int INSTANCE_COUNT;
-    public ARN ADMIN_MESSAGE_TOPIC_ARN;
-    public String ADMIN_MESSAGE_JWT;
-    public int ADMIN_MESSAGE_PORT;
-
-    public String XYZ_HUB_PUBLIC_PROTOCOL;
-    public String XYZ_HUB_PUBLIC_HOST;
-    public int XYZ_HUB_PUBLIC_PORT;
-
+    /**
+     * The hostname, which under instances can use to contact the this service node.
+     */
     public String HOST_NAME;
 
+    /**
+     * The public endpoint.
+     */
+    public String XYZ_HUB_PUBLIC_ENDPOINT;
+
+    /**
+     * The redis host.
+     */
+    public String XYZ_HUB_REDIS_HOST;
+
+    /**
+     * The redis port.
+     */
+    public int XYZ_HUB_REDIS_PORT;
+
+    /**
+     * The authorization type.
+     */
+    public Authorization.AuthorizationType XYZ_HUB_AUTH;
+
+    /**
+     * The public key used for verifying the signature of the JWT tokens.
+     */
+    public String JWT_PUB_KEY;
+
+    /**
+     * The LOG4J config file location.
+     */
+    public String LOG_CONFIG;
+
+    /**
+     * If set to true, the connectors configuration will be populated with connectors defined in connectors.json.
+     */
+    public boolean INSERT_LOCAL_CONNECTORS;
+
+    /**
+     * The ID of the default storage connector.
+     */
+    public String DEFAULT_STORAGE_ID;
+
+    /**
+     * The PostgreSQL URL.
+     */
+    public String STORAGE_DB_URL;
+
+    /**
+     * The database user.
+     */
+    public String STORAGE_DB_USER;
+
+    /**
+     * The database password.
+     */
+    public String STORAGE_DB_PASSWORD;
+
+    /**
+     * The ARN of the space table in DynamoDB.
+     */
+    public String SPACES_DYNAMODB_TABLE_ARN;
+
+    /**
+     * The ARN of the connectors table in DynamoDB.
+     */
+    public String CONNECTORS_DYNAMODB_TABLE_ARN;
+
+    /**
+     * The ARN of the packages table in DynamoDB.
+     */
+    public String PACKAGES_DYNAMODB_TABLE_ARN;
+
+    /**
+     * The ARN of the admin message topic.
+     */
+    public ARN ADMIN_MESSAGE_TOPIC_ARN;
+
+    /**
+     * The JWT token used for sending admin messages.
+     */
+    public String ADMIN_MESSAGE_JWT;
+
+    /**
+     * The port for the admin message server.
+     */
+    public int ADMIN_MESSAGE_PORT;
+
+    /**
+     * The total size assigned for remote functions queues.
+     */
     public int GLOBAL_MAX_QUEUE_SIZE; //MB
+
+    /**
+     * The default timeout for remote functions requests.
+     */
     public int REMOTE_FUNCTION_REQUEST_TIMEOUT; //seconds
 
+    /**
+     * The web root for serving static resources from the file system.
+     */
     public String FS_WEB_ROOT;
 
+    /**
+     * The name of the health check header to instruct for additional health status information.
+     */
     public String HEALTH_CHECK_HEADER_NAME;
+
+    /**
+     * The value of the health check header to instruct for additional health status information.
+     */
     public String HEALTH_CHECK_HEADER_VALUE;
 
+    /**
+     *  The S3 Bucket, which connectors with transfer limitations, could use to relocate responses.
+     */
+    public String XYZ_HUB_S3_BUCKET;
   }
 }

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/health/HealthApi.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/health/HealthApi.java
@@ -71,7 +71,7 @@ public class HealthApi extends Api {
     //The main health check endpoint
     router.route(HttpMethod.GET, MAIN_HEALTCHECK_ENDPOINT).handler(HealthApi::onHealthStatus);
     router.route(HttpMethod.GET, "/hub").handler(HealthApi::onHealthStatus);
-    router.route(HttpMethod.GET, "/").handler(HealthApi::onHealthStatus); //TODO: Maybe better replace that one by a redirect to /hub/
+    router.route(HttpMethod.GET, "/").handler(HealthApi::onHealthStatus); // TODO: Maybe better replace that one by a redirect to /hub/
     //Legacy:
     router.route(HttpMethod.GET, "/hub/health-status").handler(HealthApi::onHealthStatus);
   }
@@ -86,14 +86,7 @@ public class HealthApi extends Api {
   }
 
   private static URI getPublicServiceEndpoint() {
-    try {
-      return new URI(Service.configuration.XYZ_HUB_PUBLIC_PROTOCOL, null,
-          Service.configuration.XYZ_HUB_PUBLIC_HOST, Service.configuration.XYZ_HUB_PUBLIC_PORT,
-          MAIN_HEALTCHECK_ENDPOINT, null, null);
-    } catch (URISyntaxException e) {
-      logger.error("Wrong format of public service endpoint URI: " + Service.configuration.XYZ_HUB_PUBLIC_HOST, e);
-      return null;
-    }
+    return URI.create(Service.configuration.XYZ_HUB_PUBLIC_ENDPOINT + MAIN_HEALTCHECK_ENDPOINT);
   }
 
   private static URI getNodeHealthCheckEndpoint() {

--- a/xyz-hub-service/src/main/resources/config.json
+++ b/xyz-hub-service/src/main/resources/config.json
@@ -7,21 +7,20 @@
   "JWT_PUB_KEY": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0XyPlkIr5oFvTiSg9MAMgoY5gLXwX7uY2TsegfCO7x80ZixTJIjW+gfCdtGJtkCdl5a15YV8la0jnBqneprgasdjsxAldWUkKtA8MiEAylRM88OYC3menXvhZFyOE3NurV6oSQtMIKggg1nejCwVfVfAaHTtuTnP9Bez0wDlm4MO64cRE7JwspMjEI3rOwZcI7qQJ1cM0NQmm4WEXtefOSoucJ2WPuGM+Zhu32kMb3MUvJKlkicssr8fsNF/HQ8zN2NVvpitLThn+CYM3xkZAanY2+88OBK9kjwPtJQR0KQ2EKC4KYT/6prM/triwerLoy32ioLnNNWB/O9OnaeiqQIDAQAB",
   "XYZ_HUB_AUTH": "DUMMY",
 
-  "XYZ_HUB_REDIS_PORT": 6379,
   "XYZ_HUB_REDIS_HOST": "localhost",
+  "XYZ_HUB_REDIS_PORT": 6379,
 
   "LOG_CONFIG": "log4j2-console-plain.json",
 
   "DEFAULT_STORAGE_ID": "psql",
-  "INSERT_LOCAL_CONNECTORS": true,
 
   "STORAGE_DB_URL": "jdbc:postgresql://localhost/postgres",
   "STORAGE_DB_USER": "postgres",
   "STORAGE_DB_PASSWORD": "password",
 
-  "PSQL_HOST": "localhost",
+  "INSERT_LOCAL_CONNECTORS": true,
 
-  "XYZ_HUB_PUBLIC_PROTOCOL": "http",
+  "XYZ_HUB_PUBLIC_ENDPOINT": "http://localhost:8080",
   "XYZ_HUB_PUBLIC_HOST": "localhost",
   "XYZ_HUB_PUBLIC_PORT": 8080,
 

--- a/xyz-hub-service/src/main/resources/connectors.json
+++ b/xyz-hub-service/src/main/resources/connectors.json
@@ -23,7 +23,7 @@
       "className": "com.here.xyz.psql.PSQLXyzConnector",
       "env": {
         "PSQL_HOST": "${PSQL_HOST}",
-        "PSQL_HOST": "${PSQL_PORT}",
+        "PSQL_PORT": "${PSQL_PORT}",
         "PSQL_USER": "${PSQL_USER}",
         "PSQL_PASSWORD": "${PSQL_PASSWORD}"
       }

--- a/xyz-hub-service/src/main/resources/connectors.json
+++ b/xyz-hub-service/src/main/resources/connectors.json
@@ -23,8 +23,9 @@
       "className": "com.here.xyz.psql.PSQLXyzConnector",
       "env": {
         "PSQL_HOST": "${PSQL_HOST}",
-        "PSQL_USER": "postgres",
-        "PSQL_PASSWORD": "password"
+        "PSQL_HOST": "${PSQL_PORT}",
+        "PSQL_USER": "${PSQL_USER}",
+        "PSQL_PASSWORD": "${PSQL_PASSWORD}"
       }
     }
   },


### PR DESCRIPTION
Add documentation.
Replace the Public endpoint parameters.
Use the same PostgreSQL instance for the service and the embedded connector.

Signed-off-by: Dimitar Goshev <dimitar.goshev@here.com>