### PR TITLE
Add errorDetails for ErrorResponses

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/RpcClient.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/RpcClient.java
@@ -311,23 +311,23 @@ public class RpcClient {
 
         switch (errorResponse.getError()) {
           case NOT_IMPLEMENTED:
-            throw new HttpException(NOT_IMPLEMENTED, "The connector is unable to process this request.");
+            throw new HttpException(NOT_IMPLEMENTED, "The connector is unable to process this request.",errorResponse.getErrorDetails());
           case CONFLICT:
             throw new HttpException(CONFLICT, "A conflict occurred when writing a feature: " + errorResponse.getErrorMessage(), errorResponse.getErrorDetails());
           case FORBIDDEN:
-            throw new HttpException(FORBIDDEN, "The user is not authorized.");
+            throw new HttpException(FORBIDDEN, "The user is not authorized.",errorResponse.getErrorDetails());
           case TOO_MANY_REQUESTS:
             throw new HttpException(TOO_MANY_REQUESTS,
-                "The connector cannot process the message due to a limitation in an upstream service or a database.");
+                "The connector cannot process the message due to a limitation in an upstream service or a database.",errorResponse.getErrorDetails());
           case ILLEGAL_ARGUMENT:
-            throw new HttpException(BAD_REQUEST, errorResponse.getErrorMessage());
+            throw new HttpException(BAD_REQUEST, errorResponse.getErrorMessage(), errorResponse.getErrorDetails());
           case TIMEOUT:
-            throw new HttpException(GATEWAY_TIMEOUT, "Connector timeout error.");
+            throw new HttpException(GATEWAY_TIMEOUT, "Connector timeout error.", errorResponse.getErrorDetails());
           case EXCEPTION:
           case BAD_GATEWAY:
-            throw new HttpException(BAD_GATEWAY, "Connector error.");
+            throw new HttpException(BAD_GATEWAY, "Connector error.", errorResponse.getErrorDetails());
           case PAYLOAD_TO_LARGE:
-            throw new  HttpException( Api.RESPONSE_PAYLOAD_TOO_LARGE, String.format("%s %s",Api.RESPONSE_PAYLOAD_TOO_LARGE_MESSAGE,errorResponse.getErrorMessage()) );
+            throw new  HttpException( Api.RESPONSE_PAYLOAD_TOO_LARGE, String.format("%s %s",Api.RESPONSE_PAYLOAD_TOO_LARGE_MESSAGE, errorResponse.getErrorMessage()) , errorResponse.getErrorDetails());
         }
       }
       if (payload instanceof XyzResponse) {

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/RpcClient.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/RpcClient.java
@@ -313,7 +313,7 @@ public class RpcClient {
           case NOT_IMPLEMENTED:
             throw new HttpException(NOT_IMPLEMENTED, "The connector is unable to process this request.");
           case CONFLICT:
-            throw new HttpException(CONFLICT, "A conflict occurred when updating a feature: " + errorResponse.getErrorMessage());
+            throw new HttpException(CONFLICT, "A conflict occurred when writing a feature: " + errorResponse.getErrorMessage(), errorResponse.getErrorDetails());
           case FORBIDDEN:
             throw new HttpException(FORBIDDEN, "The user is not authorized.");
           case TOO_MANY_REQUESTS:

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/Api.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/Api.java
@@ -352,7 +352,7 @@ public abstract class Api {
 
         //This is an exception sent by intention and nothing special, no need for stacktrace logging.
         logger.warn("Error was handled by Api and will be sent as response: {}", httpException.status.code());
-        sendErrorResponse(context, httpException.status, error, e.getMessage());
+        sendErrorResponse(context, httpException, error);
         return;
       }
     }
@@ -380,6 +380,25 @@ public abstract class Api {
             .withStreamId(Api.Context.getMarker(context).getName())
             .withError(error)
             .withErrorMessage(errorMessage).serialize());
+  }
+
+  /**
+   * Send an error response to the client.
+   *
+   * @param context the routing context for which to return an error response.
+   * @param httpError the HTTPException with all information
+   * @param error the error type that will become part of the {@link ErrorResponse}.
+   */
+  private void sendErrorResponse(final RoutingContext context, final HttpException httpError, final XyzError error) {
+    context.response()
+        .putHeader(CONTENT_TYPE, APPLICATION_JSON)
+        .setStatusCode(httpError.status.code())
+        .setStatusMessage(httpError.status.reasonPhrase())
+        .end(new ErrorResponse()
+            .withStreamId(Api.Context.getMarker(context).getName())
+            .withErrorDetails(httpError.errorDetails)
+            .withError(error)
+            .withErrorMessage(httpError.getMessage()).serialize());
   }
 
   /**

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/HttpException.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/HttpException.java
@@ -20,19 +20,29 @@
 package com.here.xyz.hub.rest;
 
 import io.netty.handler.codec.http.HttpResponseStatus;
+import java.util.Map;
 
 public class HttpException extends Exception {
 
 	private static final long serialVersionUID = 3414027446220801809L;
 	public final HttpResponseStatus status;
+	public final Map<String, Object> errorDetails;
 
 	public HttpException(HttpResponseStatus status, String errorText) {
 		super(errorText);
 		this.status = status;
+		this.errorDetails = null;
+	}
+
+	public HttpException(HttpResponseStatus status, String errorText, Map<String, Object>  fails){
+		super(errorText);
+		this.status = status;
+		this.errorDetails = fails;
 	}
 
 	public HttpException(HttpResponseStatus status, String errorText, Throwable cause) {
 		super(errorText, cause);
 		this.status = status;
+		this.errorDetails = null;
 	}
 }

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/HttpException.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/HttpException.java
@@ -34,10 +34,10 @@ public class HttpException extends Exception {
 		this.errorDetails = null;
 	}
 
-	public HttpException(HttpResponseStatus status, String errorText, Map<String, Object>  fails){
+	public HttpException(HttpResponseStatus status, String errorText, Map<String, Object>  errorDetails){
 		super(errorText);
 		this.status = status;
-		this.errorDetails = fails;
+		this.errorDetails = errorDetails;
 	}
 
 	public HttpException(HttpResponseStatus status, String errorText, Throwable cause) {

--- a/xyz-models/src/main/java/com/here/xyz/responses/ErrorResponse.java
+++ b/xyz-models/src/main/java/com/here/xyz/responses/ErrorResponse.java
@@ -22,6 +22,8 @@ package com.here.xyz.responses;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import java.util.Map;
+
 /**
  * An error response.
  */
@@ -32,6 +34,28 @@ public class ErrorResponse extends XyzResponse<ErrorResponse> {
   private XyzError error;
   private String errorMessage;
   private String streamId;
+  private Map<String, Object> errorDetails;
+
+  /**
+   * Returns the errorDetails which can contains additional detail information.
+   *
+   * @return the errorDetails map.
+   */
+  public Map<String, Object>  getErrorDetails(){return this.errorDetails;}
+
+  /**
+   * Set the errorDetails map to the provided value.
+   *
+   * @param errorDetails the map with detailed information to be set.
+   */
+  public void setErrorDetails(final Map<String, Object> errorDetails){
+    this.errorDetails = errorDetails;
+  }
+
+  public ErrorResponse withErrorDetails(final Map<String, Object> errorDetails){
+    setErrorDetails(errorDetails);
+    return this;
+  }
 
   /**
    * Returns the error code as enumeration value.

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseHandler.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseHandler.java
@@ -512,14 +512,12 @@ public abstract class DatabaseHandler extends StorageConnector {
                     else {
 
                         /** Add all other Objects to failed list */
-                        addAllToFailedList(fails, getAllIds(inserts, updates, upserts, deletes));
 
-                        /** Reset the rest */
-                        collection.setFeatures(new ArrayList<>());
-                        collection.setFailed(fails);
+                        Map<String, Object> errorDetails = new HashMap<>();
+                        errorDetails.put("FailedList",fails);
 
                         connection.close();
-                        return collection;
+                        return new ErrorResponse().withErrorDetails(errorDetails).withError(XyzError.CONFLICT).withErrorMessage(DatabaseWriter.TRANSACTION_ERROR_GENERAL);
                     }
                 }
 

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseWriter.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseWriter.java
@@ -160,7 +160,7 @@ public class DatabaseWriter {
     }
 
     protected static void logException(Exception e, String streamId, int i, String action, String table){
-        if(e.getMessage() != null && e.getMessage().contains("does not exist")) {
+        if(e != null && e.getMessage() != null && e.getMessage().contains("does not exist")) {
             /* If table not yet exist */
             logger.warn("{} - Failed to "+action+" object #{}: {} on table {}", streamId, i, table, e);
         }

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseWriter.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseWriter.java
@@ -38,14 +38,14 @@ public class DatabaseWriter {
     private static final Logger logger = LogManager.getLogger();
 
     public static final String UPDATE_ERROR_GENERAL = "Update has failed";
-    public static final String UPDATE_ERROR_NOT_EXISTS = "Object does not exist";
-    public static final String UPDATE_ERROR_UUID = "Object does not exist or UUID mismatch";
-    public static final String UPDATE_ERROR_ID_MISSING = "Feature Id is missing";
-    public static final String UPDATE_ERROR_PUUID_MISSING = "Feature puuid is missing";
+    public static final String UPDATE_ERROR_NOT_EXISTS = UPDATE_ERROR_GENERAL+" - Object does not exist";
+    public static final String UPDATE_ERROR_UUID = UPDATE_ERROR_GENERAL+" - Object does not exist or UUID mismatch";
+    public static final String UPDATE_ERROR_ID_MISSING = UPDATE_ERROR_GENERAL+" - Feature Id is missing";
+    public static final String UPDATE_ERROR_PUUID_MISSING = UPDATE_ERROR_GENERAL+" -  Feature puuid is missing";
 
     public static final String DELETE_ERROR_GENERAL = "Delete has failed";
-    public static final String DELETE_ERROR_NOT_EXISTS = "Object does not exist";
-    public static final String DELETE_ERROR_UUID = "Object does not exist or UUID mismatch";
+    public static final String DELETE_ERROR_NOT_EXISTS = DELETE_ERROR_GENERAL+" - Object does not exist";
+    public static final String DELETE_ERROR_UUID = DELETE_ERROR_GENERAL+" - Object does not exist or UUID mismatch";
 
     public static final String INSERT_ERROR_GENERAL = "Insert has failed";
 


### PR DESCRIPTION
* Add errorDetails to our ErrorResponse
* Change connector behavior for errors which happens in transactional mode. The connector will now send a 409 ErrorResponse with errorDetails. Inside the errorDetails the user can find information which objects are responsible for the failed transaction.