### PR TITLE
Array search

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/ApiParam.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/ApiParam.java
@@ -141,7 +141,7 @@ public class ApiParam {
 
     static final String FORCE_2D = "force2D";
 
-    private static List<String> shortOperators = Arrays.asList("!=", ">=", "=gte=", "<=", "=lte=", ">", "=gt=", "<", "=lt=", "=");
+    private static List<String> shortOperators = Arrays.asList("!=", ">=", "=gte=", "<=", "=lte=", ">", "=gt=", "<", "=lt=", "@>", "=cs=", "=");
     private static Map<String, QueryOperation> operators = new HashMap<String, QueryOperation>() {{
       put("!=", QueryOperation.NOT_EQUALS);
       put(">=", QueryOperation.GREATER_THAN_OR_EQUALS);
@@ -153,6 +153,8 @@ public class ApiParam {
       put("<", QueryOperation.LESS_THAN);
       put("=lt=", QueryOperation.LESS_THAN);
       put("=", QueryOperation.EQUALS);
+      put("@>", QueryOperation.CONTAINS);
+      put("=cs=", QueryOperation.CONTAINS);
     }};
 
     /**

--- a/xyz-hub-service/src/main/resources/openapi.yaml
+++ b/xyz-hub-service/src/main/resources/openapi.yaml
@@ -1123,6 +1123,7 @@ components:
           - "<=" or "=lte=" - less than or equals
           - ">" or "=gt=" - greater than
           - "<" or "=lt=" - less than
+          - "@>" or "=cs" - contains
       style: form
       explode: true
       schema:
@@ -1629,7 +1630,10 @@ components:
         dot-notation e.g.: some.nested.property) and the value is a boolean telling whether the
         property should be searchable or not.
         Setting the value to `false` the property won't be searchable at all. (Even if the  property
-        was chosen to be searchable by the automated property-search algorithm before)
+        was chosen to be searchable by the automated property-search algorithm before). Optional it is
+        possible to define the datatype (object,array,string,number,boolean) of the property
+        eg.: some.nested.property::array. If the datatype is not given, an attempt is made to determine
+        it automatically.
       type: object
       additionalProperties:
         type: boolean

--- a/xyz-hub-service/src/main/resources/openapi.yaml
+++ b/xyz-hub-service/src/main/resources/openapi.yaml
@@ -1123,7 +1123,7 @@ components:
           - "<=" or "=lte=" - less than or equals
           - ">" or "=gt=" - greater than
           - "<" or "=lt=" - less than
-          - "@>" or "=cs" - contains
+          - "@>" or "=cs=" - contains
       style: form
       explode: true
       schema:

--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/PropertiesSearchIT.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/PropertiesSearchIT.java
@@ -47,6 +47,79 @@ public class PropertiesSearchIT extends TestSpaceWithFeature {
   }
 
   @Test
+  public void testContains() {
+    given().
+            accept(APPLICATION_GEO_JSON).
+            headers(getAuthHeaders(AuthProfile.ACCESS_OWNER_1_ADMIN)).
+            when().
+            get("/spaces/x-psql-test/search?p.stringArray@>foo1").
+            then().
+            body("features.size()", equalTo(1));
+    given().
+            accept(APPLICATION_GEO_JSON).
+            headers(getAuthHeaders(AuthProfile.ACCESS_OWNER_1_ADMIN)).
+            when().
+            get("/spaces/x-psql-test/search?p.stringArray=cs=foo2").
+            then().
+            body("features.size()", equalTo(2));
+    given().
+            accept(APPLICATION_GEO_JSON).
+            headers(getAuthHeaders(AuthProfile.ACCESS_OWNER_1_ADMIN)).
+            when().
+            get("/spaces/x-psql-test/search?p.stringArray=cs=foo1,NA").
+            then().
+            body("features.size()", equalTo(1));
+    given().
+            accept(APPLICATION_GEO_JSON).
+            headers(getAuthHeaders(AuthProfile.ACCESS_OWNER_1_ADMIN)).
+            when().
+            get("/spaces/x-psql-test/search?p.stringArray=cs=NA").
+            then().
+            body("features.size()", equalTo(0));
+
+    given().
+            accept(APPLICATION_GEO_JSON).
+            headers(getAuthHeaders(AuthProfile.ACCESS_OWNER_1_ADMIN)).
+            when().
+            get("/spaces/x-psql-test/search?p.intArray@>1").
+            then().
+            body("features.size()", equalTo(1));
+    given().
+            accept(APPLICATION_GEO_JSON).
+            headers(getAuthHeaders(AuthProfile.ACCESS_OWNER_1_ADMIN)).
+            when().
+            get("/spaces/x-psql-test/search?p.intArray=cs=2").
+            then().
+            body("features.size()", equalTo(2));
+
+    given().
+            accept(APPLICATION_GEO_JSON).
+            headers(getAuthHeaders(AuthProfile.ACCESS_OWNER_1_ADMIN)).
+            when().
+            queryParam("p.objectArray@>{\"foo1\":1}").
+            get("/spaces/x-psql-test/search").
+            then().
+            body("features.size()", equalTo(1));
+    given().
+            accept(APPLICATION_GEO_JSON).
+            headers(getAuthHeaders(AuthProfile.ACCESS_OWNER_1_ADMIN)).
+            when().
+            queryParam("p.objectArray=cs={\"foo2\":2}").
+            get("/spaces/x-psql-test/search").
+            then().
+            body("features.size()", equalTo(2));
+
+    given().
+            accept(APPLICATION_GEO_JSON).
+            headers(getAuthHeaders(AuthProfile.ACCESS_OWNER_1_ADMIN)).
+            when().
+            queryParam("p.nestedObjectArray@>{\"foo\":{\"foo1\":{\"foo2\":2}}}").
+            get("/spaces/x-psql-test/search").
+            then().
+            body("features.size()", equalTo(1));
+  }
+
+  @Test
   public void testGreaterThan() {
     given().
         accept(APPLICATION_GEO_JSON).

--- a/xyz-hub-test/src/test/resources/xyz/hub/processedData.json
+++ b/xyz-hub-test/src/test/resources/xyz/hub/processedData.json
@@ -21,7 +21,11 @@
                 },
                 "occupant": "Daring Club Motema Pembe",
                 "sport": "association = football",
-                "capacity": 50000
+                "capacity": 50000,
+                "stringArray" : [ "foo1" , "foo2" ],
+                "intArray" : [ 1 , 2 ],
+                "objectArray" : [ {"foo1" :  1} ,{"foo2" :  2} ],
+                "nestedObjectArray" : [ {"foo" : {"foo1" :  {"foo2" :  2}}}]
             }
         },
         {
@@ -44,7 +48,10 @@
                 },
                 "occupant": "Guangzhou Evergrande Taobao Football Club",
                 "sport": "association <= football",
-                "capacity": 58500
+                "capacity": 58500,
+                "stringArray" : [ "foo2" , "foo3" ],
+                "intArray" : [ 2 , 3 ],
+                "objectArray" : [ {"foo2" :  2} ,{"foo3" :  3} ]
             }
         },
         {

--- a/xyz-models/src/main/java/com/here/xyz/events/PropertyQuery.java
+++ b/xyz-models/src/main/java/com/here/xyz/events/PropertyQuery.java
@@ -79,5 +79,5 @@ public class PropertyQuery {
     return this;
   }
 
-  public enum QueryOperation {EQUALS, NOT_EQUALS, LESS_THAN, GREATER_THAN, LESS_THAN_OR_EQUALS, GREATER_THAN_OR_EQUALS}
+  public enum QueryOperation {EQUALS, NOT_EQUALS, LESS_THAN, GREATER_THAN, LESS_THAN_OR_EQUALS, GREATER_THAN_OR_EQUALS, CONTAINS}
 }

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseMaintainer.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseMaintainer.java
@@ -38,7 +38,7 @@ public class DatabaseMaintainer {
     private static final Logger logger = LogManager.getLogger();
 
     /** Is used to check against xyz_ext_version() */
-    private static final int XYZ_EXT_VERSION = 130;
+    private static final int XYZ_EXT_VERSION = 131;
     /** Can get configured dynamically with storageParam onDemandIdxLimit */
     protected final static int ON_DEMAND_IDX_DEFAULT_LIM = 4;
 

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/SQLQuery.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/SQLQuery.java
@@ -223,6 +223,8 @@ public class SQLQuery {
         return "<=";
       case GREATER_THAN_OR_EQUALS:
         return ">=";
+      case CONTAINS:
+        return "@>";
     }
 
     return "";
@@ -234,8 +236,10 @@ public class SQLQuery {
             "jsondata->" + Collections.nCopies(results.length, "?").stream().collect(Collectors.joining("->")), results);
   }
 
-  protected static String getValue(Object value) {
+  protected static String getValue(Object value, PropertyQuery.QueryOperation op) {
     if (value instanceof String) {
+      if(op.equals(PropertyQuery.QueryOperation.CONTAINS) && ((String) value).startsWith("{") && ((String) value).endsWith("}"))
+        return "(?::jsonb || '[]'::jsonb)";
       return "to_jsonb(?::text)";
     }
     if (value instanceof Number) {

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/SQLQueryBuilder.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/SQLQueryBuilder.java
@@ -570,7 +570,7 @@ public class SQLQueryBuilder {
                     else {
                         SQLQuery q = SQLQuery.createKey(propertyQuery.getKey());
 
-                        q.append(new SQLQuery(SQLQuery.getOperation(propertyQuery.getOperation()) + SQLQuery.getValue(v), v));
+                        q.append(new SQLQuery(SQLQuery.getOperation(propertyQuery.getOperation()) + SQLQuery.getValue(v,propertyQuery.getOperation()), v));
                         keyDisjunctionQueries.add(q);
                     }
                 });


### PR DESCRIPTION
Add possibility to search values which are stored in arrays:

1.  {"foo" : [1,2,3,4, ...]} 
search?p.foo@>1

2. {"foo" : ["bar","bar2", ...]}
search?p.foo@>bar2

3. {"foo": [ {"1" : "bar" , "2" : "bar2" }, ...]}
search?p.foo={ "1" : bar }

4. {"foo": [ {"1" : { "1.1" : true }}, ...]}
search?p.foo={"1" : { "1.1" : true }}

5. {"foo": [ {"1" : { "1.1" : { "1.1.1" : "bar" }}}, ...]}
search?p.foo= {"1" : { "1.1" : { "1.1.1" : "bar" }}}

Extend searchableProperties implementation with the possibility 
to define manually a datatype (array,object,string,number,boolean_) manually:

1. {"searchableProperties" : { "foo::array" : true}