### PR TITLE
Use current docker image for PostgreSQL 10

### DIFF
--- a/Dockerfile-postgres
+++ b/Dockerfile-postgres
@@ -1,4 +1,4 @@
-FROM postgres:10.0
+FROM postgres:10
 
 MAINTAINER Benjamin Rögner "benjamin.roegner@here.com"
 MAINTAINER Lucas Ceni "lucas.ceni@here.com"


### PR DESCRIPTION
The image of postgres:10.0 is more then two years old. The current, up-to-date one is postgres:10.