### PR TITLE
swagger: prevent urlencoding of '+' within taglists

### DIFF
--- a/xyz-hub-service/src/main/resources/openapi.yaml
+++ b/xyz-hub-service/src/main/resources/openapi.yaml
@@ -1120,6 +1120,7 @@ components:
         a plus sign (+). A comma separated list of tags means any tag may be
         found. A plus sign concatenated list means every tag is required.
       allowEmptyValue: true
+      allowReserved: true
       style: form
       schema:
         type: array


### PR DESCRIPTION
Signed-off-by: qGYdXbY2 <47661341+qGYdXbY2@users.noreply.github.com>