### PR TITLE
Added support for automatic decryption of user secrets in connectors.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
 
     <!-- Dependencies versions -->
-    <aws-sdk-version>1.11.517</aws-sdk-version>
+    <aws-sdk-version>1.11.712</aws-sdk-version>
     <vertx-version>3.6.3</vertx-version>
     <geo-tools-version>19.1</geo-tools-version>
     <jts-version>1.14.0</jts-version>
@@ -134,7 +134,6 @@
     </profile>
   </profiles>
 
-
   <build>
     <pluginManagement>
       <plugins>
@@ -142,28 +141,31 @@
         <!-- Plugin versions -->
         <plugin>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <groupId>org.apache.maven.plugins</groupId>
           <version>2.15</version>
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <groupId>org.apache.maven.plugins</groupId>
           <version>2.22.1</version>
         </plugin>
         <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
           <version>3.2.0</version>
         </plugin>
         <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.8.1</version>
+        </plugin>
+        <plugin>
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>3.1.1</version>
         </plugin>
         <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
           <version>3.1.0</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-release-plugin</artifactId>
+          <version>2.5.3</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
@@ -174,8 +176,13 @@
     </pluginManagement>
     <plugins>
       <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <useIncrementalCompilation>false</useIncrementalCompilation>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-release-plugin</artifactId>
-        <version>2.5.3</version>
         <configuration>
           <autoVersionSubmodules>true</autoVersionSubmodules>
           <tagNameFormat>@{project.version}</tagNameFormat>
@@ -438,6 +445,12 @@
         <groupId>com.jayway.restassured</groupId>
         <scope>test</scope>
         <version>2.9.0</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <artifactId>assertj-core</artifactId>

--- a/xyz-connectors/pom.xml
+++ b/xyz-connectors/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (C) 2017-2019 HERE Europe B.V.
+  ~ Copyright (C) 2017-2020 HERE Europe B.V.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -76,6 +76,10 @@
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>net.jodah</groupId>
+      <artifactId>expiringmap</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/xyz-connectors/src/main/java/com/here/xyz/connectors/AbstractConnectorHandler.java
+++ b/xyz-connectors/src/main/java/com/here/xyz/connectors/AbstractConnectorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,8 @@ import com.google.common.hash.Hashing;
 import com.here.xyz.Payload;
 import com.here.xyz.Typed;
 import com.here.xyz.XyzSerializable;
+import com.here.xyz.connectors.decryptors.EventDecryptor;
+import com.here.xyz.connectors.decryptors.EventDecryptor.Decryptors;
 import com.here.xyz.events.Event;
 import com.here.xyz.events.HealthCheckEvent;
 import com.here.xyz.events.RelocatedEvent;
@@ -44,9 +46,10 @@ import org.apache.logging.log4j.Logger;
  * A default implementation of a request handler that can be reused. It supports out of the box caching via e-tag.
  */
 public abstract class AbstractConnectorHandler implements RequestStreamHandler {
-
+  /**
+   * Logger
+   */
   private static final Logger logger = LogManager.getLogger();
-
   /**
    * The event-type-suffix for response notifications.
    */
@@ -64,7 +67,14 @@ public abstract class AbstractConnectorHandler implements RequestStreamHandler {
    * The number of the bytes to read from an input stream and preview as a String in the logs.
    */
   private static final int INPUT_PREVIEW_BYTE_SIZE = 4 * 1024; // 4K
+  /**
+   * The etag string
+   */
   private static final String ETAG_STRING = ",\"etag\":\"_\"}";
+  /**
+   * Environment variable for setting the custom event decryptor. Currently only KMS, PRIVATE_KEY, or DUMMY is supported
+   */
+  public static final String ENV_DECRYPTOR = "EVENT_DECRYPTOR";
   /**
    * The maximal response size in bytes that can be sent back without relocating the response.
    */
@@ -84,11 +94,33 @@ public abstract class AbstractConnectorHandler implements RequestStreamHandler {
    * The stream-id that should be added to every log output.
    */
   protected String streamId;
+  /**
+   * Start timestamp for logging.
+   */
   private long start;
   /**
    * A flag to inform, if the lambda is running in embedded mode.
    */
   private boolean embedded = false;
+  /**
+   * {@link EventDecryptor} used for decrypting the parameters.
+   */
+  final protected EventDecryptor eventDecryptor;
+
+  /**
+   * Default constructor that sets the correct decryptor based on the {@see ENV_DECRYPTOR} environment variable.
+   */
+  public AbstractConnectorHandler() {
+    Decryptors decryptor = Decryptors.DUMMY;
+    if (System.getenv(ENV_DECRYPTOR) != null) {
+      try {
+        decryptor = Decryptors.valueOf(System.getenv(ENV_DECRYPTOR));
+      } catch (IllegalArgumentException e) {
+        logger.warn("Unknown decryptor" + System.getenv(ENV_DECRYPTOR) + ". Using DummyDecryptor instead.", e);
+      }
+    }
+    eventDecryptor = EventDecryptor.getInstance(decryptor);
+  }
 
   /**
    * Returns the number of milliseconds that have passed since the request started (for time measuring inside the lambda).
@@ -257,6 +289,4 @@ public abstract class AbstractConnectorHandler implements RequestStreamHandler {
 
     return new String(bytes, 0, limit);
   }
-
-
 }

--- a/xyz-connectors/src/main/java/com/here/xyz/connectors/ListenerConnector.java
+++ b/xyz-connectors/src/main/java/com/here/xyz/connectors/ListenerConnector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,8 +69,11 @@ public abstract class ListenerConnector extends AbstractConnectorHandler {
       throw new ErrorResponseException(streamId, XyzError.NOT_IMPLEMENTED, "Unknown event type");
     }
 
-    final NotificationParams notificationParams = new NotificationParams(notification.getParams(), notification.getConnectorParams(),
-        notification.getMetadata(), notification.getTid());
+    final NotificationParams notificationParams = new NotificationParams(
+        eventDecryptor.decodeParams(notification.getParams()),
+        eventDecryptor.decodeParams(notification.getConnectorParams()),
+        eventDecryptor.decodeParams(notification.getMetadata()),
+        notification.getTid());
 
     if (notification.getEvent() instanceof ErrorResponse) {
       processErrorResponse((ErrorResponse) notification.getEvent(), notification.getEventType(), notificationParams);

--- a/xyz-connectors/src/main/java/com/here/xyz/connectors/ProcessorConnector.java
+++ b/xyz-connectors/src/main/java/com/here/xyz/connectors/ProcessorConnector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,8 +68,11 @@ public abstract class ProcessorConnector extends AbstractConnectorHandler {
       throw new ErrorResponseException(streamId, XyzError.NOT_IMPLEMENTED, "Unknown event type");
     }
 
-    final NotificationParams notificationParams = new NotificationParams(notification.getParams(), notification.getConnectorParams(),
-        notification.getMetadata(), notification.getTid());
+    final NotificationParams notificationParams = new NotificationParams(
+        eventDecryptor.decodeParams(notification.getParams()),
+        eventDecryptor.decodeParams(notification.getConnectorParams()),
+        eventDecryptor.decodeParams(notification.getMetadata()),
+        notification.getTid());
 
     if (notification.getEvent() instanceof ErrorResponse) {
       return processErrorResponse((ErrorResponse) notification.getEvent(), notification.getEventType(), notificationParams);

--- a/xyz-connectors/src/main/java/com/here/xyz/connectors/decryptors/DummyDecryptor.java
+++ b/xyz-connectors/src/main/java/com/here/xyz/connectors/decryptors/DummyDecryptor.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2017-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.xyz.connectors.decryptors;
+
+/**
+ * Dummy implementation that is used when no custom Decryptor is configured.
+ */
+public class DummyDecryptor extends EventDecryptor {
+
+  /**
+   * Default constructor with Default access so that only {@link EventDecryptor} can
+   * construct this instance.
+   *
+   */
+  DummyDecryptor() { }
+
+  /**
+   * Dummy implementation. Just return the original string.
+   *
+   * @param encoded The string that should be decrypted.
+   * @return Returns the not-decrypted string.
+   */
+  @Override
+  public String decryptAsymmetric(final String encoded) {
+    return encoded;
+  }
+}

--- a/xyz-connectors/src/main/java/com/here/xyz/connectors/decryptors/EventDecryptor.java
+++ b/xyz-connectors/src/main/java/com/here/xyz/connectors/decryptors/EventDecryptor.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2017-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.xyz.connectors.decryptors;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import net.jodah.expiringmap.ExpirationPolicy;
+import net.jodah.expiringmap.ExpiringMap;
+
+/**
+ * Base class for all EventDecryptor implementations. Takes care of caching the decoded secrets.
+ *
+ */
+public abstract class EventDecryptor {
+  /**
+   * Enum with the existing {@link EventDecryptor} implementations
+   */
+  public enum Decryptors {KMS, PRIVATE_KEY, DUMMY}
+  /**
+   * Prefix for asymmetric encrypted secrets.
+   */
+  public String encPrefix = "<<";
+  /**
+   * Postfix for asymmetric encrypted secrets.
+   */
+  public String encPostfix = ">>";
+  /**
+   * Map with already created instances.
+   */
+  private static Map<Decryptors, EventDecryptor> instances = new HashMap<>();
+
+  /**
+   * Cache for storing the decrypted secrets for 30s.
+   */
+  protected final ExpiringMap<String, String> secretsCache = ExpiringMap.builder()
+      .maxSize(1024)
+      .variableExpiration()
+      .expirationPolicy(ExpirationPolicy.CREATED)
+      .expiration(30, TimeUnit.SECONDS)
+      .build();
+
+  /**
+   * This method returns an instance of the known EventDecryptor implementations.
+
+   * @param decryptor The implementation to return {@link Decryptors}.
+   * @return Returns a singleton of the implementation.
+   */
+  public static synchronized EventDecryptor getInstance(final Decryptors decryptor) {
+    if (instances.get(decryptor) == null) {
+      switch (decryptor) {
+        case KMS:
+          instances.put(decryptor, new KmsEventDecryptor());
+          break;
+        case PRIVATE_KEY:
+          instances.put(decryptor, new PrivateKeyEventDecryptor());
+          break;
+        case DUMMY:
+        default:
+          instances.put(decryptor, new DummyDecryptor());
+      }
+    }
+    return instances.get(decryptor);
+  }
+
+  /**
+   * This method decrypts the given parameters.
+   *
+   * @param params The parameters that should be decrypted.
+   * @return Returns the decrypted parameters or the original if no values are encrypted or could decrypted.
+   */
+  public Map<String, Object> decodeParams(final Map<String, Object> params) {
+    if (params == null) {
+      return null;
+    }
+
+    final Map<String, Object> decodedParams = new LinkedHashMap<>(params.size());
+
+    params.forEach((key, value) -> {
+      if (value instanceof String) {
+        String encoded = (String) value;
+        if (isEncrypted(encoded)) {
+          decodedParams.put(key,
+              secretsCache.computeIfAbsent(
+                  key,
+                  k -> decryptAsymmetric(encoded.substring(2, encoded.length() - 2))));
+        } else {
+          decodedParams.put(key, value);
+        }
+      }
+    });
+
+    return decodedParams;
+  }
+
+  /**
+   * This methods checks whether the string is encrypted or not.
+   *
+   * @param str The string that should be checked.
+   * @return Returns true if the string is encrypted, otherwise false.
+   */
+  public boolean isEncrypted(final String str) {
+    if (str == null || str.length() == 0) {
+      return false;
+    }
+    return str.startsWith(encPrefix) && str.endsWith(encPostfix);
+  }
+
+  /**
+   * This method decodes a single string.
+   *
+   * @param encoded The string to decode.
+   * @return Returns the decoded string or the original value if the string is not encoded or could not be decoded.
+   */
+  public abstract String decryptAsymmetric(String encoded);
+}

--- a/xyz-connectors/src/main/java/com/here/xyz/connectors/decryptors/KmsEventDecryptor.java
+++ b/xyz-connectors/src/main/java/com/here/xyz/connectors/decryptors/KmsEventDecryptor.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2017-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.xyz.connectors.decryptors;
+
+import com.amazonaws.services.kms.AWSKMS;
+import com.amazonaws.services.kms.AWSKMSClientBuilder;
+import com.amazonaws.services.kms.model.DecryptRequest;
+import com.amazonaws.services.kms.model.EncryptionAlgorithmSpec;
+import java.nio.ByteBuffer;
+import java.util.Base64;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Helper class to en-/decryptPrivateKey secrets in Events, Token Metadata, and Space configurations.
+ */
+public class KmsEventDecryptor extends EventDecryptor {
+  /**
+   * Logger for the class
+   */
+  private static final Logger logger = LogManager.getLogger();
+
+  /**
+   * Algorithm used for asymmetric (private/public key) encryption.
+   */
+  private static final EncryptionAlgorithmSpec ASYMMETRIC_ALGORITHM = EncryptionAlgorithmSpec.RSAES_OAEP_SHA_256;
+
+  /**
+   * Environment variable for the KMS key ARN for decrypting space secrets.
+   */
+  public static String ENV_KMS_KEY_ARN = "KMS_KEY_ARN";
+
+  public final String kmsKeyArn;
+  /**
+   * AWS KMS client for getting the private key to decryptPrivateKey space secrets.
+   */
+  private final AWSKMS kmsClient;
+
+  /**
+   * Default constructor to create a new EventDecryptor that uses
+   * AWS KMS to decryptPrivateKey secrets.
+   *
+   * Following environment variables need to be set to use this class:
+   * - {@link com.here.xyz.connectors.AbstractConnectorHandler#ENV_DECRYPTOR}
+   * - {@link #ENV_KMS_KEY_ARN}
+   */
+  KmsEventDecryptor() {
+    kmsClient = AWSKMSClientBuilder.defaultClient();
+    kmsKeyArn = System.getenv(ENV_KMS_KEY_ARN);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public String decryptAsymmetric(String encoded) {
+    if (encoded == null || encoded.equals("")) {
+      return encoded;
+    }
+
+    // we cannot decode the secret if no KMS key ARN is set.
+    if (kmsKeyArn == null) {
+      return encoded;
+    }
+
+    ByteBuffer cipherText = ByteBuffer.wrap(Base64.getDecoder().decode(encoded.getBytes()));
+    DecryptRequest req = new DecryptRequest()
+        .withKeyId(kmsKeyArn)
+        .withEncryptionAlgorithm(ASYMMETRIC_ALGORITHM)
+        .withCiphertextBlob(cipherText);
+    try {
+      ByteBuffer plainText = kmsClient.decrypt(req).getPlaintext();
+      return new String(plainText.array());
+    } catch (RuntimeException e) {
+      logger.error("Error when trying to decryptPrivateKey asymmetric key. Please check the following:\n"
+          + "\t- Does the application use an IAM role?\n"
+          + "\t- Does the application's role have the permission to use the CMK the value was encrypted with?\n"
+          + "More information on that topic: https://confluence.in.here.com/display/CMECMCPDOWS/Encryption+of+secrets", e);
+    }
+
+    return encoded;
+  }
+}

--- a/xyz-connectors/src/main/java/com/here/xyz/connectors/decryptors/PrivateKeyEventDecryptor.java
+++ b/xyz-connectors/src/main/java/com/here/xyz/connectors/decryptors/PrivateKeyEventDecryptor.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (C) 2017-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.xyz.connectors.decryptors;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+import java.security.Key;
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.stream.Collectors;
+import javax.crypto.Cipher;
+import javax.crypto.EncryptedPrivateKeyInfo;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class PrivateKeyEventDecryptor extends EventDecryptor {
+
+  /**
+   * Logger for the class
+   */
+  private static final Logger logger = LogManager.getLogger();
+
+  /**
+   * Environment variable for the file path to the private key in PKCS#8 PEM format.
+   */
+  public static final String ENV_PRIVATE_KEY = "PRIVATE_KEY_FILE";
+
+  /**
+   * The optional (but recommended) passphrase to decode the private key.
+   */
+  public static final String ENV_PRIVATE_KEY_PASSPHRASE = "PRIVATE_KEY_PASSPHRASE";
+
+  /**
+   * The algorithm used for decrypting the secrets.
+   */
+  public static final String ALGORITHM = "RSA/ECB/OAEPWithSHA-256AndMGF1Padding";
+  /**
+   * The algorithm for creating the private key.
+   */
+  public static final String RSA = "RSA";
+
+  final private PrivateKey privateKey;
+
+  /**
+   * Default constructor to create a new EventDecryptor that takes
+   * a private key for decrypting the secrets.
+   *
+   * For security reasons should the private key be encrypted
+   * using PKCS#12 scheme.
+   * This line converts an openssl private key to an usable, encrypted
+   * PKCS#8 key:
+   * openssl pkcs8 -topk8 -in private_key.pem  -v1 PBE-SHA1-3DES -out private_pkcs8.pem
+   *
+   * Following environment variables need to be set to use this class:
+   * - {@link com.here.xyz.connectors.AbstractConnectorHandler#ENV_DECRYPTOR}
+   * - {@link #ENV_PRIVATE_KEY}
+   * - {@link #ENV_PRIVATE_KEY_PASSPHRASE}
+   */
+  PrivateKeyEventDecryptor() {
+    PrivateKey tmp;
+    try {
+      tmp = loadPrivateKey(System.getenv(ENV_PRIVATE_KEY), System.getenv(ENV_PRIVATE_KEY_PASSPHRASE));
+    } catch (Exception e) {
+      tmp = null;
+      logger.error("Could not load the private key. Params will not be decrypted!", e);
+    }
+    privateKey = tmp;
+  }
+
+  @Override
+  public String decryptAsymmetric(final String encoded) {
+    if (privateKey == null) {
+      return encoded;
+    }
+    try {
+      Cipher cipher = Cipher.getInstance(ALGORITHM);
+      cipher.init(Cipher.DECRYPT_MODE, privateKey);
+
+      byte[] decryptedBytes = cipher.doFinal(Base64.getDecoder().decode(encoded));
+      return new String(decryptedBytes, UTF_8);
+    } catch(Exception e) {
+      logger.warn("Could not decrypt string.", e);
+      return encoded;
+    }
+  }
+
+  /**
+   * Load the private key.
+   *
+   * @param filePath The file path to the private key in PKCS#8 PEM format
+   * @param passphrase The optional passphrase to decode the private key (recommended).
+   * @return Returns the {@link PrivateKey} or null if there a problem.
+   */
+  public static PrivateKey loadPrivateKey(final String filePath, final String passphrase) {
+    if (filePath == null) {
+      return null;
+    }
+    BufferedReader reader;
+    try {
+      reader = new BufferedReader(new FileReader(filePath));
+    } catch (IOException e) {
+      logger.error("Could not load private key from file path '" + filePath + "'", e);
+      return null;
+    }
+    String[] lines = reader.lines().toArray(String[]::new);
+    if ("-----BEGIN PRIVATE KEY-----".equals(lines[0])) {
+      // not encrypted
+      String privateKeyPEM = Arrays.stream(lines)
+          .filter(s -> !"-----BEGIN PRIVATE KEY-----".equals(s) && !"-----END PRIVATE KEY-----".equals(s))
+          .collect(Collectors.joining(""));
+      return createPrivateKey(privateKeyPEM);
+    } else if("-----BEGIN ENCRYPTED PRIVATE KEY-----".equals(lines[0])) {
+      // encrypted
+      String privateKeyPEM = Arrays.stream(lines)
+          .filter(s -> !"-----BEGIN ENCRYPTED PRIVATE KEY-----".equals(s) && !"-----END ENCRYPTED PRIVATE KEY-----".equals(s))
+          .collect(Collectors.joining(""));
+      return decryptPrivateKey(privateKeyPEM, passphrase);
+    } else {
+      logger.error("Unknown key format. Params will not be decrypted.");
+      return null;
+    }
+  }
+
+  /**
+   * This method decrypts the private key that was encrypted using PKCS#12 scheme.
+   *
+   * @param pkcs8Data The private key in PEM format without header and footer.
+   * @param passphrase The passphrase for decrypting the private key.
+   * @return Returns the {@link PrivateKey} or null if there a problem.
+   */
+  public static PrivateKey decryptPrivateKey(final String pkcs8Data, final String passphrase) {
+    if (passphrase == null || pkcs8Data == null) {
+      logger.error("Could not create private key because passphrase or key is null");
+      return null;
+    }
+    try {
+      PBEKeySpec pbeSpec = new PBEKeySpec(passphrase.toCharArray());
+      EncryptedPrivateKeyInfo pkinfo = new EncryptedPrivateKeyInfo(Base64.getDecoder().decode(pkcs8Data.getBytes(UTF_8)));
+      SecretKeyFactory skf = SecretKeyFactory.getInstance(pkinfo.getAlgName());
+      Key secret = skf.generateSecret(pbeSpec);
+      PKCS8EncodedKeySpec keySpec = pkinfo.getKeySpec(secret);
+      KeyFactory keyFactory = KeyFactory.getInstance(RSA);
+      return keyFactory.generatePrivate(keySpec);
+    } catch (Exception e) {
+      logger.error("Could not create encrypted private key from environment variable", e);
+      return null;
+    }
+  }
+
+  /**
+   * Try to create a RSA private key from a PKCS#8 PEM without header and footer.
+   *
+   * @param pkcs8Data The private key in PKCS#8 PEM format without header and footer.
+   * @return Returns the {@link PrivateKey} or null if there was a problem.
+   */
+  public static PrivateKey createPrivateKey(final String pkcs8Data) {
+    try {
+      KeyFactory keyFactory = KeyFactory.getInstance(RSA);
+      return keyFactory.generatePrivate(new PKCS8EncodedKeySpec(Base64.getDecoder().decode(pkcs8Data.getBytes(UTF_8))));
+    } catch (Exception e) {
+      logger.error("Could not create unencrypted private key from environment variable", e);
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
Closes #59

Provided three implementations:
- Dummy -> Just return the value
- KMS -> Use AWS KMS asymmetric key pair to decrypt secrets
- PrivateKey -> Use provided and encrypted private key file to decrypt secrets

Event Decryptors are configured by environment variables:
- EVENT_DECRYPTOR -> possible values are DUMMY, KMS, PRIVATE_KEY - default is DUMMY

For KMS:
- KMS_KEY_ARN -> ARN to AWS KMS asymmetric key

For PRIVATE_KEY:
- PRIVATE_KEY_FILE -> File path to private key
- PRIVATE_KEY_PASSPHRASE -> Optional but recommended passphrase to decode private key.

Signed-off-by: Josef Wegner <josef.wegner@here.com>