### PR TITLE
Cache the result of the verified JWT token.

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/auth/JwtDummyHandler.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/auth/JwtDummyHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ public class JwtDummyHandler extends AuthHandlerImpl implements JWTAuthHandler {
   private static final Logger logger = LogManager.getLogger();
   private final JsonObject options = new JsonObject();
   private static final String DUMMY_JWT_RESOURCE_FILE = "/auth/dummyJwt.json";
-  private static volatile String dummyJwt = JwtGenerator.generateToken(DUMMY_JWT_RESOURCE_FILE);
+  private static final  String dummyJwt = JwtGenerator.generateToken(DUMMY_JWT_RESOURCE_FILE);
 
   static {
     logger.info("DUMMY token was created.");

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/auth/XyzAuthProvider.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/auth/XyzAuthProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,10 @@ import io.vertx.ext.auth.jwt.JWTAuthOptions;
 import io.vertx.ext.auth.jwt.impl.JWTAuthProviderImpl;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.concurrent.TimeUnit;
 import java.util.zip.DataFormatException;
+import net.jodah.expiringmap.ExpirationPolicy;
+import net.jodah.expiringmap.ExpiringMap;
 import org.apache.commons.lang3.StringUtils;
 
 public class XyzAuthProvider extends JWTAuthProviderImpl {
@@ -38,6 +41,12 @@ public class XyzAuthProvider extends JWTAuthProviderImpl {
   public XyzAuthProvider(Vertx vertx, JWTAuthOptions config) {
     super(vertx, config);
   }
+
+  protected final ExpiringMap<String, User> usersCache = ExpiringMap.builder()
+      .maxSize(8*1024)
+      .expirationPolicy(ExpirationPolicy.CREATED)
+      .expiration(10, TimeUnit.MINUTES)
+      .build();
 
   @Override
   public void authenticate(JsonObject authInfo, Handler<AsyncResult<User>> resultHandler) {
@@ -55,6 +64,12 @@ public class XyzAuthProvider extends JWTAuthProviderImpl {
       }
     }
 
+    User cachedUser = usersCache.get(jwt);
+    if( cachedUser != null ){
+      resultHandler.handle(Future.succeededFuture(cachedUser));
+      return;
+    }
+
     super.authenticate(authInfo, (authResult) -> {
       if (authResult.failed()) {
         resultHandler.handle(Future.failedFuture(authResult.cause()));
@@ -64,6 +79,7 @@ public class XyzAuthProvider extends JWTAuthProviderImpl {
       final User user = authResult.result();
       user.principal().put("jwt", jwt);
 
+      usersCache.put(jwt,user);
       resultHandler.handle(Future.succeededFuture(user));
     });
   }


### PR DESCRIPTION
Verifying the signature of a token is an expensive operation. Use a cached result for 10 minutes.

Signed-off-by: Dimitar Goshev <dimitar.goshev@here.com>