### PR TITLE
Treat empty config-strings from environment-variables as null values

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/Service.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/Service.java
@@ -155,6 +155,12 @@ public class Service {
    */
   private static void onConfigLoaded(AsyncResult<JsonObject> ar) {
     final JsonObject config = ar.result();
+    //Convert empty string values to null
+    config.forEach(e -> {
+      if (e.getValue() != null && e.getValue().equals("")) {
+        config.put(e.getKey(), (String) null);
+      }
+    });
     configuration = config.mapTo(Config.class);
 
     initializeLogger(configuration);


### PR DESCRIPTION
This is necessary to support overriding values from the default config with null values.

Signed-off-by: Benjamin Rögner <benjamin.roegner@here.com>