### PR TITLE
Fix missing storage info in space config for shared spaces

### DIFF
--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/auth/AuthTestsIT.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/auth/AuthTestsIT.java
@@ -240,6 +240,24 @@ public class AuthTestsIT extends RestAssuredTest {
   }
 
   @Test
+  public void testCreateSharedSpace() {
+    createSpace("/xyz/hub/auth/createSharedSpace.json", AuthProfile.ACCESS_OWNER_1_ADMIN)
+        .statusCode(OK.code());
+
+    getSpace("x-auth-test-space-shared", AuthProfile.ACCESS_OWNER_1_NO_ADMIN)
+        .body("storage", equalTo(null));
+  }
+
+  @Test
+  public void testCreateSharedSpaceAdminRead() {
+    createSpace("/xyz/hub/auth/createSharedSpace.json", AuthProfile.ACCESS_OWNER_1_ADMIN)
+        .statusCode(OK.code());
+
+    getSpace("x-auth-test-space-shared", AuthProfile.ACCESS_OWNER_1_ADMIN)
+        .body("storage.id", equalTo("psql"));
+  }
+
+  @Test
   public void testSpaceListWithSharedOwnerDefault() {
     testSpaceListWithShared(null)
         .statusCode(OK.code())


### PR DESCRIPTION
Fix bug in SpaceAuthorization which caused that the storage information was not returned for shared spaces even if the token had the permission "accessConnectors".

Signed-off-by: Benjamin Rögner <benjamin.roegner@here.com>