### PR TITLE
Fix concurrency issues with VertX webclient in HTTPFunctionClient

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/HTTPFunctionClient.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/HTTPFunctionClient.java
@@ -34,6 +34,8 @@ import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.concurrent.TimeoutException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -43,8 +45,9 @@ public class HTTPFunctionClient extends RemoteFunctionClient {
 
   private static final Logger logger = LogManager.getLogger();
 
-  private volatile WebClient webClient;
+  private volatile ThreadLocal<WebClient> webClient;
   private static volatile String url;
+  private static volatile List<DestroyableWebClient> webClientsToDestroy = new LinkedList<>();
 
   HTTPFunctionClient(Connector connectorConfig) {
     super(connectorConfig);
@@ -53,7 +56,7 @@ public class HTTPFunctionClient extends RemoteFunctionClient {
   @Override
   synchronized void setConnectorConfig(final Connector newConnectorConfig) throws NullPointerException, IllegalArgumentException {
     super.setConnectorConfig(newConnectorConfig);
-    shutdownWebClient(webClient);
+    shutdownWebClient();
     createClient();
   }
 
@@ -64,18 +67,22 @@ public class HTTPFunctionClient extends RemoteFunctionClient {
     }
     Http httpRemoteFunction = (Http) remoteFunction;
     url = httpRemoteFunction.url.toString();
-    webClient = WebClient.create(Service.vertx, new WebClientOptions()
+    webClient = ThreadLocal.withInitial(() -> WebClient.create(Service.vertx, new WebClientOptions()
         .setUserAgent(Service.XYZ_HUB_USER_AGENT)
-        .setMaxPoolSize(getMaxConnections()));
+        .setMaxPoolSize(getMaxConnections())));
+  }
+
+  private WebClient getWebClient() {
+    return webClient.get();
   }
 
   @Override
   void destroy() {
     super.destroy();
-    shutdownWebClient(webClient);
+    shutdownWebClient();
   }
 
-  private static void shutdownWebClient(WebClient webClient) {
+  private void shutdownWebClient() {
     if (webClient == null) return;
     //Shutdown the web client after the request timeout
     //TODO: Use CompletableFuture.delayedExecutor() after switching to Java 9
@@ -84,7 +91,8 @@ public class HTTPFunctionClient extends RemoteFunctionClient {
         Thread.sleep(REQUEST_TIMEOUT);
       }
       catch (InterruptedException ignored) {}
-      webClient.close();
+      webClientsToDestroy.forEach(wc -> wc.destroy());
+      webClientsToDestroy = new LinkedList<>();
     }).start();
   }
 
@@ -92,9 +100,9 @@ public class HTTPFunctionClient extends RemoteFunctionClient {
   protected void invoke(Marker marker, byte[] bytes, boolean fireAndForget, Handler<AsyncResult<byte[]>> callback) {
     //TODO: respect fireAndForget parameter
     final RemoteFunctionConfig remoteFunction = getConnectorConfig().remoteFunction;
-    logger.debug(marker, "Invoke http remote function '{}' Event size is: {}", remoteFunction.id, bytes.length);
+    logger.info(marker, "Invoke http remote function '{}' URL is: {} Event size is: {}", remoteFunction.id, url, bytes.length);
 
-    webClient.postAbs(url)
+    getWebClient().postAbs(url)
         .timeout(REQUEST_TIMEOUT)
         .putHeader("content-type", "application/json; charset=" + Charset.defaultCharset().name())
         .sendBuffer(Buffer.buffer(bytes), ar -> {
@@ -109,5 +117,17 @@ public class HTTPFunctionClient extends RemoteFunctionClient {
             callback.handle(Future.succeededFuture(responseBytes));
           }
         });
+  }
+
+  private static class DestroyableWebClient {
+    private WebClient webClient;
+
+    DestroyableWebClient(WebClient webClient) {
+      this.webClient = webClient;
+    }
+
+    public void destroy() {
+      webClient.close();
+    }
   }
 }


### PR DESCRIPTION
Using ThreadLocal for all webClients of HTTPFunctionClient now.

Signed-off-by: Benjamin Rögner <benjamin.roegner@here.com>