### PR TITLE
Improve RemoteFunctionClients to be invoked with "fireAndForget" mode

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/EmbeddedFunctionClient.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/EmbeddedFunctionClient.java
@@ -85,7 +85,8 @@ public class EmbeddedFunctionClient extends RemoteFunctionClient {
     }).start();
   }
 
-  protected void invoke(Marker marker, byte[] bytes, Handler<AsyncResult<byte[]>> callback) {
+  @Override
+  protected void invoke(Marker marker, byte[] bytes, boolean fireAndForget, Handler<AsyncResult<byte[]>> callback) {
     final RemoteFunctionConfig remoteFunction = getConnectorConfig().remoteFunction;
     logger.info(marker, "Invoke embedded lambda '{}' for event: {}", remoteFunction.id, new String(bytes));
     embeddedExecutor.execute(() -> {
@@ -103,8 +104,7 @@ public class EmbeddedFunctionClient extends RemoteFunctionClient {
                 ((Connector.RemoteFunctionConfig.Embedded) remoteFunction).env));
         logger.info(marker, "Handling response of embedded lambda call to '{}'.", remoteFunction.id);
         byte[] responseBytes = output.toByteArray();
-        checkResponseSize(responseBytes);
-        callback.handle(Future.succeededFuture(getDecompressed(responseBytes)));
+        callback.handle(Future.succeededFuture(responseBytes));
       } catch (ClassNotFoundException e) {
         logger.error(marker, "Configuration error, the specified class '{}' was not found {}", className, e);
         callback.handle(Future.failedFuture(e));

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/HTTPFunctionClient.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/HTTPFunctionClient.java
@@ -89,7 +89,8 @@ public class HTTPFunctionClient extends RemoteFunctionClient {
   }
 
   @Override
-  protected void invoke(Marker marker, byte[] bytes, Handler<AsyncResult<byte[]>> callback) {
+  protected void invoke(Marker marker, byte[] bytes, boolean fireAndForget, Handler<AsyncResult<byte[]>> callback) {
+    //TODO: respect fireAndForget parameter
     final RemoteFunctionConfig remoteFunction = getConnectorConfig().remoteFunction;
     logger.debug(marker, "Invoke http remote function '{}' Event size is: {}", remoteFunction.id, bytes.length);
 
@@ -104,14 +105,8 @@ public class HTTPFunctionClient extends RemoteFunctionClient {
               callback.handle(Future.failedFuture(ar.cause()));
             }
           } else {
-            try {
-              //TODO: Refactor to move decompression into the base-class RemoteFunctionClient as it's not HTTP specific
-              byte[] responseBytes = ar.result().body().getBytes();
-              checkResponseSize(responseBytes);
-              callback.handle(Future.succeededFuture(getDecompressed(responseBytes)));
-            } catch (IOException | HttpException e) {
-              callback.handle(Future.failedFuture(e));
-            }
+            byte[] responseBytes = ar.result().body().getBytes();
+            callback.handle(Future.succeededFuture(responseBytes));
           }
         });
   }

--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/connectors/MockedRemoteFunctionClient.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/connectors/MockedRemoteFunctionClient.java
@@ -59,7 +59,7 @@ public class MockedRemoteFunctionClient extends RemoteFunctionClient {
     }
 
     @Override
-    protected void invoke(Marker marker, byte[] bytes, Handler<AsyncResult<byte[]>> callback) {
+    protected void invoke(Marker marker, byte[] bytes, boolean fireAndForget, Handler<AsyncResult<byte[]>> callback) {
         long executionTime = (long) (Math.random() * (double) (maxExecutionTime - minExecutionTime) + minExecutionTime);
 
         MockedRequest req = new MockedRequest(callback) {

--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/connectors/RFCMeasurement.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/connectors/RFCMeasurement.java
@@ -71,7 +71,7 @@ public class RFCMeasurement {
         ScheduledFuture<?> f = requesterPool.scheduleAtFixedRate(() -> {
             for (int i = 0; i < concurrency; i++) {
                 long now = Service.currentTimeMillis();
-                rfc.submit(null, null, r -> {
+                rfc.submit(null, null, false, r -> {
                     //Nothing to do
                 });
             }


### PR DESCRIPTION
Using that mode the request will be sent off and all its references in the memory will be deleted. Also the client doesn't wait for any response.

Signed-off-by: Benjamin Rögner <benjamin.roegner@here.com>