### PR TITLE
All lambda clients are using the same fixed thread-pool now

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/Service.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/Service.java
@@ -407,6 +407,11 @@ public class Service {
     public int REMOTE_FUNCTION_REQUEST_TIMEOUT; //seconds
 
     /**
+     * The amount of executor threads of the pool being shared by all LambdaFunctionClients.
+     */
+    public int LAMBDA_REMOTE_FUNCTION_EXECUTORS;
+
+    /**
      * The web root for serving static resources from the file system.
      */
     public String FS_WEB_ROOT;

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/LambdaFunctionClient.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/LambdaFunctionClient.java
@@ -26,6 +26,7 @@ import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
+import com.amazonaws.client.builder.ExecutorFactory;
 import com.amazonaws.handlers.AsyncHandler;
 import com.amazonaws.services.lambda.AWSLambdaAsync;
 import com.amazonaws.services.lambda.AWSLambdaAsyncClientBuilder;
@@ -34,6 +35,7 @@ import com.amazonaws.services.lambda.model.InvocationType;
 import com.amazonaws.services.lambda.model.InvokeRequest;
 import com.amazonaws.services.lambda.model.InvokeResult;
 import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
+import com.here.xyz.hub.Service;
 import com.here.xyz.hub.connectors.models.Connector;
 import com.here.xyz.hub.connectors.models.Connector.RemoteFunctionConfig;
 import com.here.xyz.hub.connectors.models.Connector.RemoteFunctionConfig.AWSLambda;
@@ -43,6 +45,8 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.Marker;
@@ -51,8 +55,9 @@ public class LambdaFunctionClient extends RemoteFunctionClient {
 
   private static final Logger logger = LogManager.getLogger();
   private static final int CONNECTION_ESTABLISH_TIMEOUT = 5_000;
-  private static final int CLIENT_REQUEST_TIMEOUT = REQUEST_TIMEOUT + 3_000;
+  //private static final int CLIENT_REQUEST_TIMEOUT = REQUEST_TIMEOUT + 3_000;
   private static final int CONNECTION_TTL = 60_000;
+  private static ExecutorFactory clientExecutorFactory;
 
   /**
    * The maximal response size in bytes that can be sent back without relocating the response.
@@ -88,10 +93,11 @@ public class LambdaFunctionClient extends RemoteFunctionClient {
         .withClientConfiguration(new ClientConfiguration()
             .withMaxConnections(maxConnections)
             .withConnectionTimeout(CONNECTION_ESTABLISH_TIMEOUT)
-            .withRequestTimeout((int) REQUEST_TIMEOUT)
+            .withRequestTimeout(REQUEST_TIMEOUT)
             .withMaxErrorRetry(0)
-            .withClientExecutionTimeout(CLIENT_REQUEST_TIMEOUT)
+            //.withClientExecutionTimeout(CLIENT_REQUEST_TIMEOUT)
             .withConnectionTTL(CONNECTION_TTL))
+        .withExecutorFactory(getClientExecutorFactory())
         .build();
   }
 
@@ -190,5 +196,19 @@ public class LambdaFunctionClient extends RemoteFunctionClient {
     }
 
     return new HttpException(BAD_GATEWAY, "Unable to parse the response of the connector.", e);
+  }
+
+  private static ExecutorFactory getClientExecutorFactory() {
+    if (clientExecutorFactory == null) {
+      return clientExecutorFactory = new ExecutorFactory() {
+        private ExecutorService executorService = Executors.newFixedThreadPool(Service.configuration.LAMBDA_REMOTE_FUNCTION_EXECUTORS);
+
+        @Override
+        public ExecutorService newExecutor() {
+          return executorService;
+        }
+      };
+    }
+    else return clientExecutorFactory;
   }
 }

--- a/xyz-hub-service/src/main/resources/config.json
+++ b/xyz-hub-service/src/main/resources/config.json
@@ -13,6 +13,7 @@
   "LOG_CONFIG": "log4j2-console-plain.json",
 
   "DEFAULT_STORAGE_ID": "psql",
+  "LAMBDA_REMOTE_FUNCTION_EXECUTORS": 256,
 
   "STORAGE_DB_URL": "jdbc:postgresql://localhost/postgres",
   "STORAGE_DB_USER": "postgres",


### PR DESCRIPTION
The size of the shared thread-pool is defined by the config- / environment-variable "LAMBDA_REMOTE_FUNCTION_EXECUTORS" of which the default value is 256

Signed-off-by: Benjamin Rögner <benjamin.roegner@here.com>