### PR TITLE
Add information about the taglist parameter.

### DIFF
--- a/xyz-hub-service/src/main/resources/openapi.yaml
+++ b/xyz-hub-service/src/main/resources/openapi.yaml
@@ -993,7 +993,8 @@ components:
       in: query
       description: >-
         A comma separated list of tags or combination of tags concatenated with
-        a plus sign (+).
+        a plus sign (+). A comma separated list of tags means any tag may be 
+        found. A plus sign concatenated list means every tag is required.
       allowEmptyValue: true
       style: form
       schema:


### PR DESCRIPTION
This adds information to the TagList parameter to make it more clear the A,B implies OR and A+B implies AND. My concern is that it doesn't apply to every use of the TagList parameter.