### PR TITLE
Set a minimal amount for minConnection value.

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/RemoteFunctionClient.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/RemoteFunctionClient.java
@@ -36,7 +36,6 @@ import io.vertx.core.impl.ConcurrentHashSet;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -388,7 +387,7 @@ public abstract class RemoteFunctionClient {
   }
 
   public int getMinConnections() {
-    return connectorConfig == null ? 0 : connectorConfig.getMinConnectionsPerInstance();
+    return connectorConfig == null ? MIN_CONNECTIONS_PER_NODE : Math.max(MIN_CONNECTIONS_PER_NODE, connectorConfig.getMinConnectionsPerInstance());
   }
 
   public int getMaxConnections() {


### PR DESCRIPTION
This value is used to calculate the RFC's priority,
which then, is used to calculate the RFC's queue byte size.
Having it as a value at least greater than zero, ensures a minimal
queue size.

Signed-off-by: Lucas Ceni <lucas.ceni@here.com>