### PR TITLE
Fix propertysearch bug

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/ApiParam.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/ApiParam.java
@@ -268,29 +268,36 @@ public class ApiParam {
               e.printStackTrace();
             }
 
+            int position=0;
+            String op=null;
+
+            /** store "main" operator. Needed for such cases foo=bar-->test*/
             for (String shortOperator : shortOperators) {
-              if (keyValuePair.contains(shortOperator)) {
-                // If the original parameter expression doesn't contain the equal sign API GW appends it at the end
-                String[] keyVal = keyValuePair.split(shortOperator);
-                if (keyVal.length < 2) {
-                  break;
+              int currentPositionOfOp = keyValuePair.indexOf(shortOperator);
+              if (currentPositionOfOp != -1) {
+                if(op == null || currentPositionOfOp < position) {
+                  op = shortOperator;
+                  position = currentPositionOfOp;
                 }
-                if ((">".equals(shortOperator) || "<".equals(shortOperator)) && keyVal[1].endsWith("=")) {
-                  keyVal[1] = keyVal[1].substring(0, keyVal[1].length() - 1);
-                }
+              }
+            }
+
+            if(op != null){
+                String[] keyVal = new String[]{keyValuePair.substring(0, position), keyValuePair.substring(position + op.length())};
+
                 propertyQuery.setKey(getConvertedKey(keyVal[0]));
-                propertyQuery.setOperation(operators.get(shortOperator));
+                propertyQuery.setOperation(operators.get(op));
                 String[] rawValues = keyVal[1].split(",");
+
                 ArrayList<Object> values = new ArrayList<>();
                 for (String rawValue : rawValues) {
                   values.add(getConvertedValue(rawValue));
                 }
                 propertyQuery.setValues(values);
                 pql.add(propertyQuery);
-                break;
               }
-            }
           });
+
       PropertiesQuery pq = new PropertiesQuery();
       pq.add(pql);
 

--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/PropertiesSearchIT.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/PropertiesSearchIT.java
@@ -68,20 +68,20 @@ public class PropertiesSearchIT extends TestSpaceWithFeature {
   @Test
   public void testGreaterThanEquals() {
     given().
-            accept(APPLICATION_GEO_JSON).
-            headers(getAuthHeaders(AuthProfile.ACCESS_OWNER_1_ADMIN)).
-            when().
-            get("/spaces/x-psql-test/search?p.capacity>=50000").
-            then().
-            body("features.size()", equalTo(150));
+        accept(APPLICATION_GEO_JSON).
+        headers(getAuthHeaders(AuthProfile.ACCESS_OWNER_1_ADMIN)).
+        when().
+        get("/spaces/x-psql-test/search?p.capacity>=50000").
+        then().
+        body("features.size()", equalTo(150));
 
     given().
-            accept(APPLICATION_GEO_JSON).
-            headers(getAuthHeaders(AuthProfile.ACCESS_OWNER_1_ADMIN)).
-            when().
-            get("/spaces/x-psql-test/search?p.capacity=gte=50000").
-            then().
-            body("features.size()", equalTo(150));
+        accept(APPLICATION_GEO_JSON).
+        headers(getAuthHeaders(AuthProfile.ACCESS_OWNER_1_ADMIN)).
+        when().
+        get("/spaces/x-psql-test/search?p.capacity=gte=50000").
+        then().
+        body("features.size()", equalTo(150));
   }
 
   @Test
@@ -106,20 +106,20 @@ public class PropertiesSearchIT extends TestSpaceWithFeature {
   @Test
   public void testLessThanEquals() {
     given().
-            accept(APPLICATION_GEO_JSON).
-            headers(getAuthHeaders(AuthProfile.ACCESS_OWNER_1_ADMIN)).
-            when().
-            get("/spaces/x-psql-test/search?p.capacity<=50000").
-            then().
-            body("features.size()", equalTo(119));
+        accept(APPLICATION_GEO_JSON).
+        headers(getAuthHeaders(AuthProfile.ACCESS_OWNER_1_ADMIN)).
+        when().
+        get("/spaces/x-psql-test/search?p.capacity<=50000").
+        then().
+        body("features.size()", equalTo(119));
 
     given().
-            accept(APPLICATION_GEO_JSON).
-            headers(getAuthHeaders(AuthProfile.ACCESS_OWNER_1_ADMIN)).
-            when().
-            get("/spaces/x-psql-test/search?p.capacity=lte=50000").
-            then().
-            body("features.size()", equalTo(119));
+        accept(APPLICATION_GEO_JSON).
+        headers(getAuthHeaders(AuthProfile.ACCESS_OWNER_1_ADMIN)).
+        when().
+        get("/spaces/x-psql-test/search?p.capacity=lte=50000").
+        then().
+        body("features.size()", equalTo(119));
   }
 
   @Test
@@ -140,6 +140,42 @@ public class PropertiesSearchIT extends TestSpaceWithFeature {
         then().
         body("features.size()", equalTo(1)).
         body("features[0].properties.name", equalTo("Arizona Stadium"));
+
+    given().
+        accept(APPLICATION_GEO_JSON).
+        headers(getAuthHeaders(AuthProfile.ACCESS_OWNER_1_ADMIN)).
+        when().
+        get("/spaces/x-psql-test/search?p.name=").
+        then().
+        body("features.size()", equalTo(1)).
+        body("features[0].properties.name", equalTo(""));
+  }
+
+  @Test
+  public void testNotEquals() {
+    given().
+            accept(APPLICATION_GEO_JSON).
+            headers(getAuthHeaders(AuthProfile.ACCESS_OWNER_1_ADMIN)).
+            when().
+            get("/spaces/x-psql-test/search?p.capacity!=50000").
+            then().
+            body("features.size()", equalTo(235));
+
+    given().
+            accept(APPLICATION_GEO_JSON).
+            headers(getAuthHeaders(AuthProfile.ACCESS_OWNER_1_ADMIN)).
+            when().
+            get("/spaces/x-psql-test/search?p.name!=Arizona Stadium").
+            then().
+            body("features.size()", equalTo(251));
+
+    given().
+            accept(APPLICATION_GEO_JSON).
+            headers(getAuthHeaders(AuthProfile.ACCESS_OWNER_1_ADMIN)).
+            when().
+            get("/spaces/x-psql-test/search?p.name!=").
+            then().
+            body("features.size()", equalTo(251));
   }
 
   @Test

--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/PropertiesSearchIT.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/PropertiesSearchIT.java
@@ -66,22 +66,60 @@ public class PropertiesSearchIT extends TestSpaceWithFeature {
   }
 
   @Test
+  public void testGreaterThanEquals() {
+    given().
+            accept(APPLICATION_GEO_JSON).
+            headers(getAuthHeaders(AuthProfile.ACCESS_OWNER_1_ADMIN)).
+            when().
+            get("/spaces/x-psql-test/search?p.capacity>=50000").
+            then().
+            body("features.size()", equalTo(150));
+
+    given().
+            accept(APPLICATION_GEO_JSON).
+            headers(getAuthHeaders(AuthProfile.ACCESS_OWNER_1_ADMIN)).
+            when().
+            get("/spaces/x-psql-test/search?p.capacity=gte=50000").
+            then().
+            body("features.size()", equalTo(150));
+  }
+
+  @Test
   public void testLessThan() {
     given().
         accept(APPLICATION_GEO_JSON).
         headers(getAuthHeaders(AuthProfile.ACCESS_OWNER_1_ADMIN)).
         when().
-        get("/spaces/x-psql-test/search?p.capacity>50000").
+        get("/spaces/x-psql-test/search?p.capacity<50000").
         then().
-        body("features.size()", equalTo(133));
+        body("features.size()", equalTo(102));
 
     given().
         accept(APPLICATION_GEO_JSON).
         headers(getAuthHeaders(AuthProfile.ACCESS_OWNER_1_ADMIN)).
         when().
-        get("/spaces/x-psql-test/search?p.capacity=gt=50000").
+        get("/spaces/x-psql-test/search?p.capacity=lt=50000").
         then().
-        body("features.size()", equalTo(133));
+        body("features.size()", equalTo(102));
+  }
+
+  @Test
+  public void testLessThanEquals() {
+    given().
+            accept(APPLICATION_GEO_JSON).
+            headers(getAuthHeaders(AuthProfile.ACCESS_OWNER_1_ADMIN)).
+            when().
+            get("/spaces/x-psql-test/search?p.capacity<=50000").
+            then().
+            body("features.size()", equalTo(119));
+
+    given().
+            accept(APPLICATION_GEO_JSON).
+            headers(getAuthHeaders(AuthProfile.ACCESS_OWNER_1_ADMIN)).
+            when().
+            get("/spaces/x-psql-test/search?p.capacity=lte=50000").
+            then().
+            body("features.size()", equalTo(119));
   }
 
   @Test
@@ -159,7 +197,53 @@ public class PropertiesSearchIT extends TestSpaceWithFeature {
         body("features.size()", equalTo(252));
   }
 
-  /*
+  @Test
+  public void testSpecialCharactersProperty() {
+    given().
+            accept(APPLICATION_GEO_JSON).
+            headers(getAuthHeaders(AuthProfile.ACCESS_OWNER_1_ADMIN)).
+            when().
+            get("/spaces/x-psql-test/search?p.sport=association = football").
+            then().
+            body("features.size()", equalTo(1));
+
+    given().
+            accept(APPLICATION_GEO_JSON).
+            headers(getAuthHeaders(AuthProfile.ACCESS_OWNER_1_ADMIN)).
+            when().
+            get("/spaces/x-psql-test/search?p.sport=association <= football").
+            then().
+            body("features.size()", equalTo(1));
+
+    given().
+            accept(APPLICATION_GEO_JSON).
+            headers(getAuthHeaders(AuthProfile.ACCESS_OWNER_1_ADMIN)).
+            when().
+            get("/spaces/x-psql-test/search?p.sport=association =gte= football").
+            then().
+            body("features.size()", equalTo(1));
+
+    given().
+            accept(APPLICATION_GEO_JSON).
+            headers(getAuthHeaders(AuthProfile.ACCESS_OWNER_1_ADMIN)).
+            when().
+            get("/spaces/x-psql-test/search?p.sport=association --> football").
+            then().
+            body("features.size()", equalTo(1));
+  }
+
+  @Test
+  public void testSearchWithoutValues() {
+    given().
+            accept(APPLICATION_GEO_JSON).
+            headers(getAuthHeaders(AuthProfile.ACCESS_OWNER_1_ADMIN)).
+            when().
+            get("/spaces/x-psql-test/search?p.sport=&p.sport>=&p.sport=gte=&foo=bar").
+            then().
+            body("features.size()", equalTo(0));
+  }
+
+    /*
    * Test is commented out because it takes too long to execute, since the indexes should be created by the connector for the test be valid.
    * Only kept here for future reference
    */

--- a/xyz-hub-test/src/test/resources/xyz/hub/processedData.json
+++ b/xyz-hub-test/src/test/resources/xyz/hub/processedData.json
@@ -35,7 +35,7 @@
             "id": "Q929126",
             "type": "Feature",
             "properties": {
-                "name": "Tianhe Stadium",
+                "name": "",
                 "@ns:com:here:xyz": {
                     "tags": [
                         "stadium",

--- a/xyz-hub-test/src/test/resources/xyz/hub/processedData.json
+++ b/xyz-hub-test/src/test/resources/xyz/hub/processedData.json
@@ -20,7 +20,7 @@
                     ]
                 },
                 "occupant": "Daring Club Motema Pembe",
-                "sport": "association football",
+                "sport": "association = football",
                 "capacity": 50000
             }
         },
@@ -43,7 +43,7 @@
                     ]
                 },
                 "occupant": "Guangzhou Evergrande Taobao Football Club",
-                "sport": "association football",
+                "sport": "association <= football",
                 "capacity": 58500
             }
         },
@@ -66,7 +66,7 @@
                     ]
                 },
                 "occupant": "Clube do Remo",
-                "sport": "association football",
+                "sport": "association =gte= football",
                 "capacity": 45007
             }
         },
@@ -89,7 +89,7 @@
                     ]
                 },
                 "occupant": "Maranhão Atlético Clube",
-                "sport": "association football",
+                "sport": "association --> football",
                 "capacity": 40000
             }
         },


### PR DESCRIPTION
Fix problems if values are containing search operands. 
E.g: &p.foo=foo-->1