### PR TITLE
Improve logging, re-add the logger's name (the src class-name)

### DIFF
--- a/xyz-hub-service/src/main/resources/log4j2-console-json.json
+++ b/xyz-hub-service/src/main/resources/log4j2-console-json.json
@@ -19,7 +19,7 @@
         "name": "STDOUT",
         "PatternLayout": {
           "MarkerPatternSelector": {
-            "defaultPattern": "{\"t\":\"%p\",\"time\":\"%d{ISO8601}\",\"unixtime\":\"%d{UNIX_MILLIS}\",\"msg\":\"%enc{%.-4096msg%ex}{JSON} \",\"streamId\":\"%marker\"}%n%xEx{none}",
+            "defaultPattern": "{\"t\":\"%p\",\"time\":\"%d{ISO8601}\",\"unixtime\":\"%d{UNIX_MILLIS}\",\"msg\":\"%enc{%.-4096msg%ex}{JSON} \",\"streamId\":\"%marker\",\"src\":\"%c{1}\"}%n%xEx{none}",
             "PatternMatch": {
               "key": "ACCESS",
               "pattern": "%m%n"

--- a/xyz-hub-service/src/main/resources/log4j2-docker-debug.json
+++ b/xyz-hub-service/src/main/resources/log4j2-docker-debug.json
@@ -21,7 +21,7 @@
         "filePattern": "${env:LOG_PATH}/trace.log.%i",
         "PatternLayout": {
           "MarkerPatternSelector": {
-            "defaultPattern": "{\"t\":\"%p\",\"time\":\"%d{ISO8601}\",\"unixtime\":\"%d{UNIX_MILLIS}\",\"msg\":\"%enc{%.-4096msg%ex}{JSON} \",\"streamId\":\"%marker\"}%n%xEx{none}",
+            "defaultPattern": "{\"t\":\"%p\",\"time\":\"%d{ISO8601}\",\"unixtime\":\"%d{UNIX_MILLIS}\",\"msg\":\"%enc{%.-4096msg%ex}{JSON} \",\"streamId\":\"%marker\",\"src\":\"%c{1}\"}%n%xEx{none}",
             "PatternMatch": {
               "key": "ACCESS",
               "pattern": "%m%n"

--- a/xyz-hub-service/src/main/resources/log4j2-docker.json
+++ b/xyz-hub-service/src/main/resources/log4j2-docker.json
@@ -21,7 +21,7 @@
         "filePattern": "${env:LOG_PATH}/trace.log.%i",
         "PatternLayout": {
           "MarkerPatternSelector": {
-            "defaultPattern": "{\"t\":\"%p\",\"time\":\"%d{ISO8601}\",\"unixtime\":\"%d{UNIX_MILLIS}\",\"msg\":\"%enc{%.-4096msg%ex}{JSON} \",\"streamId\":\"%marker\"}%n%xEx{none}",
+            "defaultPattern": "{\"t\":\"%p\",\"time\":\"%d{ISO8601}\",\"unixtime\":\"%d{UNIX_MILLIS}\",\"msg\":\"%enc{%.-4096msg%ex}{JSON} \",\"streamId\":\"%marker\",\"src\":\"%c{1}\"}%n%xEx{none}",
             "PatternMatch": {
               "key": "ACCESS",
               "pattern": "%m%n"


### PR DESCRIPTION
.. this makes it possible again to find the according source class of an occured error in the logs

Signed-off-by: Benjamin Rögner <benjamin.roegner@here.com>