### PR TITLE
Update Vertx configuration and the mode of the REST verticle

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/Service.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/Service.java
@@ -134,7 +134,7 @@ public class Service {
     boolean debug = Arrays.asList(arguments).contains("--debug");
 
     final VertxOptions vertxOptions = new VertxOptions();
-    vertxOptions.setWorkerPoolSize(512);
+    vertxOptions.setWorkerPoolSize(128);
 
     if (debug) {
       vertxOptions
@@ -202,7 +202,7 @@ public class Service {
     }
     else {
       //Start / Deploy the service including all endpoints and listeners
-      vertx.deployVerticle(XYZHubRESTVerticle.class, new DeploymentOptions().setConfig(config).setWorker(true).setInstances(8));
+      vertx.deployVerticle(XYZHubRESTVerticle.class, new DeploymentOptions().setConfig(config).setWorker(false).setInstances(8));
 
       logger.info("XYZ Hub " + BUILD_VERSION + " was started at " + new Date().toString());
 


### PR DESCRIPTION
Change the mode of the REST verticle to standard and reduce the worker pull size.

Signed-off-by: Dimitar Goshev <dimitar.goshev@here.com>