### PR TITLE
Add compact history feature

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/auth/SpaceAuthorization.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/auth/SpaceAuthorization.java
@@ -57,7 +57,7 @@ import javax.annotation.Nonnull;
 public class SpaceAuthorization extends Authorization {
 
   public static List<String> basicEdit = Arrays
-      .asList("title", "description", "client", "copyright", "license", "shared", "enableUUID", "enableHistory", "cacheTTL", STORAGE,
+      .asList("title", "description", "client", "copyright", "license", "shared", "enableUUID", "enableHistory", "maxVersionCount", "cacheTTL", STORAGE,
           LISTENERS, PROCESSORS, SEARCHABLE_PROPERTIES);
 
   public static List<String> packageEdit = Collections.singletonList(PACKAGES);

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/task/SpaceTaskHandler.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/task/SpaceTaskHandler.java
@@ -186,6 +186,13 @@ public class SpaceTaskHandler {
 
     Space space = task.modifyOp.entries.get(0).result;
 
+    if(space.getMaxVersionCount() != null){
+      if(!space.isEnableHistory())
+        throw new HttpException(BAD_REQUEST, "Validation failed. The property 'maxVersionCount' can only get set if 'enableHistory' is set.");
+      if(space.getMaxVersionCount() < -1)
+        throw new HttpException(BAD_REQUEST, "Validation failed. The property 'maxVersionCount' must be greater or equal to -1.");
+    }
+
     if (task.isCreate() && space.isEnableHistory()) {
       if(!space.isEnableUUID())
         task.modifyOp.entries.get(0).result.setEnableUUID(true);

--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/ModifySpaceWithUUID.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/ModifySpaceWithUUID.java
@@ -191,8 +191,8 @@ public class ModifySpaceWithUUID extends TestSpaceWithFeature {
 
   @Test
   public void testMergeWithHistory() throws JsonProcessingException {
-    /** Keep 5 versions of objects */
-    patchSpaceWithMaxVersionCount(5,AuthProfile.ACCESS_ALL);
+    /** Keep 6 versions of objects */
+    patchSpaceWithMaxVersionCount(6,AuthProfile.ACCESS_ALL);
     String body = createRequest(generateRandomFeatures(1, 2))
             .post("/spaces/x-psql-test/features")
             .getBody().asString();
@@ -218,7 +218,7 @@ public class ModifySpaceWithUUID extends TestSpaceWithFeature {
 
   @Test
   public void testPatchConflictWithHistory() throws JsonProcessingException {
-    /** Keep 5 versions of objects */
+    /** Keep 6 versions of objects */
     patchSpaceWithMaxVersionCount(5,AuthProfile.ACCESS_ALL);
     String body = createRequest(generateRandomFeatures(1, 2))
             .post("/spaces/x-psql-test/features")
@@ -246,7 +246,7 @@ public class ModifySpaceWithUUID extends TestSpaceWithFeature {
   @Test
   public void testPatchWithHistory() throws JsonProcessingException {
     /** Keep 5 versions of objects */
-    patchSpaceWithMaxVersionCount(5,AuthProfile.ACCESS_ALL);
+    patchSpaceWithMaxVersionCount(6,AuthProfile.ACCESS_ALL);
     String body = createRequest(generateRandomFeatures(1, 2))
             .post("/spaces/x-psql-test/features")
             .getBody().asString();
@@ -276,12 +276,10 @@ public class ModifySpaceWithUUID extends TestSpaceWithFeature {
             .body("features[0].properties.foo", equalTo(10))
             .body("features[0].properties.foo2", equalTo("bar"))
             .body("features[0].id",equalTo(oldVersion.getId()));
-
-//    fc = XyzSerializable.deserialize(response.extract().asString());
   }
 
   private void patchSpaceWithMaxVersionCount(int maxVersionCount, AuthProfile profile){
-    String body = "{\"storage\": {\"id\": \"psql\",\"params\": { \"maxVersionCount\" : "+maxVersionCount+" }}}";
+    String body = "{\"maxVersionCount\" : "+maxVersionCount+" }";
     final ValidatableResponse response = given()
             .contentType(APPLICATION_JSON)
             .accept(APPLICATION_JSON)
@@ -290,7 +288,7 @@ public class ModifySpaceWithUUID extends TestSpaceWithFeature {
             .when().patch("/spaces/x-psql-test").then();
 
     response.statusCode(OK.code())
-            .body("storage.params.maxVersionCount", equalTo(maxVersionCount));
+            .body("maxVersionCount", equalTo(maxVersionCount));
   }
 
   private Map<Integer,List<Feature>> produceUpdates(FeatureCollection fc , int updateCnt) throws JsonProcessingException {

--- a/xyz-models/src/main/java/com/here/xyz/models/hub/Space.java
+++ b/xyz-models/src/main/java/com/here/xyz/models/hub/Space.java
@@ -141,6 +141,12 @@ public class Space {
   @JsonInclude(Include.NON_DEFAULT)
   private boolean enableHistory = false;
 
+  /**
+   * Can be used to control how many versions should get hold in the history. -1 means infinite
+   */
+  @JsonView({Public.class, Static.class})
+  @JsonInclude(Include.NON_EMPTY)
+  private Integer maxVersionCount;
 
   /**
    * List of packages that this space belongs to.
@@ -371,6 +377,19 @@ public class Space {
 
   public Space withEnableHistory(final boolean enableHistory) {
     this.enableHistory = enableHistory;
+    return this;
+  }
+
+  public Integer getMaxVersionCount() {
+    return maxVersionCount;
+  }
+
+  public void setMaxVersionCount(final Integer maxVersionCount) {
+    this.maxVersionCount = maxVersionCount;
+  }
+
+  public Space withMaxVersionCount(final Integer maxVersionCount) {
+    this.maxVersionCount = maxVersionCount;
     return this;
   }
 

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseMaintainer.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseMaintainer.java
@@ -38,7 +38,7 @@ public class DatabaseMaintainer {
     private static final Logger logger = LogManager.getLogger();
 
     /** Is used to check against xyz_ext_version() */
-    private static final int XYZ_EXT_VERSION = 129;
+    private static final int XYZ_EXT_VERSION = 130;
     /** Can get configured dynamically with storageParam onDemandIdxLimit */
     protected final static int ON_DEMAND_IDX_DEFAULT_LIM = 4;
 

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/PSQLXyzConnector.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/PSQLXyzConnector.java
@@ -242,17 +242,20 @@ public class PSQLXyzConnector extends DatabaseHandler {
   protected XyzResponse processModifySpaceEvent(ModifySpaceEvent event) throws Exception {
     try{
       if(event.getSpaceDefinition() != null && event.getSpaceDefinition().isEnableUUID()){
-        Integer maxVersionCount = null;
-
-        if(event.getParams() != null)
-          maxVersionCount = (Integer)event.getParams().get("maxVersionCount");
+        Integer maxVersionCount;
+        Boolean compactHistory = true;
 
         if(event.getSpaceDefinition().isEnableHistory()){
+          maxVersionCount = event.getSpaceDefinition().getMaxVersionCount();
+          if(event.getConnectorParams() != null){
+            compactHistory = (Boolean)event.getConnectorParams().get("compactHistory");
+            compactHistory = compactHistory == null ? true : compactHistory;
+          }
           if(ModifySpaceEvent.Operation.CREATE == event.getOperation()){
-            ensureHistorySpace(maxVersionCount);
+            ensureHistorySpace(maxVersionCount, compactHistory);
           }else if(ModifySpaceEvent.Operation.UPDATE == event.getOperation()){
             //TODO: ONLY update Trigger
-            ensureHistorySpace(maxVersionCount);
+            ensureHistorySpace(maxVersionCount, compactHistory);
           }
         }
       }

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/SQLQueryBuilder.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/SQLQueryBuilder.java
@@ -693,11 +693,16 @@ public class SQLQueryBuilder {
         return SQLQuery.replaceVars(deleteHistoryTriggerSQL, schema, table);
     }
 
-    protected static String addHistoryTriggerSQL(final String schema, final String table, final Integer maxVersionCount){
+    protected static String addHistoryTriggerSQL(final String schema, final String table, final Integer maxVersionCount, final boolean compactHistory){
+        String triggerFunction = compactHistory ? "xyz_trigger_historywriter" : "xyz_trigger_historywriter_full";
+
         String historyTriggerSQL = "CREATE TRIGGER TR_"+table.replaceAll("-","_")+"_HISTORY_WRITER " +
-                "BEFORE UPDATE OR DELETE ON ${schema}.${table} " +
+                "BEFORE "+(compactHistory ? "" : "INSERT OR ")+" UPDATE OR DELETE ON ${schema}.${table} " +
                 " FOR EACH ROW " +
-                "EXECUTE PROCEDURE xyz_trigger_historywriter("+(maxVersionCount == null ? "" : maxVersionCount)+"); ";
+                "EXECUTE PROCEDURE "+triggerFunction;
+        historyTriggerSQL+=
+                    maxVersionCount == null ? "()" : "('"+maxVersionCount+"')";
+
         return SQLQuery.replaceVars(historyTriggerSQL, schema, table);
     }
 

--- a/xyz-psql-connector/src/main/resources/xyz_ext.sql
+++ b/xyz-psql-connector/src/main/resources/xyz_ext.sql
@@ -144,9 +144,72 @@
 CREATE OR REPLACE FUNCTION xyz_ext_version()
   RETURNS integer AS
 $BODY$
- select 129
+ select 130
 $BODY$
   LANGUAGE sql IMMUTABLE;
+------------------------------------------------
+------------------------------------------------
+CREATE OR REPLACE FUNCTION xyz_trigger_historywriter_full()
+  RETURNS trigger AS
+$BODY$
+	DECLARE oldest_uuids text[];
+	DECLARE max_version_cnt integer := COALESCE(TG_ARGV[0]::NUMERIC::INTEGER,10);
+	DECLARE max_version_diff integer;
+	DECLARE uuid_deletes text[];
+
+	BEGIN
+		IF TG_OP = 'INSERT' THEN
+			EXECUTE
+				format('INSERT INTO'
+					||' %s."%s_hst" (uuid,jsondata,geo)'
+					||' VALUES( %L,%L,%L)',TG_TABLE_SCHEMA, TG_TABLE_NAME, NEW.jsondata->'properties'->'@ns:com:here:xyz'->>'uuid', NEW.jsondata, NEW.geo);
+			RETURN NEW;
+		END IF;
+
+		IF max_version_cnt != -1 THEN
+			--IF MORE THAN max_version_cnt ARE EXISTING DELETE OLDEST ENTRIES
+			EXECUTE
+				format('SELECT array_agg(uuid)'
+					|| 'FROM( '
+					|| '	select uuid FROM %s."%s_hst" '
+					|| '		WHERE jsondata->>''id'' = %L ORDER BY jsondata->''properties''->''@ns:com:here:xyz''->''updatedAt'' ASC'
+					|| ') A',TG_TABLE_SCHEMA, TG_TABLE_NAME, OLD.jsondata->>'id'
+				) into oldest_uuids;
+
+			max_version_diff := array_length(oldest_uuids,1) - max_version_cnt;
+
+			IF max_version_diff >= 0 THEN
+				-- DELETE OLDEST ENTRIES
+				FOR i IN 1..max_version_diff+1 LOOP
+					select array_append(uuid_deletes, oldest_uuids[i])
+						INTO uuid_deletes;
+				END LOOP;
+				EXECUTE
+					format('DELETE FROM %s."%s_hst" WHERE uuid = ANY(%L)',TG_TABLE_SCHEMA, TG_TABLE_NAME, uuid_deletes);
+			END IF;
+		END IF;
+
+		IF TG_OP = 'UPDATE' THEN
+			EXECUTE
+				format('INSERT INTO'
+					||' %s."%s_hst" (uuid,jsondata,geo)'
+					||' VALUES( %L,%L,%L)',TG_TABLE_SCHEMA, TG_TABLE_NAME, NEW.jsondata->'properties'->'@ns:com:here:xyz'->>'uuid', NEW.jsondata, NEW.geo);
+			RETURN NEW;
+
+		ELSEIF TG_OP = 'DELETE' THEN
+			EXECUTE
+				format('INSERT INTO'
+					||' %s."%s_hst" (uuid,jsondata,geo)'
+					||' VALUES( %L,%L,%L)',TG_TABLE_SCHEMA, TG_TABLE_NAME,
+					OLD.jsondata->'properties'->'@ns:com:here:xyz'->>'uuid' || '_deleted',
+					jsonb_set(OLD.jsondata,'{properties,@ns:com:here:xyz}', ('{"deleted":true}'::jsonb  || (OLD.jsondata->'properties'->'@ns:com:here:xyz')::jsonb)),
+					OLD.geo);
+			RETURN OLD;
+		END IF;
+	END;
+$BODY$
+language plpgsql;
+
 ------------------------------------------------
 ------------------------------------------------
 CREATE OR REPLACE FUNCTION xyz_trigger_historywriter()
@@ -158,25 +221,28 @@ $BODY$
 	DECLARE uuid_deletes text[];
 
 	BEGIN
-		EXECUTE
-			format('SELECT array_agg(uuid)'
-				|| 'FROM( '
-				|| '	select uuid FROM %s."%s_hst" '
-				|| '		WHERE jsondata->>''id'' = %L ORDER BY jsondata->''properties''->''@ns:com:here:xyz''->''updatedAt'' ASC'
-				|| ') A',TG_TABLE_SCHEMA, TG_TABLE_NAME, OLD.jsondata->>'id'
-			) into path;
+        IF max_version_cnt != -1 THEN
+            --IF MORE THAN max_version_cnt ARE EXISTING DELETE OLDEST ENTRIES
+            EXECUTE
+                format('SELECT array_agg(uuid)'
+                    || 'FROM( '
+                    || '	select uuid FROM %s."%s_hst" '
+                    || '		WHERE jsondata->>''id'' = %L ORDER BY jsondata->''properties''->''@ns:com:here:xyz''->''updatedAt'' ASC'
+                    || ') A',TG_TABLE_SCHEMA, TG_TABLE_NAME, OLD.jsondata->>'id'
+                ) into path;
 
-		max_version_diff := array_length(path,1) - max_version_cnt;
+            max_version_diff := array_length(path,1) - max_version_cnt;
 
-		IF max_version_diff >= 0 THEN
-			-- DELETE OLDEST ENTRIES
-			FOR i IN 1..max_version_diff+1 LOOP
-				select array_append(uuid_deletes, path[i])
-					INTO uuid_deletes;
-			END LOOP;
-			EXECUTE
-				format('DELETE FROM %s."%s_hst" WHERE uuid = ANY(%L)',TG_TABLE_SCHEMA, TG_TABLE_NAME, uuid_deletes);
-		END IF;
+            IF max_version_diff >= 0 THEN
+                -- DELETE OLDEST ENTRIES
+                FOR i IN 1..max_version_diff+1 LOOP
+                    select array_append(uuid_deletes, path[i])
+                        INTO uuid_deletes;
+                END LOOP;
+                EXECUTE
+                    format('DELETE FROM %s."%s_hst" WHERE uuid = ANY(%L)',TG_TABLE_SCHEMA, TG_TABLE_NAME, uuid_deletes);
+            END IF;
+        END IF;
 
 		IF TG_OP = 'UPDATE' THEN
 			EXECUTE


### PR DESCRIPTION
Add:
- possibility to define a connector Parameter "compactHistory". If is set to false all states (including Inserts) are get written to the history table. Default is "true".
- possibility to define an unlimited history by using "maxVersionCount" : -1. Default is "10" - means 10 versions are getting stored.

Fix: 
- persist "maxVersionCount" in SpaceDefinition