### PR TITLE
Fix HTTPFunctionClient to use postAbs method of the webClient

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/HTTPFunctionClient.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/HTTPFunctionClient.java
@@ -88,7 +88,7 @@ public class HTTPFunctionClient extends QueueingRemoteFunctionClient {
   protected void invoke(Marker marker, byte[] bytes, Handler<AsyncResult<byte[]>> callback) {
     logger.debug(marker, "Invoke http remote function '{}' Event size is: {}", remoteFunction.id, bytes.length);
 
-    webClient.post(url)
+    webClient.postAbs(url)
         .timeout(REQUEST_TIMEOUT)
         .sendBuffer(Buffer.buffer(bytes), ar -> {
           if (ar.failed()) {

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/RpcClient.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/RpcClient.java
@@ -200,7 +200,7 @@ public class RpcClient {
   private void parseResponse(Marker marker, final byte[] bytes, @SuppressWarnings("rawtypes") Handler<AsyncResult<XyzResponse>> callback) {
     String stringResponse = null;
     if (bytes != null) {
-      stringResponse = new String(bytes, StandardCharsets.UTF_8);
+      stringResponse = new String(bytes);
     }
     if (bytes == null || stringResponse.length() == 0) {
       logger.error(marker, "Received empty response, but expected a JSON response.", new NullPointerException());


### PR DESCRIPTION
Signed-off-by: Benjamin Rögner <benjamin.roegner@here.com>

#post() didn't respect the host of the URL.