### PR TITLE
Added aid and jwt to NotificationParams.

### DIFF
--- a/xyz-connectors/src/main/java/com/here/xyz/connectors/ListenerConnector.java
+++ b/xyz-connectors/src/main/java/com/here/xyz/connectors/ListenerConnector.java
@@ -73,7 +73,7 @@ public abstract class ListenerConnector extends AbstractConnectorHandler {
         eventDecryptor.decryptParams(notification.getParams()),
         eventDecryptor.decryptParams(notification.getConnectorParams()),
         eventDecryptor.decryptParams(notification.getMetadata()),
-        notification.getTid());
+        notification.getTid(), notification.getAid(), notification.getJwt());
 
     if (notification.getEvent() instanceof ErrorResponse) {
       processErrorResponse((ErrorResponse) notification.getEvent(), notification.getEventType(), notificationParams);

--- a/xyz-connectors/src/main/java/com/here/xyz/connectors/NotificationParams.java
+++ b/xyz-connectors/src/main/java/com/here/xyz/connectors/NotificationParams.java
@@ -26,12 +26,16 @@ public class NotificationParams {
   public final Map<String, Object> params;
   public final Map<String, Object> connectorParams;
   public final String tid;
+  public final String aid;
+  public final String jwt;
   public final Map<String, Object> metadata;
 
-  public NotificationParams(Map<String, Object> params, Map<String, Object> connectorParams, Map<String, Object> metadata, String tid) {
+  public NotificationParams(Map<String, Object> params, Map<String, Object> connectorParams, Map<String, Object> metadata, String tid, String aid, String jwt) {
     this.params = params;
     this.connectorParams = connectorParams;
     this.metadata = metadata;
     this.tid = tid;
+    this.aid = aid;
+    this.jwt = jwt;
   }
 }

--- a/xyz-connectors/src/main/java/com/here/xyz/connectors/ProcessorConnector.java
+++ b/xyz-connectors/src/main/java/com/here/xyz/connectors/ProcessorConnector.java
@@ -72,7 +72,7 @@ public abstract class ProcessorConnector extends AbstractConnectorHandler {
         eventDecryptor.decryptParams(notification.getParams()),
         eventDecryptor.decryptParams(notification.getConnectorParams()),
         eventDecryptor.decryptParams(notification.getMetadata()),
-        notification.getTid());
+        notification.getTid(), notification.getAid(), notification.getJwt());
 
     if (notification.getEvent() instanceof ErrorResponse) {
       return processErrorResponse((ErrorResponse) notification.getEvent(), notification.getEventType(), notificationParams);


### PR DESCRIPTION
Trusted prostprocessors can not easily access aid and jwt information since they are not readily available within the NotificationParams.
While a workaround is possible, it isn't pretty and likely to cause problems in the future due to code changes.

I've added the two fields to the NotificationParams.
This way, postprocessors of trusted connectors can access jwt and aid.