### PR TITLE
Add missing return-statement in HTTP RFC in case of retry

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/HTTPFunctionClient.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/HTTPFunctionClient.java
@@ -104,6 +104,7 @@ public class HTTPFunctionClient extends RemoteFunctionClient {
       if (tryCount <= 1) {
         logger.error(e.getMessage() + " Retrying ...", e);
         invokeWithRetry(fc, tryCount, callback);
+        return;
       }
     }
     logger.error(fc.marker, "Error sending event to remote http service", e);


### PR DESCRIPTION
Signed-off-by: Benjamin Rögner <benjamin.roegner@here.com>