### PR TITLE
"Salt" the encrypted value with the spaceID.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -393,7 +393,6 @@
         <version>0.7.0</version>
       </dependency>
 
-
       <!--  Geo -->
       <dependency>
         <artifactId>jts-core</artifactId>

--- a/xyz-connectors/src/main/java/com/here/xyz/connectors/EncryptingProcessorConnector.java
+++ b/xyz-connectors/src/main/java/com/here/xyz/connectors/EncryptingProcessorConnector.java
@@ -51,7 +51,7 @@ public abstract class EncryptingProcessorConnector extends ProcessorConnector {
     if (space != null)  {
       List<ListenerConnectorRef> processors = space.getProcessors().get(connectorId);
       if (processors != null) {
-        processors.forEach(p -> p.setParams(eventDecryptor.encryptParams(p.getParams(), fieldsToEncrypt)));
+        processors.forEach(p -> p.setParams(eventDecryptor.encryptParams(p.getParams(), fieldsToEncrypt, space.getId())));
       }
     }
     event.setSpaceDefinition(space);

--- a/xyz-connectors/src/main/java/com/here/xyz/connectors/ListenerConnector.java
+++ b/xyz-connectors/src/main/java/com/here/xyz/connectors/ListenerConnector.java
@@ -43,7 +43,7 @@ import com.here.xyz.responses.SuccessResponse;
 /**
  * This class could be extended by any listener connector implementations.
  */
-@SuppressWarnings({"WeakerAccess", "EmptyMethod", "unused"})
+@SuppressWarnings({"WeakerAccess", "EmptyMethod", "unused", "rawtypes"})
 public abstract class ListenerConnector extends AbstractConnectorHandler {
 
   @Override
@@ -70,9 +70,9 @@ public abstract class ListenerConnector extends AbstractConnectorHandler {
     }
 
     final NotificationParams notificationParams = new NotificationParams(
-        eventDecryptor.decryptParams(notification.getParams()),
-        eventDecryptor.decryptParams(notification.getConnectorParams()),
-        eventDecryptor.decryptParams(notification.getMetadata()),
+        eventDecryptor.decryptParams(notification.getParams(), notification.getSpace()),
+        eventDecryptor.decryptParams(notification.getConnectorParams(), notification.getSpace()),
+        eventDecryptor.decryptParams(notification.getMetadata(), notification.getSpace()),
         notification.getTid(), notification.getAid(), notification.getJwt());
 
     if (notification.getEvent() instanceof ErrorResponse) {
@@ -187,7 +187,6 @@ public abstract class ListenerConnector extends AbstractConnectorHandler {
   protected void processSearchForFeatures(SearchForFeaturesEvent event, NotificationParams notificationParams) throws Exception {
   }
 
-  @SuppressWarnings("RedundantThrows")
   protected void processSearchForFeatures(FeatureCollection response, NotificationParams notificationParams) throws Exception {
   }
 
@@ -199,7 +198,6 @@ public abstract class ListenerConnector extends AbstractConnectorHandler {
   protected void processDeleteFeaturesByTag(FeatureCollection response, NotificationParams notificationParams) throws Exception {
   }
 
-  @SuppressWarnings("RedundantThrows")
   protected void processModifyFeatures(ModifyFeaturesEvent event, NotificationParams notificationParams) throws Exception {
   }
 

--- a/xyz-connectors/src/main/java/com/here/xyz/connectors/ProcessorConnector.java
+++ b/xyz-connectors/src/main/java/com/here/xyz/connectors/ProcessorConnector.java
@@ -45,7 +45,7 @@ import com.here.xyz.responses.XyzResponse;
 /**
  * This class could be extended by any processor connector implementations.
  */
-@SuppressWarnings({"WeakerAccess", "unused"})
+@SuppressWarnings({"WeakerAccess", "unused", "rawtypes"})
 public abstract class ProcessorConnector extends AbstractConnectorHandler {
 
   public static final String REQUEST = ".request";
@@ -69,9 +69,9 @@ public abstract class ProcessorConnector extends AbstractConnectorHandler {
     }
 
     final NotificationParams notificationParams = new NotificationParams(
-        eventDecryptor.decryptParams(notification.getParams()),
-        eventDecryptor.decryptParams(notification.getConnectorParams()),
-        eventDecryptor.decryptParams(notification.getMetadata()),
+        eventDecryptor.decryptParams(notification.getParams(), notification.getSpace()),
+        eventDecryptor.decryptParams(notification.getConnectorParams(), notification.getSpace()),
+        eventDecryptor.decryptParams(notification.getMetadata(), notification.getSpace()),
         notification.getTid(), notification.getAid(), notification.getJwt());
 
     if (notification.getEvent() instanceof ErrorResponse) {

--- a/xyz-connectors/src/main/java/com/here/xyz/connectors/decryptors/DummyDecryptor.java
+++ b/xyz-connectors/src/main/java/com/here/xyz/connectors/decryptors/DummyDecryptor.java
@@ -41,7 +41,7 @@ public class DummyDecryptor extends EventDecryptor {
    * @return Returns the not-decrypted map.
    */
   @Override
-  public Map<String, Object> decryptParams(final Map<String, Object> params) {
+  public Map<String, Object> decryptParams(final Map<String, Object> params, final String spaceId) {
     return params;
   }
 
@@ -53,7 +53,7 @@ public class DummyDecryptor extends EventDecryptor {
    * @return Returns the not-encrypted map.
    */
   @Override
-  public Map<String, Object> encryptParams(final Map<String, Object> params, final Set<String> fieldsToEncrypt) {
+  public Map<String, Object> encryptParams(final Map<String, Object> params, final Set<String> fieldsToEncrypt, final String spaceId) {
     return params;
   }
 

--- a/xyz-connectors/src/main/java/com/here/xyz/connectors/decryptors/EventDecryptor.java
+++ b/xyz-connectors/src/main/java/com/here/xyz/connectors/decryptors/EventDecryptor.java
@@ -28,6 +28,8 @@ import java.util.stream.Collectors;
 
 import net.jodah.expiringmap.ExpirationPolicy;
 import net.jodah.expiringmap.ExpiringMap;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Base class for all EventDecryptor implementations. Takes care of caching the decrypted secrets.
@@ -70,6 +72,11 @@ public abstract class EventDecryptor {
       .build();
 
   /**
+   * Logger
+   */
+  private static final Logger logger = LogManager.getLogger();
+
+  /**
    * This method returns an instance of the known EventDecryptor implementations.
 
    * @param decryptor The implementation to return {@link Decryptors}.
@@ -99,13 +106,14 @@ public abstract class EventDecryptor {
    * This method decrypts the given parameters.
    *
    * @param params The parameters that should be decrypted.
+   * @param spaceId The ID of the space to verify that the encrypted string was not copied from a different space.
    * @return Returns the decrypted parameters or the original if no values are encrypted or could decrypted.
    */
-  public Map<String, Object> decryptParams(final Map<String, Object> params) {
+  public Map<String, Object> decryptParams(final Map<String, Object> params, final String spaceId) {
     if (params == null) {
       return null;
     }
-    params.forEach((key, value) -> params.put(key, decryptValue(value)));
+    params.forEach((key, value) -> params.put(key, decryptValue(value, spaceId)));
     return params;
   }
 
@@ -114,29 +122,32 @@ public abstract class EventDecryptor {
    *
    * @param params The parameters that should be encrypted.
    * @param fieldToEncrypt A set of field names that should be encrypted.
+   * @param spaceId The ID of the Space that will be added to the params before encrypting.
    * @return Returns the encrypted parameters or the original if no values should be encrypted or could encrypted.
    */
-  public Map<String, Object> encryptParams(final Map<String, Object> params, final Set<String> fieldToEncrypt) {
+  public Map<String, Object> encryptParams(final Map<String, Object> params,
+                                           final Set<String> fieldToEncrypt,
+                                           final String spaceId) {
     if (params == null) {
       return null;
     }
-    params.forEach(((key, value) -> params.put(key, encryptValue(key, value, fieldToEncrypt))));
+    params.forEach(((key, value) -> params.put(key, encryptValue(key, value, fieldToEncrypt, spaceId))));
     return params;
   }
 
   @SuppressWarnings("unchecked")
-  private Object decryptValue(final Object value) {
+  private Object decryptValue(final Object value, String spaceId) {
     if (value instanceof Map) {
       Map<String, Object> map = (Map<String, Object>) value;
-      map.forEach((k,v) -> map.put(k, decryptValue(v)));
+      map.forEach((k,v) -> map.put(k, decryptValue(v, spaceId)));
       return map;
     } else if (value instanceof List) {
       List<Object> list = (List<Object>) value;
-      return list.stream().map(this::decryptValue).collect(Collectors.toList());
+      return list.stream().map(o -> decryptValue(o, spaceId)).collect(Collectors.toList());
     } else if (value instanceof String) {
       String encrypted = (String) value;
       if (isEncrypted(encrypted)) {
-        return secretsCache.computeIfAbsent(encrypted, this::decryptAsymmetric);
+        return secretsCache.computeIfAbsent(spaceId + encrypted, k -> decryptAndCheckSpaceId(encrypted, spaceId));
       } else {
         return value;
       }
@@ -145,18 +156,40 @@ public abstract class EventDecryptor {
     }
   }
 
+  private String decryptAndCheckSpaceId(final String secret, final String spaceId) {
+    String result = secret;
+    // check if the secret is encrypted at all
+    if (isEncrypted(secret)) {
+      // yes, it is. so decrypt it
+      result = decryptAsymmetric(secret);
+      // check if the secret was successfully decrypted
+      if (!isEncrypted(result)) {
+        // it is no longer encrypted, so check if the decrypted secret ends with the spaceId
+        if (result.endsWith("|" + spaceId)) {
+          // spaceIds match, return the decrypted secret without spaceId
+          result = result.substring(0, result.length() - spaceId.length() - 1);
+        } else {
+          // no, it is missing or differs -> set it to "invalid"
+          result = "invalid";
+          logger.warn("Possible copied secret. SpaceId: {}", spaceId);
+        }
+      }
+    }
+    return result;
+  }
+
   @SuppressWarnings("unchecked")
-  private Object encryptValue(final String key, final Object value, final Set<String> fieldToEncrypt) {
+  private Object encryptValue(final String key, final Object value, final Set<String> fieldToEncrypt, final String spaceId) {
     if (value instanceof Map) {
       Map<String, Object> map = (Map<String, Object>) value;
-      map.forEach((k,v) -> map.put(k, encryptValue(key + "." + k, v, fieldToEncrypt)));
+      map.forEach((k,v) -> map.put(k, encryptValue(key + "." + k, v, fieldToEncrypt, spaceId)));
       return map;
     } else if (value instanceof List) {
       List<Object> list = (List<Object>) value;
-      return list.stream().map(v -> encryptValue(key + "[]", v, fieldToEncrypt)).collect(Collectors.toList());
+      return list.stream().map(v -> encryptValue(key + "[]", v, fieldToEncrypt, spaceId)).collect(Collectors.toList());
     } else if (value instanceof String) {
       if (isToBeEncrypted((String) value) || (fieldToEncrypt.contains(key) && !isEncrypted((String) value))) {
-        return encryptAsymmetric((String) value);
+        return encryptAsymmetric(value + "|" + spaceId);
       } else {
         return value;
       }

--- a/xyz-connectors/src/main/java/com/here/xyz/connectors/decryptors/KmsEventDecryptor.java
+++ b/xyz-connectors/src/main/java/com/here/xyz/connectors/decryptors/KmsEventDecryptor.java
@@ -68,6 +68,24 @@ public class KmsEventDecryptor extends EventDecryptor {
    * Default constructor to create a new EventDecryptor that uses
    * AWS KMS to decryptPrivateKey secrets.
    *
+   * This is how you can encrypt a secret using AWS CLI:
+   * aws kms encrypt --key-id="KMS_KEY_ARN or alias/KMS_KEY_ALIAS" \
+   *                 --encryption-algorithm=RSAES_OAEP_SHA_256 \
+   *                 --output text \
+   *                 --query CiphertextBlob \
+   *                 --plaintext='YOUR SECRET|YOUR SPACE ID'
+   *
+   * This is how you can decrypt a secret using AWS CLI:
+   * aws kms decrypt --key-id="KMS_KEY_ARN or alias/KMS_KEY_ALIAS" \
+   *                 --encryption-algorithm=RSAES_OAEP_SHA_256 \
+   *                 --ciphertext-blob "$(echo "SECRET" | base64 --decode)" \
+   *                 --output text \
+   *                 --query Plaintext \
+   *                 | base64 --decode
+   *
+   * Please note that you need to append "|YOUR_SPACE_ID" to the secrets. We need this
+   * to verify that the encrypted secret was not copied from a different space.
+   *
    * Following environment variables need to be set to use this class:
    * - {@link com.here.xyz.connectors.AbstractConnectorHandler#ENV_DECRYPTOR}
    * - {@link #ENV_KMS_KEY_ARN}

--- a/xyz-connectors/src/main/java/com/here/xyz/connectors/decryptors/PrivateKeyEventDecryptor.java
+++ b/xyz-connectors/src/main/java/com/here/xyz/connectors/decryptors/PrivateKeyEventDecryptor.java
@@ -107,7 +107,20 @@ public class PrivateKeyEventDecryptor extends EventDecryptor {
    *                 -in secret.txt \
    *                 -pkeyopt rsa_padding_mode:oaep \
    *                 -pkeyopt rsa_oaep_md:sha256 \
+   *                 -pkeyopt rsa_mgf1_md:sha256 \
+   *                 base64 -w 0
+   *
+   * This is how you can decrypt a secret using openssl and the private key:
+   * echo "ENCODED SECRET" | base64 -d > secret.bin
+   * openssl pkeyutl -decrypt \
+   *                 -inkey private_key_pkcs8.pem \
+   *                 -in secret.bin \
+   *                 -pkeyopt rsa_padding_mode:oaep \
+   *                 -pkeyopt rsa_oaep_md:sha256 \
    *                 -pkeyopt rsa_mgf1_md:sha256
+   *
+   * Please note that you need to append "|YOUR_SPACE_ID" to the secrets. We need this
+   * to verify that the encrypted secret was not copied from a different space.
    *
    * Following environment variables need to be set to use this class:
    * - {@link com.here.xyz.connectors.AbstractConnectorHandler#ENV_DECRYPTOR}

--- a/xyz-connectors/src/main/java/com/here/xyz/connectors/decryptors/TestDecryptor.java
+++ b/xyz-connectors/src/main/java/com/here/xyz/connectors/decryptors/TestDecryptor.java
@@ -52,7 +52,7 @@ public class TestDecryptor extends EventDecryptor {
   }
 
   /**
-   * Test implementation. Replace pre- and postfix markers.
+   * Test implementation. Remove pre- and postfix marker.
    *
    * @param encrypted The string that should be "decrypted".
    * @return Returns the "decrypted" string.
@@ -60,7 +60,7 @@ public class TestDecryptor extends EventDecryptor {
   @Override
   public String decryptAsymmetric(final String encrypted) {
     if (isEncrypted(encrypted)) {
-      return TO_ENCRYPT_PREFIX + encrypted.substring(2, encrypted.length() - 2) + TO_ENCRYPT_POSTFIX;
+      return encrypted.substring(2, encrypted.length() - 2);
     }
     return encrypted;
   }

--- a/xyz-connectors/src/test/java/com/here/xyz/connectors/EventDecryptorTest.java
+++ b/xyz-connectors/src/test/java/com/here/xyz/connectors/EventDecryptorTest.java
@@ -19,8 +19,12 @@
 
 package com.here.xyz.connectors;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.here.xyz.connectors.decryptors.EventDecryptor;
 import com.here.xyz.connectors.decryptors.EventDecryptor.Decryptors;
 
@@ -35,8 +39,9 @@ import org.junit.Test;
 public class EventDecryptorTest {
   @SuppressWarnings("unchecked")
   @Test
-  public void testJsonPath() {
+  public void testEnDecryption() throws JsonProcessingException {
     EventDecryptor decryptor = EventDecryptor.getInstance(Decryptors.TEST);
+    ObjectMapper mapper = new ObjectMapper();
 
     Set<String> fieldsToEncrypt = new HashSet<>();
     fieldsToEncrypt.add("secret");
@@ -50,7 +55,17 @@ public class EventDecryptorTest {
     params.put("list", new ArrayList<Map<String, Object>>(1){{ this.add(new HashMap<String, Object>() {{ this.put("secret", "test"); }});}});
     params.put("anotherList", new ArrayList<String>(3) {{ this.add("test1"); this.add("test2"); this.add("test3"); }});
 
-    Map<String, Object> result = decryptor.encryptParams(params, fieldsToEncrypt);
+    // make copy of params for later comparison
+    String original = mapper.writeValueAsString(params);
+
+    System.out.println("Original params:");
+    System.out.println(original);
+
+    Map<String, Object> result = decryptor.encryptParams(params, fieldsToEncrypt, "mySpaceId");
+
+    String encrypted = mapper.writeValueAsString(result);
+    System.out.println("Encrypted params:");
+    System.out.println(encrypted);
 
     assertTrue(decryptor.isEncrypted((String) result.get("secret")));
     assertTrue(decryptor.isEncrypted((String) ((Map<String, Object>) result.get("object")).get("secret")));
@@ -58,5 +73,23 @@ public class EventDecryptorTest {
     assertTrue(decryptor.isEncrypted((String) ((List<Object>) result.get("anotherList")).get(0)));
     assertTrue(decryptor.isEncrypted((String) ((List<Object>) result.get("anotherList")).get(1)));
     assertTrue(decryptor.isEncrypted((String) ((List<Object>) result.get("anotherList")).get(2)));
+
+    // de-crypt again
+    result = decryptor.decryptParams(result, "mySpaceId");
+
+    String tmp = mapper.writeValueAsString(result);
+
+    System.out.println("Decrypted params:");
+    System.out.println(tmp);
+
+    assertEquals(original, tmp);
+
+    // check if decryption fails if spaceId does not match
+    result = decryptor.decryptParams(mapper.readValue(encrypted, new TypeReference<Map<String, Object>>() {}), "invalidSpaceId");
+
+    System.out.println("Decrypted params with invalid space ID:");
+    System.out.println(mapper.writeValueAsString(result));
+
+    assertEquals("invalid", result.get("secret"));
   }
 }


### PR DESCRIPTION
For automatic encryption we add the | + spaceID to the secret before encrypting.
When decrypting the secret, we check if the spaceID attached to the secret match the space. If not, the value is set to "invalid".

Signed-off-by: Josef Wegner <josef.wegner@here.com>