### PR TITLE
Added throws Exception to processModifySpace method.

### DIFF
--- a/xyz-connectors/src/main/java/com/here/xyz/connectors/EncryptingProcessorConnector.java
+++ b/xyz-connectors/src/main/java/com/here/xyz/connectors/EncryptingProcessorConnector.java
@@ -28,7 +28,7 @@ import java.util.List;
 /**
  * This class could be extended by any processor connector implementations that want automatic encryption of secrets.
  */
-@SuppressWarnings({"WeakerAccess", "unused"})
+@SuppressWarnings({"WeakerAccess"})
 public abstract class EncryptingProcessorConnector extends ProcessorConnector {
 
   /**
@@ -44,8 +44,9 @@ public abstract class EncryptingProcessorConnector extends ProcessorConnector {
   /**
    * {@inheritDoc}
    */
+  @SuppressWarnings("RedundantThrows")
   @Override
-  protected ModifySpaceEvent processModifySpace(ModifySpaceEvent event, NotificationParams notificationParams) {
+  protected ModifySpaceEvent processModifySpace(ModifySpaceEvent event, NotificationParams notificationParams) throws Exception {
     Space space = event.getSpaceDefinition();
     if (space != null)  {
       List<ListenerConnectorRef> processors = space.getProcessors().get(connectorId);


### PR DESCRIPTION
This allows extensions of EncryptingProcessorConnector to throw arbitrary Exception when processing space updates.

Signed-off-by: Josef Wegner <josef.wegner@here.com>