### PR TITLE
Refactor the modify feature and space operations

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/auth/FeatureAuthorization.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/auth/FeatureAuthorization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -105,7 +105,7 @@ public class FeatureAuthorization extends Authorization {
   }
 
   private static void addAttributeMapForEntry(ConditionalOperation task, XyzHubActionMatrix requestRights,
-      Entry<Feature, Feature, Feature> entry) {
+      Entry<Feature> entry) {
 
     // READ
     if (!requestRights.containsKey(XyzHubActionMatrix.READ_FEATURES) && (entry.head != null && IfExists.RETAIN

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/auth/SpaceAuthorization.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/auth/SpaceAuthorization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,9 +29,12 @@ import static com.here.xyz.hub.auth.XyzHubAttributeMap.SPACE;
 import static com.here.xyz.hub.auth.XyzHubAttributeMap.STORAGE;
 import static io.netty.handler.codec.http.HttpResponseStatus.FORBIDDEN;
 
+import com.here.xyz.XyzSerializable;
 import com.here.xyz.hub.connectors.models.Space;
 import com.here.xyz.hub.rest.HttpException;
+import com.here.xyz.hub.task.ModifyOp;
 import com.here.xyz.hub.task.ModifyOp.Entry;
+import com.here.xyz.hub.task.ModifySpaceOp;
 import com.here.xyz.hub.task.SpaceTask.ConditionalOperation;
 import com.here.xyz.hub.task.SpaceTask.MatrixReadQuery;
 import com.here.xyz.hub.task.TaskPipeline.Callback;
@@ -284,7 +287,8 @@ public class SpaceAuthorization extends Authorization {
 
   private static Map asMap(Object object) {
     try {
-      return Json.decodeValue(Json.mapper.writerWithView(Static.class).writeValueAsString(object), Map.class);
+      return XyzSerializable.filter(
+          Json.decodeValue(Json.mapper.writerWithView(Static.class).writeValueAsString(object), Map.class), ModifySpaceOp.metadataFilter);
     } catch (Exception e) {
       return Collections.emptyMap();
     }

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/models/Space.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/models/Space.java
@@ -256,17 +256,10 @@ public class Space extends com.here.xyz.models.hub.Space implements Cloneable {
     }
   }
 
-  public Map asMap() {
+  public Map<String,Object> asMap() {
     try {
+      //noinspection unchecked
       return Json.decodeValue(Json.mapper.writerWithView(Static.class).writeValueAsString(this), Map.class);
-    } catch (Exception e) {
-      return Collections.emptyMap();
-    }
-  }
-
-  public Map<String,Object> asMap(Map<String,Object> filter) {
-    try {
-      return XyzSerializable.filter( Json.decodeValue(Json.mapper.writerWithView(Static.class).writeValueAsString(this), Map.class), filter);
     } catch (Exception e) {
       return Collections.emptyMap();
     }

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/models/Space.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/models/Space.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,9 +26,11 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonView;
 import com.google.common.primitives.Longs;
+import com.here.xyz.XyzSerializable;
 import com.here.xyz.hub.Service;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
+import io.vertx.core.json.Json;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -63,7 +65,7 @@ public class Space extends com.here.xyz.models.hub.Space implements Cloneable {
   /**
    * An indicator, if the data in the space is edited often (value tends to 1) or static (value tends to 0).
    */
-  @JsonIgnore
+  @JsonView({Internal.class, Static.class})
   public double volatilityAtLastContentUpdate = 0;
 
   @JsonIgnore
@@ -251,6 +253,22 @@ public class Space extends com.here.xyz.models.hub.Space implements Cloneable {
       this.cdnTTL = Longs.constrainToRange(cdnTTL, 0, MAX_CDN_TTL);
       this.serviceTTL = Longs.constrainToRange(serviceTTL, 0, MAX_SERVICE_TTL);
       this.contentUpdatedAt = contentUpdatedAt;
+    }
+  }
+
+  public Map asMap() {
+    try {
+      return Json.decodeValue(Json.mapper.writerWithView(Static.class).writeValueAsString(this), Map.class);
+    } catch (Exception e) {
+      return Collections.emptyMap();
+    }
+  }
+
+  public Map<String,Object> asMap(Map<String,Object> filter) {
+    try {
+      return XyzSerializable.filter( Json.decodeValue(Json.mapper.writerWithView(Static.class).writeValueAsString(this), Map.class), filter);
+    } catch (Exception e) {
+      return Collections.emptyMap();
     }
   }
 }

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/FeatureApi.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/FeatureApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,10 +25,6 @@ import static com.here.xyz.hub.rest.ApiParam.Query.SKIP_CACHE;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.vertx.core.http.HttpHeaders.ACCEPT;
 
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.here.xyz.Typed;
-import com.here.xyz.XyzSerializable;
 import com.here.xyz.events.DeleteFeaturesByTagEvent;
 import com.here.xyz.events.GetFeaturesByIdEvent;
 import com.here.xyz.events.ModifyFeaturesEvent;
@@ -41,17 +37,17 @@ import com.here.xyz.hub.task.FeatureTask.IdsQuery;
 import com.here.xyz.hub.task.ModifyFeatureOp;
 import com.here.xyz.hub.task.ModifyOp.IfExists;
 import com.here.xyz.hub.task.ModifyOp.IfNotExists;
-import com.here.xyz.models.geojson.implementation.Feature;
-import com.here.xyz.models.geojson.implementation.FeatureCollection;
 import com.here.xyz.models.geojson.implementation.XyzNamespace;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.json.DecodeException;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.api.contract.openapi3.OpenAPI3RouterFactory;
-import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -154,7 +150,7 @@ public class FeatureApi extends Api {
    */
   private void deleteFeature(final RoutingContext context) {
     executeConditionalOperationChain(true, context, ApiResponseType.EMPTY, IfExists.DELETE, IfNotExists.RETAIN, true,
-        Collections.singletonList(Feature.createEmptyFeature().withId(context.pathParam(Path.FEATURE_ID))));
+        Collections.singletonList(new JsonObject().put("id", context.pathParam(Path.FEATURE_ID)).getMap()));
   }
 
   /**
@@ -169,15 +165,15 @@ public class FeatureApi extends Api {
 
     //Delete features by IDs
     if (featureIds != null && !featureIds.isEmpty()) {
-      final List<Feature> features = featureIds.stream().distinct()
-          .map(id -> Feature.createEmptyFeature().withId(id))
+      final List<Map<String, Object>> features = featureIds.stream().distinct()
+          .map(id -> new JsonObject().put("id", id).getMap())
           .collect(Collectors.toList());
 
       executeConditionalOperationChain(false, context, responseType, IfExists.DELETE, IfNotExists.RETAIN, true, features);
     }
 
     //Delete features by tags
-    else if (tags != null && !tags.isEmpty()) {
+    else if (!tags.isEmpty()) {
       DeleteFeaturesByTagEvent event = new DeleteFeaturesByTagEvent();
       if (!tags.containsWildcard()) {
         event.setTags(tags);
@@ -197,13 +193,12 @@ public class FeatureApi extends Api {
       ApiResponseType apiResponseTypeType,
       IfExists ifExists, IfNotExists ifNotExists, boolean transactional) {
     try {
-      FeatureCollection fc = getBodyAsFeatureCollection(context);
+      List<Map<String, Object>> features = getObjectsAsList(context);
       if (apiResponseTypeType == ApiResponseType.FEATURE) {
-        fc.getFeatures().get(0).setId(context.pathParam(ApiParam.Path.FEATURE_ID));
+        features.get(0).put("id", context.pathParam(ApiParam.Path.FEATURE_ID));
       }
 
-      executeConditionalOperationChain(requireResourceExists, context, apiResponseTypeType, ifExists, ifNotExists, transactional,
-          fc.getFeatures());
+      executeConditionalOperationChain(requireResourceExists, context, apiResponseTypeType, ifExists, ifNotExists, transactional, features);
     } catch (HttpException e) {
       sendErrorResponse(context, e);
     } catch (Exception e) {
@@ -215,7 +210,8 @@ public class FeatureApi extends Api {
    * Creates and executes a ModifyMapOp
    */
   private void executeConditionalOperationChain(boolean requireResourceExists, final RoutingContext context,
-      ApiResponseType apiResponseTypeType, IfExists ifExists, IfNotExists ifNotExists, boolean transactional, List<Feature> features) {
+      ApiResponseType apiResponseTypeType, IfExists ifExists, IfNotExists ifNotExists, boolean transactional,
+      List<Map<String, Object>> features) {
     ModifyFeaturesEvent event = new ModifyFeaturesEvent();
     ConditionalOperation task = new ConditionalOperation(event, context, apiResponseTypeType,
         new ModifyFeatureOp(features, ifNotExists, ifExists, transactional), requireResourceExists);
@@ -233,38 +229,45 @@ public class FeatureApi extends Api {
   /**
    * Parses the body of the request as a FeatureCollection or a Feature object and returns the features as a list.
    */
-  private FeatureCollection getBodyAsFeatureCollection(final RoutingContext context) throws HttpException {
+  private List<Map<String, Object>> getObjectsAsList(final RoutingContext context) throws HttpException {
     final Marker logMarker = Context.getMarker(context);
     try {
-      final String text = context.getBodyAsString();
-      if (text == null) {
+      JsonObject json = context.getBodyAsJson();
+      return getJsonObjects(json, context);
+    } catch (DecodeException e) {
+      logger.info(logMarker, "Invalid input encoding.", e);
+      // Some types of decoding exceptions could be avoided by reading the entire string.
+      try {
+        JsonObject json = new JsonObject(context.getBodyAsString());
+        return getJsonObjects(json, context);
+      } catch (Exception ex) {
+        logger.info(logMarker, "Error in the provided content ", e);
+        throw new HttpException(BAD_REQUEST, "Invalid JSON input string.");
+      }
+    } catch (Exception e) {
+      logger.info(logMarker, "Error in the provided content ", e);
+      throw new HttpException(BAD_REQUEST, "Cannot read input JSON string.");
+    }
+  }
+
+  private List<Map<String, Object>> getJsonObjects(JsonObject json, RoutingContext context) throws HttpException {
+    try {
+      if (json == null) {
         throw new HttpException(BAD_REQUEST, "Missing content");
       }
+      if ("FeatureCollection".equals(json.getString("type"))) {
+        //noinspection unchecked
+        return json.getJsonArray("features", new JsonArray()).getList();
+      }
 
-      final Typed input = XyzSerializable.deserialize(text);
-      FeatureCollection featureCollection;
-      if (input instanceof FeatureCollection) {
-        featureCollection = (FeatureCollection) input;
-        if (featureCollection.getFeatures() == null) {
-          featureCollection.setFeatures(new ArrayList<>());
-        }
-      } else if (input instanceof Feature) {
-        featureCollection = new FeatureCollection().withFeatures(Collections.singletonList((Feature) input));
+      if ("Feature".equals(json.getString("type"))) {
+        return Collections.singletonList(json.getMap());
       } else {
         throw new HttpException(BAD_REQUEST,
-            "The provided content is of type '" + input.getClass().getSimpleName() + "'. Expected is a FeatureCollection or a Feature.");
+            "The provided content does not have a type FeatureCollection or a Feature.");
       }
-      Api.Context.getAccessLog(context).reqInfo.numberOfObjects = featureCollection.getFeatures().size();
-      return featureCollection;
-    } catch (JsonMappingException e) {
-      logger.info(logMarker, "Error in the provided content ", e);
-      throw new HttpException(BAD_REQUEST, "Invalid JSON type. Expected is a FeatureCollection or a Feature.");
-    } catch (JsonParseException e) {
-      logger.info(logMarker, "Error in the provided content ", e);
-      throw new HttpException(BAD_REQUEST,
-          "Invalid JSON string. Error at line " + e.getLocation().getLineNr() + ", column " + e.getLocation().getColumnNr() + ".");
-    } catch (IOException e) {
-      logger.info(logMarker, "Error in the provided content ", e);
+    } catch (Exception e) {
+      logger.info(Context.getMarker(context), "Error in the provided content ", e);
       throw new HttpException(BAD_REQUEST, "Cannot read input JSON string.");
     }
   }

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/FeatureApi.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/FeatureApi.java
@@ -236,13 +236,14 @@ public class FeatureApi extends Api {
       return getJsonObjects(json, context);
     } catch (DecodeException e) {
       logger.info(logMarker, "Invalid input encoding.", e);
-      // Some types of decoding exceptions could be avoided by reading the entire string.
       try {
+        // Some types of exceptions could be avoided by reading the entire string.
         JsonObject json = new JsonObject(context.getBodyAsString());
         return getJsonObjects(json, context);
-      } catch (Exception ex) {
-        logger.info(logMarker, "Error in the provided content ", e);
-        throw new HttpException(BAD_REQUEST, "Invalid JSON input string.");
+      } catch (DecodeException ex) {
+        ex.getCause();
+        logger.info(logMarker, "Error in the provided content ", ex.getCause());
+        throw new HttpException(BAD_REQUEST, "Invalid JSON input string: " + ex.getMessage());
       }
     } catch (Exception e) {
       logger.info(logMarker, "Error in the provided content ", e);

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/SpaceApi.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/SpaceApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,7 @@ import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.api.contract.openapi3.OpenAPI3RouterFactory;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 public class SpaceApi extends Api {
 
@@ -58,7 +59,7 @@ public class SpaceApi extends Api {
    * Read a space.
    */
   public void getSpace(final RoutingContext context) {
-    JsonObject input = new JsonObject().put("id", context.pathParam(ApiParam.Path.SPACE_ID));
+    Map<String, Object> input = new JsonObject().put("id", context.pathParam(ApiParam.Path.SPACE_ID)).getMap();
     ModifySpaceOp modifyOp = new ModifySpaceOp(Collections.singletonList(input), IfNotExists.ERROR, IfExists.RETAIN, true);
 
     new ConditionalOperation(context, ApiResponseType.SPACE, modifyOp, true)
@@ -89,8 +90,7 @@ public class SpaceApi extends Api {
       context.fail(new HttpException(BAD_REQUEST, "Invalid JSON string"));
       return;
     }
-    ModifySpaceOp modifyOp = new ModifySpaceOp(Collections.singletonList(input), IfNotExists.CREATE, IfExists.ERROR,
-        true);
+    ModifySpaceOp modifyOp = new ModifySpaceOp(Collections.singletonList(input.getMap()), IfNotExists.CREATE, IfExists.ERROR, true);
 
     new ConditionalOperation(context, ApiResponseType.SPACE, modifyOp, false)
         .execute(this::sendResponse, this::sendErrorResponseOnEdit);
@@ -118,7 +118,7 @@ public class SpaceApi extends Api {
       return;
     }
 
-    ModifySpaceOp modifyOp = new ModifySpaceOp(Collections.singletonList(input), IfNotExists.ERROR, IfExists.PATCH, true);
+    ModifySpaceOp modifyOp = new ModifySpaceOp(Collections.singletonList(input.getMap()), IfNotExists.ERROR, IfExists.PATCH, true);
 
     new ConditionalOperation(context, ApiResponseType.SPACE, modifyOp, true)
         .execute(this::sendResponse, this::sendErrorResponseOnEdit);
@@ -129,7 +129,7 @@ public class SpaceApi extends Api {
    * Delete a space.
    */
   public void deleteSpace(final RoutingContext context) {
-    JsonObject input = new JsonObject().put("id", context.pathParam(Path.SPACE_ID));
+    Map<String,Object> input = new JsonObject().put("id", context.pathParam(Path.SPACE_ID)).getMap();
     ModifySpaceOp modifyOp = new ModifySpaceOp(Collections.singletonList(input), IfNotExists.ERROR, IfExists.DELETE, true);
 
     //Delete the space
@@ -155,6 +155,7 @@ public class SpaceApi extends Api {
 
   @JsonIgnoreProperties(ignoreUnknown = true)
   public static class BasicSpaceView {
+
     public String id;
     public String owner;
     public String title;

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/task/FeatureTask.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/task/FeatureTask.java
@@ -507,6 +507,7 @@ public abstract class FeatureTask<T extends Event<?>, X extends FeatureTask<T, ?
     public String prefixId;
     private Map<Object, Integer> positionById;
     private LoadFeaturesEvent loadFeaturesEvent;
+    public boolean hasNonModified;
 
     public ConditionalOperation(ModifyFeaturesEvent event, RoutingContext context, ApiResponseType apiResponseTypeType,
         ModifyFeatureOp modifyOp,

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/task/FeatureTask.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/task/FeatureTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,6 +58,7 @@ import com.here.xyz.models.geojson.implementation.FeatureCollection;
 import com.here.xyz.models.geojson.implementation.Properties;
 import com.here.xyz.responses.XyzResponse;
 import io.vertx.core.AsyncResult;
+import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
 import java.nio.charset.Charset;
 import java.util.HashMap;
@@ -547,14 +548,9 @@ public abstract class FeatureTask<T extends Event, X extends FeatureTask<T, ?>> 
       }
 
       final HashMap<String, String> idsMap = new HashMap<>();
-      for (Entry<Feature, Feature, Feature> entry : modifyOp.entries) {
-        if (entry.input.getId() != null) {
-          String uuid = null;
-          final Properties properties = entry.input.getProperties();
-          if (properties != null && properties.getXyzNamespace() != null) {
-            uuid = properties.getXyzNamespace().getUuid();
-          }
-          idsMap.put(entry.input.getId(), uuid);
+      for (Entry<Feature> entry : modifyOp.entries) {
+        if (entry.input.get("id") instanceof String ) {
+          idsMap.put((String)entry.input.get("id"), entry.inputUUID);
         }
       }
       if (idsMap.size() == 0) {
@@ -641,9 +637,9 @@ public abstract class FeatureTask<T extends Event, X extends FeatureTask<T, ?>> 
       if (positionById == null) {
         positionById = new HashMap<>();
         for (int i = 0; i < modifyOp.entries.size(); i++) {
-          final Feature input = modifyOp.entries.get(i).input;
-          if (input != null && input.getId() != null) {
-            positionById.put(input.getId(), i);
+          final Map<String,Object> input = modifyOp.entries.get(i).input;
+          if (input != null && input.get("id") instanceof String) {
+            positionById.put(input.get("id"), i);
           }
         }
       }

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/task/FeatureTask.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/task/FeatureTask.java
@@ -55,17 +55,15 @@ import com.here.xyz.hub.task.ModifyOp.Entry;
 import com.here.xyz.hub.task.TaskPipeline.Callback;
 import com.here.xyz.models.geojson.implementation.Feature;
 import com.here.xyz.models.geojson.implementation.FeatureCollection;
-import com.here.xyz.models.geojson.implementation.Properties;
 import com.here.xyz.responses.XyzResponse;
 import io.vertx.core.AsyncResult;
-import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
 import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public abstract class FeatureTask<T extends Event, X extends FeatureTask<T, ?>> extends Task<T, X> {
+public abstract class FeatureTask<T extends Event<?>, X extends FeatureTask<T, ?>> extends Task<T, X> {
 
   /**
    * The space for this operation.
@@ -80,12 +78,27 @@ public abstract class FeatureTask<T extends Event, X extends FeatureTask<T, ?>> 
   /**
    * The response.
    */
+  @SuppressWarnings("rawtypes")
   private XyzResponse response;
 
   /**
    * The calculated cache key.
    */
   private String cacheKey;
+
+  public static final class FeatureKey {
+
+    public static final String ID = "id";
+    public static final String TYPE = "type";
+    public static final String BBOX = "bbox";
+    public static final String PROPERTIES = "properties";
+    public static final String SPACE = "space";
+    public static final String CREATED_AT = "createdAt";
+    public static final String UPDATED_AT = "updatedAt";
+    public static final String UUID = "uuid";
+    public static final String PUUID = "puuid";
+    public static final String MUUID = "muuid";
+  }
 
   private FeatureTask(T event, RoutingContext context, ApiResponseType responseType, boolean skipCache) {
     super(event, context, responseType, skipCache);
@@ -123,7 +136,7 @@ public abstract class FeatureTask<T extends Event, X extends FeatureTask<T, ?>> 
    * The hook which will be called once all pre-processors have been called. The hook will get the pre-processed event as parameter. The
    * hook will *not* be called if no pre-processors have been defined for the space. The hook may be overridden in sub-classes.
    */
-  public void onPreProcessed(Event event) {
+  public void onPreProcessed(T event) {
   }
 
   @Override
@@ -170,7 +183,7 @@ public abstract class FeatureTask<T extends Event, X extends FeatureTask<T, ?>> 
     return null;
   }
 
-  abstract static class ReadQuery<T extends QueryEvent, X extends FeatureTask<T, ?>> extends FeatureTask<T, X> {
+  abstract static class ReadQuery<T extends QueryEvent<?>, X extends FeatureTask<T, ?>> extends FeatureTask<T, X> {
 
     private ReadQuery(T event, RoutingContext context, ApiResponseType apiResponseTypeType, boolean skipCache) {
       super(event, context, apiResponseTypeType, skipCache);
@@ -186,6 +199,7 @@ public abstract class FeatureTask<T extends Event, X extends FeatureTask<T, ?>> 
   }
 
   public static class GeometryQuery extends ReadQuery<GetFeaturesByGeometryEvent, GeometryQuery> {
+
     public final String refSpaceId;
     private final String refFeatureId;
     public Space refSpace;
@@ -213,7 +227,7 @@ public abstract class FeatureTask<T extends Event, X extends FeatureTask<T, ?>> 
 
     private void verifyResourceExists(GeometryQuery task, Callback<GeometryQuery> callback) {
       if (this.getEvent().getGeometry() == null) {
-        callback.exception(new HttpException(NOT_FOUND, "The 'refFeatureId' : '"+refFeatureId+"' does not exist."));
+        callback.exception(new HttpException(NOT_FOUND, "The 'refFeatureId' : '" + refFeatureId + "' does not exist."));
       } else {
         callback.call(task);
       }
@@ -221,7 +235,7 @@ public abstract class FeatureTask<T extends Event, X extends FeatureTask<T, ?>> 
 
     private void resolveRefConnector(final GeometryQuery gq, final Callback<GeometryQuery> c) {
       try {
-        if(refSpace == null || (refSpace != null && refSpace.getStorage().getId() == space.getStorage().getId())) {
+        if (refSpace == null || refSpace.getStorage().getId().equals(space.getStorage().getId())) {
           refConnector = storage;
           c.call(gq);
           return;
@@ -248,19 +262,17 @@ public abstract class FeatureTask<T extends Event, X extends FeatureTask<T, ?>> 
         //Load the space definition.
         Service.spaceConfigClient.get(getMarker(), refSpaceId, arSpace -> {
           if (arSpace.failed()) {
-            c.exception(new HttpException(BAD_REQUEST, "'RefSpace' : '"+refSpaceId+"' does not exist!", arSpace.cause()));
+            c.exception(new HttpException(BAD_REQUEST, "'RefSpace' : '" + refSpaceId + "' does not exist!", arSpace.cause()));
             return;
           }
           refSpace = arSpace.result();
 
-          if(refSpace == null) {
-            c.exception(new HttpException(BAD_REQUEST, "RefSpace : '"+refSpaceId+"'  not exist!", arSpace.cause()));
+          if (refSpace == null) {
+            c.exception(new HttpException(BAD_REQUEST, "RefSpace : '" + refSpaceId + "'  not exist!", arSpace.cause()));
             return;
           }
 
-          if (refSpace != null) {
-            gq.getEvent().setParams(gq.space.getStorage().getParams());
-          }
+          gq.getEvent().setParams(gq.space.getStorage().getParams());
           c.call(gq);
         });
       } catch (Exception e) {
@@ -270,7 +282,7 @@ public abstract class FeatureTask<T extends Event, X extends FeatureTask<T, ?>> 
 
     @SuppressWarnings("serial")
     private void loadObject(final GeometryQuery gq, final Callback<GeometryQuery> c) {
-      if(gq.getEvent().getGeometry() != null) {
+      if (gq.getEvent().getGeometry() != null) {
         c.call(this);
         return;
       }
@@ -279,7 +291,7 @@ public abstract class FeatureTask<T extends Event, X extends FeatureTask<T, ?>> 
           .withStreamId(getMarker().getName())
           .withSpace(refSpaceId)
           .withParams(this.refSpace.getStorage().getParams())
-          .withIdsMap(new HashMap<String,String>() {{
+          .withIdsMap(new HashMap<String, String>() {{
             put(refFeatureId, null);
           }});
 
@@ -309,8 +321,9 @@ public abstract class FeatureTask<T extends Event, X extends FeatureTask<T, ?>> 
         final FeatureCollection collection = (FeatureCollection) response;
         final List<Feature> features = collection.getFeatures();
 
-        if(features.size() == 1)
-         this.getEvent().setGeometry(features.get(0).getGeometry());
+        if (features.size() == 1) {
+          this.getEvent().setGeometry(features.get(0).getGeometry());
+        }
 
         callback.call(this);
       } catch (Exception e) {
@@ -319,7 +332,7 @@ public abstract class FeatureTask<T extends Event, X extends FeatureTask<T, ?>> 
     }
   }
 
-  public static class BBoxQuery extends ReadQuery<GetFeaturesByBBoxEvent, BBoxQuery> {
+  public static class BBoxQuery extends ReadQuery<GetFeaturesByBBoxEvent<?>, BBoxQuery> {
 
     public BBoxQuery(GetFeaturesByBBoxEvent event, RoutingContext context, ApiResponseType apiResponseTypeType, boolean skipCache) {
       super(event, context, apiResponseTypeType, skipCache);
@@ -338,6 +351,7 @@ public abstract class FeatureTask<T extends Event, X extends FeatureTask<T, ?>> 
   }
 
   public static class TileQuery extends ReadQuery<GetFeaturesByTileEvent, TileQuery> {
+
     public TileQuery(GetFeaturesByTileEvent event, RoutingContext context, ApiResponseType apiResponseTypeType, boolean skipCache) {
       super(event, context, apiResponseTypeType, skipCache);
     }
@@ -390,8 +404,9 @@ public abstract class FeatureTask<T extends Event, X extends FeatureTask<T, ?>> 
     }
   }
 
-  public static class SearchQuery extends ReadQuery<SearchForFeaturesEvent, SearchQuery> {
-    public SearchQuery(SearchForFeaturesEvent event, RoutingContext context, ApiResponseType apiResponseTypeType, boolean skipCache) {
+  public static class SearchQuery extends ReadQuery<SearchForFeaturesEvent<?>, SearchQuery> {
+
+    public SearchQuery(SearchForFeaturesEvent<?> event, RoutingContext context, ApiResponseType apiResponseTypeType, boolean skipCache) {
       super(event, context, apiResponseTypeType, skipCache);
     }
 
@@ -469,10 +484,10 @@ public abstract class FeatureTask<T extends Event, X extends FeatureTask<T, ?>> 
 
     //That hook will be called only if there were pre-processors which have been called and it sets the manipulatedSpaceDefinition value
     @Override
-    public void onPreProcessed(Event event) {
-      manipulatedOp = ((ModifySpaceEvent) event).getOperation();
+    public void onPreProcessed(ModifySpaceEvent event) {
+      manipulatedOp = event.getOperation();
       //FIXME: Don't take the incoming spaceDefinition as is. Instead only merge the non-admin top-level properties and the connector config of the according processor (Processors should NOT be able to manipulate connector registrations of other connections at the space)
-      manipulatedSpaceDefinition = ((ModifySpaceEvent) event).getSpaceDefinition();
+      manipulatedSpaceDefinition = event.getSpaceDefinition();
     }
 
     @Override
@@ -549,8 +564,8 @@ public abstract class FeatureTask<T extends Event, X extends FeatureTask<T, ?>> 
 
       final HashMap<String, String> idsMap = new HashMap<>();
       for (Entry<Feature> entry : modifyOp.entries) {
-        if (entry.input.get("id") instanceof String ) {
-          idsMap.put((String)entry.input.get("id"), entry.inputUUID);
+        if (entry.input.get("id") instanceof String) {
+          idsMap.put((String) entry.input.get("id"), entry.inputUUID);
         }
       }
       if (idsMap.size() == 0) {
@@ -637,7 +652,7 @@ public abstract class FeatureTask<T extends Event, X extends FeatureTask<T, ?>> 
       if (positionById == null) {
         positionById = new HashMap<>();
         for (int i = 0; i < modifyOp.entries.size(); i++) {
-          final Map<String,Object> input = modifyOp.entries.get(i).input;
+          final Map<String, Object> input = modifyOp.entries.get(i).input;
           if (input != null && input.get("id") instanceof String) {
             positionById.put(input.get("id"), i);
           }

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/task/FeatureTaskHandler.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/task/FeatureTaskHandler.java
@@ -19,6 +19,10 @@
 
 package com.here.xyz.hub.task;
 
+import static com.here.xyz.hub.task.FeatureTask.FeatureKey.BBOX;
+import static com.here.xyz.hub.task.FeatureTask.FeatureKey.ID;
+import static com.here.xyz.hub.task.FeatureTask.FeatureKey.PROPERTIES;
+import static com.here.xyz.hub.task.FeatureTask.FeatureKey.TYPE;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.CONFLICT;
 import static io.netty.handler.codec.http.HttpResponseStatus.FORBIDDEN;
@@ -81,7 +85,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import net.jodah.expiringmap.ExpirationPolicy;
@@ -104,10 +107,6 @@ public class FeatureTaskHandler {
   private static final byte BINARY_VALUE = 2;
 
   private static final boolean ENABLE_SERVICE_UUID = true;
-  public static final String ID = "id";
-  public static final String TYPE = "type";
-  public static final String BBOX = "bbox";
-  public static final String PROPERTIES = "properties";
 
   /**
    * Sends the event to the connector client and write the response as the responseCollection of the task.
@@ -693,7 +692,7 @@ public class FeatureTaskHandler {
 
             // UUID
             if (task.space.isEnableUUID() && Event.VERSION.compareTo("0.2.0") >= 0) {
-              nsXyz.setUuid(UUID.randomUUID().toString());
+              nsXyz.setUuid(java.util.UUID.randomUUID().toString());
             }
             insert.add(result);
           }
@@ -705,7 +704,7 @@ public class FeatureTaskHandler {
 
             // UUID
             if (task.space.isEnableUUID() && Event.VERSION.compareTo("0.2.0") >= 0) {
-              nsXyz.setUuid(UUID.randomUUID().toString());
+              nsXyz.setUuid(java.util.UUID.randomUUID().toString());
               nsXyz.setPuuid(entry.head.getProperties().getXyzNamespace().getUuid());
               // If the user was updating an older version, set it under the merge uuid
               if (!entry.base.equals(entry.head)) {

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/task/ModifyOp.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/task/ModifyOp.java
@@ -269,7 +269,7 @@ public abstract class ModifyOp<T, K extends Entry<T>> {
      *
      * @return true, if the result of the operation is different than the the head state.
      */
-    public boolean isModified() throws HttpException, ModifyOpError {
+    boolean isModified() throws HttpException, ModifyOpError {
       if (Objects.equals(head, result)) {
         return false;
       }

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/task/ModifyOp.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/task/ModifyOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -92,7 +92,8 @@ public abstract class ModifyOp<INPUT, SOURCE, TARGET> {
           }
         }
 
-        entry.isModified = !equalStates(entry.head, entry.result);
+        // Check if the isModified flag is not already set. Compare the objects in case it is not set yet.
+        entry.isModified = entry.isModified || !dataEquals(entry.head, entry.result);
       } catch (ModifyOpError e) {
         if (isTransactional) {
           throw e;
@@ -114,14 +115,13 @@ public abstract class ModifyOp<INPUT, SOURCE, TARGET> {
   public abstract TARGET transform(SOURCE sourceState) throws ModifyOpError, HttpException;
 
   /**
-   * Returns true, if the 2 objects represent the same object in the same state. Modifications that are not relevant should be ignored by
-   * this method, therefore the method is not binary safe.
+   * Returns true, if the 2 objects are equal, apart from any metadata information added by the service, such as timestamps, uuid, etc.
    *
    * @param state1 the source state.
    * @param state2 the target state.
    * @return true when the source and target state are logically equal; false otherwise.
    */
-  public abstract boolean equalStates(SOURCE state1, TARGET state2);
+  public abstract boolean dataEquals(SOURCE state1, TARGET state2);
 
   public enum IfExists {
     RETAIN,

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/task/ModifySpaceOp.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/task/ModifySpaceOp.java
@@ -22,120 +22,71 @@ package com.here.xyz.hub.task;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.here.xyz.XyzSerializable;
 import com.here.xyz.hub.connectors.models.Space;
 import com.here.xyz.hub.rest.HttpException;
-import com.here.xyz.hub.util.diff.Difference;
-import com.here.xyz.hub.util.diff.Patcher;
-import com.here.xyz.hub.util.diff.Patcher.MergeConflictException;
+import com.here.xyz.hub.task.ModifySpaceOp.SpaceEntry;
+import com.here.xyz.models.geojson.implementation.Feature;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
+import java.util.stream.Collectors;
 
-public class ModifySpaceOp extends ModifyOp<Space> {
+public class ModifySpaceOp extends ModifyOp<Space, SpaceEntry> {
 
-  public ModifySpaceOp(List<Map<String,Object>> inputStates, IfNotExists ifNotExists, IfExists ifExists,
-      boolean isTransactional) {
-    super(inputStates, ifNotExists, ifExists, isTransactional);
-    for (Entry<Space> entry : entries) {
-      entry.input = XyzSerializable.filter(entry.input, metadataFilter);
+  public ModifySpaceOp(List<Map<String, Object>> inputStates, IfNotExists ifNotExists, IfExists ifExists, boolean isTransactional) {
+    super((inputStates == null) ? Collections.emptyList() : inputStates.stream().map(SpaceEntry::new).collect(Collectors.toList()),
+        ifNotExists, ifExists, isTransactional);
+  }
+
+  public static class SpaceEntry extends ModifyOp.Entry<Space> {
+
+    public SpaceEntry(Map<String, Object> input) {
+      super(input);
+    }
+
+    @Override
+    protected String getId(Space record) {
+      return record == null ? null : record.getId();
+    }
+
+    @Override
+    protected String getUuid(Space record) {
+      return null;
+    }
+
+    @Override
+    protected String getUuid(Map<String, Object> record) {
+      return null;
+    }
+
+    @Override
+    public Map<String, Object> filterMetadata(Map<String, Object> map) {
+      return filter(map, metadataFilter);
+    }
+
+    @Override
+    public Space fromMap(Map<String, Object> map) throws ModifyOpError, HttpException {
+      try {
+        return Json.mapper.readValue(Json.encode(map), Space.class);
+      } catch (JsonProcessingException e) {
+        throw new HttpException(BAD_REQUEST, "Invalid space definition: " + e.getMessage(), e);
+      }
+    }
+
+    @Override
+    public Map<String, Object> toMap(Space record) throws ModifyOpError, HttpException {
+      return filter(record.asMap(), metadataFilter);
+    }
+
+    public String getId(Feature record) {
+      return record == null ? null : record.getId();
     }
   }
 
-  @SuppressWarnings({"rawtypes", "unchecked"})
-  @Override
-  public Space patch(Entry<Space> entry, Space headState, Space baseState, Map<String,Object> inputState) throws ModifyOpError, HttpException {
-    Map baseClone = baseState.asMap(metadataFilter);
-    Map input = XyzSerializable.filter(inputState, metadataFilter);
 
-    final Difference difference = Patcher.calculateDifferenceOfPartialUpdate(baseClone, input, null, true);
-
-    // Nothing was changed, return the head state
-    if (difference == null) {
-      return headState;
-    }
-
-    Patcher.patch(baseClone, difference);
-    return merge(entry, headState, baseState, baseClone);
-  }
-
-  @SuppressWarnings("rawtypes")
-  @Override
-  public Space merge(Entry<Space> entry, Space headState, Space baseState, Map<String,Object> inputState) throws ModifyOpError, HttpException {
-    if (headState.equals(baseState)) {
-      return replace(entry, headState, inputState);
-    }
-    Map headClone = headState.asMap(metadataFilter);
-    Map baseClone = baseState.asMap(metadataFilter);
-    Map input = XyzSerializable.filter(inputState, metadataFilter);
-
-    final Difference diffInput = Patcher.getDifference(baseClone, input);
-    // Nothing was changed, return the head state
-    if (diffInput == null) {
-      return headState;
-    }
-
-    final Difference diffHead = Patcher.getDifference(baseClone, headClone);
-    try {
-      final Difference mergedDiff = Patcher.mergeDifferences(diffInput, diffHead);
-      Patcher.patch(headClone, mergedDiff);
-      return Json.mapper.readValue(Json.encode(headClone), Space.class);
-    } catch (MergeConflictException e) {
-      throw new ModifyOpError(e.getMessage());
-    } catch (JsonProcessingException e) {
-      throw new HttpException(BAD_REQUEST, "Invalid space definition: " + e.getMessage(), e);
-    }
-  }
-
-  @Override
-  public Space replace(Entry<Space> entry, Space headState, Map<String,Object> inputState) throws HttpException {
-    try {
-      return Json.mapper.readValue(Json.encode(inputState), Space.class);
-    } catch (JsonProcessingException e) {
-      throw new HttpException(BAD_REQUEST, "Invalid space definition: " + e.getMessage(), e);
-    }
-  }
-
-  @Override
-  public Space delete(Entry<Space> entry, Space headState, Map<String,Object> inputState) throws HttpException {
-    return null;
-  }
-
-  @Override
-  public Space create(Entry<Space> entry, Map<String,Object> input) throws HttpException {
-    try {
-      return Json.mapper.readValue(Json.encode(input), Space.class);
-    } catch (JsonProcessingException e) {
-      throw new HttpException(BAD_REQUEST, "Invalid space definition: " + e.getMessage(), e);
-    }
-  }
-
-  @Override
-  public Space transform(Entry<Space> entry, Space sourceState) {
-    return sourceState;
-  }
-
-  @Override
-  public boolean dataEquals(Space space1, Space space2) {
-    if (Objects.equals(space1, space2)) {
-      return true;
-    }
-
-    final ObjectMapper mapper = XyzSerializable.STATIC_MAPPER.get();
-    Map map1 = XyzSerializable.filter(mapper.convertValue(space1, Map.class), metadataFilter);
-    Map map2 = XyzSerializable.filter(mapper.convertValue(space2, Map.class), metadataFilter);
-    return Patcher.getDifference(map1, map2) == null;
-  }
-
-  public static Map metadataFilter;
-
-  static {
-    try {
-      metadataFilter = Json.mapper.readValue("{\"createdAt\":true, \"updatedAt\":true}", Map.class);
-    } catch (JsonProcessingException ignored) {
-    }
-  }
+  public static Map<String, Object> metadataFilter = new JsonObject()
+      .put("createdAt", true)
+      .put("updatedAt", true).getMap();
 }

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/task/SpaceTask.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/task/SpaceTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -199,10 +199,10 @@ public abstract class SpaceTask<X extends SpaceTask<?>> extends Task<Event, X> {
           .then(SpaceTaskHandler::preprocess)
           .then(this::verifyResourceExists)
           .then(SpaceTaskHandler::processModifyOp)
+          .then(SpaceTaskHandler::postProcess)
           .then(SpaceTaskHandler::validate)
           .then(SpaceAuthorization::authorizeModifyOp)
           .then(SpaceTaskHandler::enforceUsageQuotas)
-          .then(SpaceTaskHandler::timestamp)
           .then(SpaceTaskHandler::sendEvents)
           .then(SpaceTaskHandler::modifySpaces)
           .then(SpaceTaskHandler::convertResponse);

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/util/logging/AccessLog.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/util/logging/AccessLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,7 +56,6 @@ public class AccessLog extends AccessLogExtended {
     public String uri;
     public String contentType;
     public String accept;
-    public long numberOfObjects;
     public long size;
     public String referer;
     public String origin;

--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/auth/AuthTestsIT.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/auth/AuthTestsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -141,7 +141,6 @@ public class AuthTestsIT extends RestAssuredTest {
         .headers(getAuthHeaders(profile))
         .when()
         .get("/spaces" + (owner != null ? "?owner=" + owner : ""))
-        .prettyPeek()
         .then();
   }
 

--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/connectors/RFCMeasurement.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/connectors/RFCMeasurement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,11 +70,9 @@ public class RFCMeasurement {
         ScheduledFuture<?> f = requesterPool.scheduleAtFixedRate(() -> {
             for (int i = 0; i < concurrency; i++) {
                 long now = Service.currentTimeMillis();
-                System.out.println("Submitted at: " + (now - TEST_START));
                 rfc.submit(null, null, r -> {
                     //Nothing to do
                 });
-                System.out.println("Submit took: " + (Service.currentTimeMillis() - now));
             }
         }, offset, interval, TimeUnit.MILLISECONDS);
 
@@ -83,8 +81,6 @@ public class RFCMeasurement {
         double ar = rfc.getArrivalRate();
         double tp = rfc.getThroughput();
 
-        System.out.println("Arrival rate: " + ar);
-        System.out.println("Throughput: " + tp);
 
         assertEquals("arrivalRate should match", expectedArrivalRate, Math.round(ar));
         assertEquals("throughput should match", expectedThroughput, Math.round(tp));

--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/RestAssuredTest.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/RestAssuredTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,12 @@
 
 package com.here.xyz.hub.rest;
 
+import static com.jayway.restassured.config.DecoderConfig.decoderConfig;
+import static com.jayway.restassured.config.EncoderConfig.encoderConfig;
+
 import com.here.xyz.hub.auth.TestAuthenticator;
 import com.jayway.restassured.RestAssured;
+import java.nio.charset.StandardCharsets;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
@@ -31,6 +35,8 @@ public class RestAssuredTest extends TestAuthenticator {
         RestAssured.baseURI = RestAssuredConfig.config().baseURI;
         RestAssured.port = RestAssuredConfig.config().port;
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+        RestAssured.config = RestAssured.config().encoderConfig(encoderConfig().defaultContentCharset("UTF-8"));
+        RestAssured.config = RestAssured.config().decoderConfig(decoderConfig().defaultContentCharset("UTF-8"));
     }
 
     @AfterClass

--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/UpdateFeatureApiIT.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/UpdateFeatureApiIT.java
@@ -71,6 +71,7 @@ public class UpdateFeatureApiIT extends TestSpaceWithFeature {
         body(content("/xyz/hub/featureWithNumberId.json")).
         when().
         post("/spaces/x-psql-test/features").
+        prettyPeek().
         then().
         statusCode(OK.code()).
         body("features[0].id", equalTo("1234"));

--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/UpdateFeatureApiIT.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/UpdateFeatureApiIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -357,7 +357,7 @@ public class UpdateFeatureApiIT extends TestSpaceWithFeature {
         headers(getAuthHeaders(AuthProfile.ACCESS_ALL)).
         body(point.serialize()).
         when().
-        put("/spaces/x-psql-test/features/C001").prettyPeek().
+        put("/spaces/x-psql-test/features/C001").
         then().statusCode(METHOD_NOT_ALLOWED.code());
   }
 }

--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/task/ModifyFeatureOpTest.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/task/ModifyFeatureOpTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2017-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.xyz.hub.task;
+
+import static org.junit.Assert.*;
+
+import com.here.xyz.XyzSerializable;
+import com.here.xyz.hub.task.ModifyOp.IfExists;
+import com.here.xyz.hub.task.ModifyOp.IfNotExists;
+import com.here.xyz.hub.task.ModifyOp.ModifyOpError;
+import com.here.xyz.models.geojson.implementation.Feature;
+import com.here.xyz.models.geojson.implementation.FeatureCollection;
+import java.io.IOException;
+import java.io.InputStream;
+import org.junit.Test;
+
+public class ModifyFeatureOpTest {
+
+  @Test
+  public void patch() {
+  }
+
+  @Test
+  public void merge() throws IOException, ModifyOpError {
+    try (
+        final InputStream is1 = ModifyFeatureOpTest.class.getResourceAsStream("/xyz/hub/task/FeatureSample01.json")
+    ) {
+      final Feature baseState = XyzSerializable.deserialize(is1);
+      final Feature headState = baseState.copy();
+      final Feature input = baseState.copy();
+
+      long now = System.currentTimeMillis();
+      headState.getProperties().put("newProperty", 1);
+      headState.getProperties().getXyzNamespace().setUuid("new-uuid");
+      headState.getProperties().getXyzNamespace().setPuuid(baseState.getProperties().getXyzNamespace().getUuid());
+      headState.getProperties().getXyzNamespace().setUpdatedAt(now);
+
+      input.getProperties().put("name", "changed");
+      input.getProperties().getXyzNamespace().setCreatedAt(123);
+      input.getProperties().getXyzNamespace().getTags().add("tag2");
+
+      ModifyFeatureOp op = new ModifyFeatureOp(null, IfNotExists.CREATE, IfExists.MERGE, true);
+      Feature res = op.merge(headState, baseState, input);
+
+      assertNotEquals(res.getProperties().getXyzNamespace().getCreatedAt(), 123);
+      assertTrue(res.getProperties().getXyzNamespace().getTags().contains("tag1"));
+      assertTrue(res.getProperties().getXyzNamespace().getTags().contains("tag2"));
+      assertEquals(res.getProperties().get("name"), "changed");
+    } catch (IOException | ModifyOpError e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Test
+  public void replace() {
+    try (
+        final InputStream is1 = ModifyFeatureOpTest.class.getResourceAsStream("/xyz/hub/task/FeatureSample01.json")
+    ) {
+      final Feature baseState = XyzSerializable.deserialize(is1);
+      final Feature input = baseState.copy();
+      input.getProperties().put("name", "changed");
+      input.getProperties().getXyzNamespace().setCreatedAt(123);
+      input.getProperties().getXyzNamespace().getTags().add("tag2");
+
+      ModifyFeatureOp op = new ModifyFeatureOp(null, IfNotExists.CREATE, IfExists.MERGE, true);
+      Feature res = op.replace(baseState, input);
+
+      assertNotEquals(res.getProperties().getXyzNamespace().getCreatedAt(), 123);
+      assertTrue(res.getProperties().getXyzNamespace().getTags().contains("tag1"));
+      assertTrue(res.getProperties().getXyzNamespace().getTags().contains("tag2"));
+      assertEquals(res.getProperties().get("name"), "changed");
+    } catch (IOException | ModifyOpError e) {
+      e.printStackTrace();
+    }
+  }
+}

--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/task/ModifyFeatureOpTest.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/task/ModifyFeatureOpTest.java
@@ -22,6 +22,7 @@ package com.here.xyz.hub.task;
 import static org.junit.Assert.*;
 
 import com.here.xyz.XyzSerializable;
+import com.here.xyz.hub.rest.HttpException;
 import com.here.xyz.hub.task.ModifyOp.Entry;
 import com.here.xyz.hub.task.ModifyOp.IfExists;
 import com.here.xyz.hub.task.ModifyOp.IfNotExists;
@@ -66,14 +67,14 @@ public class ModifyFeatureOpTest {
       final Entry<Feature> entry = op.entries.get(0);
       entry.head = head;
       entry.base = base;
-      Feature res = op.merge(entry, entry.head, entry.base, entry.input);
+      Feature res = entry.merge();
 
       // Expect to be reset to the default value
       assertNotEquals(res.getProperties().getXyzNamespace().getCreatedAt(), 123);
       assertTrue(res.getProperties().getXyzNamespace().getTags().contains("tag1"));
       assertTrue(res.getProperties().getXyzNamespace().getTags().contains("tag2"));
       assertEquals(res.getProperties().get("name"), "changed");
-    } catch (IOException | ModifyOpError e) {
+    } catch (IOException | ModifyOpError | HttpException e) {
       e.printStackTrace();
     }
   }
@@ -93,13 +94,13 @@ public class ModifyFeatureOpTest {
       final Entry<Feature> entry = op.entries.get(0);
       entry.head = base;
       entry.base = base;
-      Feature res = op.replace(entry, entry.base, entry.input);
+      Feature res = entry.replace();
 
       assertNotEquals(res.getProperties().getXyzNamespace().getCreatedAt(), 123);
       assertTrue(res.getProperties().getXyzNamespace().getTags().contains("tag1"));
       assertTrue(res.getProperties().getXyzNamespace().getTags().contains("tag2"));
       assertEquals(res.getProperties().get("name"), "changed");
-    } catch (IOException | ModifyOpError e) {
+    } catch (IOException | ModifyOpError | HttpException e) {
       e.printStackTrace();
     }
   }

--- a/xyz-hub-test/src/test/resources/xyz/hub/task/FeatureSample01.json
+++ b/xyz-hub-test/src/test/resources/xyz/hub/task/FeatureSample01.json
@@ -1,0 +1,21 @@
+{
+  "type":"Feature",
+  "id":"aa",
+  "geometry":{
+    "type":"Point",
+    "coordinates":[
+      -2.960847,
+      53.430828
+    ]
+  },
+  "properties":{
+    "@ns:com:here:xyz":{
+      "space":"2aGEUZpZ",
+      "createdAt":1579685281744,
+      "updatedAt":1579685281744,
+      "uuid":"92a4bd24-ccbe-4ba3-9f4b-c1b5db53f243",
+      "tags":[ "tag1"]
+    },
+    "name":"Anfield"
+  }
+}

--- a/xyz-models/src/main/java/com/here/xyz/XyzSerializable.java
+++ b/xyz-models/src/main/java/com/here/xyz/XyzSerializable.java
@@ -154,32 +154,6 @@ public interface XyzSerializable {
     return DEFAULT_MAPPER.get().convertValue(this, Map.class);
   }
 
-  default Map<String, Object> asMap(Map<String,Object> filter) {
-    //noinspection unchecked
-    return filter( DEFAULT_MAPPER.get().convertValue(this, Map.class), filter);
-  }
-
-  /**
-   * Filter recursively all properties from the provided filter, where the value is set to 'true'.
-   *
-   * @param map the object to filter
-   * @param filter the filter to apply
-   */
-  static Map<String,Object> filter(Map<String,Object>  map, Map<String,Object>  filter) {
-    if( map == null || filter == null )
-      return map;
-
-    for (String key : filter.keySet()) {
-      if (filter.get(key) instanceof Map && map.get(key) instanceof Map) {
-        //noinspection unchecked
-        filter((Map<String,Object> ) map.get(key), (Map<String,Object> ) filter.get(key));
-      }
-      if (filter.get(key) instanceof Boolean && (Boolean) filter.get(key)) {
-        map.remove(key);
-      }
-    }
-    return map;
-  }
   @SuppressWarnings("unused")
   default List<Object> asList() {
     //noinspection unchecked

--- a/xyz-models/src/main/java/com/here/xyz/XyzSerializable.java
+++ b/xyz-models/src/main/java/com/here/xyz/XyzSerializable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -154,6 +154,32 @@ public interface XyzSerializable {
     return DEFAULT_MAPPER.get().convertValue(this, Map.class);
   }
 
+  default Map<String, Object> asMap(Map<String,Object> filter) {
+    //noinspection unchecked
+    return filter( DEFAULT_MAPPER.get().convertValue(this, Map.class), filter);
+  }
+
+  /**
+   * Filter recursively all properties from the provided filter, where the value is set to 'true'.
+   *
+   * @param map the object to filter
+   * @param filter the filter to apply
+   */
+  static Map<String,Object> filter(Map<String,Object>  map, Map<String,Object>  filter) {
+    if( map == null || filter == null )
+      return map;
+
+    for (String key : filter.keySet()) {
+      if (filter.get(key) instanceof Map && map.get(key) instanceof Map) {
+        //noinspection unchecked
+        filter((Map<String,Object> ) map.get(key), (Map<String,Object> ) filter.get(key));
+      }
+      if (filter.get(key) instanceof Boolean && (Boolean) filter.get(key)) {
+        map.remove(key);
+      }
+    }
+    return map;
+  }
   @SuppressWarnings("unused")
   default List<Object> asList() {
     //noinspection unchecked

--- a/xyz-models/src/main/java/com/here/xyz/events/Event.java
+++ b/xyz-models/src/main/java/com/here/xyz/events/Event.java
@@ -60,6 +60,8 @@ import java.util.Map;
 
 public abstract class Event<T extends Event> extends Payload {
 
+  public static final String VERSION = "0.1.0";
+
   @JsonView(ExcludeFromHash.class)
   private Map<String, Object> connectorParams;
   @JsonView(ExcludeFromHash.class)
@@ -77,7 +79,7 @@ public abstract class Event<T extends Event> extends Payload {
   @JsonView(ExcludeFromHash.class)
   private String aid;
   @JsonView(ExcludeFromHash.class)
-  private String version = "0.1.0";
+  private String version = VERSION;
 
   /**
    * The identifier of the space.

--- a/xyz-models/src/main/java/com/here/xyz/models/geojson/implementation/Feature.java
+++ b/xyz-models/src/main/java/com/here/xyz/models/geojson/implementation/Feature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,46 +64,17 @@ public class Feature extends Extensible<Feature> implements Typed {
    * @throws NullPointerException if feature, space or the 'id' of the feature are null.
    */
   @SuppressWarnings("WeakerAccess")
-  public static void finalizeFeature(final Feature feature, final String space, final long timestamp, boolean addUUID) throws NullPointerException {
-    if (feature == null) {
-      throw new NullPointerException("feature");
-    }
-    if (space == null) {
-      throw new NullPointerException("space");
-    }
+  public static void finalizeFeature(final Feature feature, final String space, boolean addUUID) throws NullPointerException {
+    final XyzNamespace xyzNamespace = feature.getProperties().getXyzNamespace();
 
-    if (feature.getProperties() == null) {
-      feature.setProperties(new Properties());
-    }
-
-    final Properties props = feature.getProperties();
-    if (props.getXyzNamespace() == null) {
-      props.setXyzNamespace(new XyzNamespace());
-    }
-
-    final XyzNamespace nsXyz = props.getXyzNamespace();
-    nsXyz.setSpace(space);
-
-    final List<String> tags = nsXyz.getTags();
-
-    if (tags != null) {
-      XyzNamespace.normalizeTagsOfFeature(feature);
-    } else {
-      nsXyz.setTags(new ArrayList<>());
-    }
-    if (nsXyz.getCreatedAt() == 0) {
-      nsXyz.setCreatedAt(timestamp);
-    }
-    nsXyz.setUpdatedAt(timestamp);
     if (addUUID) {
-      String puuid = nsXyz.getUuid();
+      String puuid = xyzNamespace.getUuid();
       if (puuid != null) {
-        nsXyz.setPuuid(puuid);
+        xyzNamespace.setPuuid(puuid);
       }
-      nsXyz.setUuid(UUID.randomUUID().toString());
+      xyzNamespace.setUuid(UUID.randomUUID().toString());
     }
-
-    nsXyz.setInputPosition(null);
+    xyzNamespace.setInputPosition(null);
   }
 
   public String getId() {

--- a/xyz-models/src/main/java/com/here/xyz/models/geojson/implementation/XyzNamespace.java
+++ b/xyz-models/src/main/java/com/here/xyz/models/geojson/implementation/XyzNamespace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -118,7 +118,7 @@ public class XyzNamespace implements XyzSerializable {
    *
    * @param feature the feature in which to normalize the tags.
    */
-  static void normalizeTagsOfFeature(final Feature feature) {
+  public static void normalizeTagsOfFeature(final Feature feature) {
     if (feature == null) {
       return;
     }
@@ -271,12 +271,10 @@ public class XyzNamespace implements XyzSerializable {
     return this;
   }
 
-  @SuppressWarnings("unused")
   public String getPuuid() {
     return puuid;
   }
 
-  @SuppressWarnings("WeakerAccess")
   public void setPuuid(String puuid) {
     this.puuid = puuid;
   }

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/PSQLXyzConnector.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/PSQLXyzConnector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -874,6 +874,7 @@ public class PSQLXyzConnector extends PSQLRequestStreamHandler {
     }
 
     final long now = System.currentTimeMillis();
+    final boolean addUUID = event.getEnableUUID() && event.getVersion().compareTo("0.2.0") < 0;
     // Update the features to insert
     final List<Feature> inserts = event.getInsertFeatures();
     if (inserts != null) {
@@ -881,14 +882,14 @@ public class PSQLXyzConnector extends PSQLRequestStreamHandler {
         if (feature.getId() == null) {
           feature.setId(RandomStringUtils.randomAlphanumeric(16));
         }
-        Feature.finalizeFeature(feature, event.getSpace(), now, event.getEnableUUID() == Boolean.TRUE);
+        Feature.finalizeFeature(feature, event.getSpace(), addUUID);
       }
     }
 
     final List<Feature> updates = event.getUpdateFeatures();
     if (updates != null) {
       for (final Feature feature : updates) {
-        Feature.finalizeFeature(feature, event.getSpace(), now, event.getEnableUUID() == Boolean.TRUE);
+        Feature.finalizeFeature(feature, event.getSpace(), addUUID);
       }
     }
 


### PR DESCRIPTION
All metadata properties are set by the service for events with version higher than 0.1.0
For version 0.1.0, the uuid and preceding uuid are set by the storage connector.
All input is handled as map before processing. Updated the modify operation class to avoid duplicate conversions to a map for  patch, merge and replace operations.
Fixed that the createdAt value can be overwritten by the value in the input.
Changed for all POST, PUT and PATCH requests, that when a feature input does not contain any changes, compared to the latest version of the feature, an update operation will not be executed.
If the feature was not changed, the existing version of the object is included in the response.
