### PR TITLE
Add JCL bridge dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -320,7 +320,6 @@
         <version>${aws-sdk-version}</version>
       </dependency>
 
-
       <!-- AWS Lambda Core -->
       <dependency>
         <groupId>com.amazonaws</groupId>
@@ -397,6 +396,11 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
+        <version>${log4j-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-jcl</artifactId>
         <version>${log4j-version}</version>
       </dependency>
       <dependency>

--- a/xyz-hub-service/pom.xml
+++ b/xyz-hub-service/pom.xml
@@ -105,6 +105,18 @@
                     <exclude>**/Log4j2Plugins.dat</exclude>
                   </excludes>
                 </filter>
+                <filter>
+                  <artifact>org.apache.logging.log4j:log4j-jcl</artifact>
+                  <includes>
+                    <include>**</include>
+                  </includes>
+                </filter>
+                <filter>
+                  <artifact>commons-logging:commons-logging</artifact>
+                  <includes>
+                    <include>**</include>
+                  </includes>
+                </filter>
               </filters>
               <finalName>xyz-hub-service</finalName>
               <transformers>
@@ -179,6 +191,10 @@
     <dependency>
       <artifactId>log4j-core</artifactId>
       <groupId>org.apache.logging.log4j</groupId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-jcl</artifactId>
     </dependency>
     <dependency>
       <artifactId>disruptor</artifactId>

--- a/xyz-psql-connector/pom.xml
+++ b/xyz-psql-connector/pom.xml
@@ -107,6 +107,12 @@
               </excludes>
             </filter>
             <filter>
+              <artifact>org.apache.logging.log4j:log4j-slf4j-impl</artifact>
+              <includes>
+                <include>**</include>
+              </includes>
+            </filter>
+            <filter>
               <artifact>commons-logging:commons-logging</artifact>
               <includes>
                 <include>**</include>
@@ -114,6 +120,12 @@
             </filter>
             <filter>
               <artifact>org.apache.logging.log4j:log4j-core</artifact>
+              <includes>
+                <include>**</include>
+              </includes>
+            </filter>
+            <filter>
+              <artifact>org.apache.logging.log4j:log4j-jcl</artifact>
               <includes>
                 <include>**</include>
               </includes>
@@ -215,6 +227,10 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-jcl</artifactId>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/PSQLXyzConnector.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/PSQLXyzConnector.java
@@ -84,7 +84,6 @@ import org.apache.commons.dbutils.ResultSetHandler;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.util.CachedClock;
 import org.postgresql.util.PGobject;
 
 /**


### PR DESCRIPTION
AWS SDK uses commons logging which now get's logged through log4j

Signed-off-by: Benjamin Rögner <benjamin.roegner@here.com>