### PR TITLE
Fix an error when updating a feature without tags in the body

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/task/FeatureTaskHandler.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/task/FeatureTaskHandler.java
@@ -77,7 +77,6 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.Json;
-import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -756,14 +755,16 @@ public class FeatureTaskHandler {
 
     for (Entry<Feature> entry : task.modifyOp.entries) {
       // For existing objects: if the input does not contain the tags, copy them from the edited state.
-      final JsonObject nsXyz = new JsonObject(entry.input).getJsonObject("properties").getJsonObject(XyzNamespace.XYZ_NAMESPACE);
-      if (nsXyz.getJsonArray("tags", null) == null) {
+      final Map<String, Object> nsXyz = new JsonObject(entry.input).getJsonObject("properties").getJsonObject(XyzNamespace.XYZ_NAMESPACE)
+          .getMap();
+      if (!(nsXyz.get("tags") instanceof List)) {
+        ArrayList<String> inputTags = new ArrayList<>();
         if (entry.base != null && entry.base.getProperties().getXyzNamespace().getTags() != null) {
-          List<String> baseTags = entry.base.getProperties().getXyzNamespace().getTags();
-          nsXyz.put("tags", new JsonArray(baseTags));
+          inputTags.addAll(entry.base.getProperties().getXyzNamespace().getTags());
         }
+        nsXyz.put("tags", inputTags);
       }
-      final JsonArray tags = nsXyz.getJsonArray("tags");
+      final List<String> tags = (List<String>) nsXyz.get("tags");
       if (task.addTags != null) {
         task.addTags.forEach(tag -> {
           if (!tags.contains(tag)) {

--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/UpdateFeatureApiIT.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/UpdateFeatureApiIT.java
@@ -232,14 +232,27 @@ public class UpdateFeatureApiIT extends TestSpaceWithFeature {
   }
 
   @Test
-  public void updateFeatureById_put_WithAllAccess() {
+  public void updateFeatureById_put_WithAccessAll() {
     given().
         accept(APPLICATION_GEO_JSON).
         contentType(APPLICATION_GEO_JSON).
         headers(getAuthHeaders(AuthProfile.ACCESS_ALL)).
         body(content("/xyz/hub/updateFeature.json")).
         when().
-        put("/spaces/x-psql-test/features/Q2838923?addTags=baseball&removeTags=soccer").
+        patch("/spaces/x-psql-test/features/Q2838923?addTags=baseball&removeTags=soccer").
+        then().
+        statusCode(OK.code());
+  }
+
+  @Test
+  public void updateFeatureById_patch_WithAllAccess() {
+    given().
+        accept(APPLICATION_GEO_JSON).
+        contentType(APPLICATION_GEO_JSON).
+        headers(getAuthHeaders(AuthProfile.ACCESS_ALL)).
+        body(content("/xyz/hub/patchFeature.json")).
+        when().
+        patch("/spaces/x-psql-test/features/Q2838923?addTags=baseball&removeTags=soccer").
         then().
         statusCode(OK.code());
   }

--- a/xyz-hub-test/src/test/resources/xyz/hub/patchFeature.json
+++ b/xyz-hub-test/src/test/resources/xyz/hub/patchFeature.json
@@ -1,0 +1,14 @@
+{
+    "geometry": {
+        "type": "Point",
+        "coordinates": [
+            -77.075,
+            -12.057
+        ]
+    },
+    "type": "Feature",
+    "properties": {
+        "name": "Estadio Universidad San Marcos Updated",
+        "occupant": "National University of San Marcos Updated"
+    }
+}

--- a/xyz-models/src/main/java/com/here/xyz/models/geojson/implementation/XyzNamespace.java
+++ b/xyz-models/src/main/java/com/here/xyz/models/geojson/implementation/XyzNamespace.java
@@ -34,6 +34,7 @@ public class XyzNamespace implements XyzSerializable {
   public static final String XYZ_NAMESPACE = "@ns:com:here:xyz";
 
   @JsonProperty("_inputPosition")
+  @JsonInclude(Include.NON_NULL)
   private Long inputPosition;
   private String space;
   /**


### PR DESCRIPTION
Fix an error when updating a feature, using the query parameters _addTags_ or _removeTags_ , and providing a body with a feature, which does not include tags.

Signed-off-by: Dimitar Goshev <dimitar.goshev@here.com>