### PR TITLE
Log connector ID instead of remote function ID in RpcClient

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/RpcClient.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/RpcClient.java
@@ -306,7 +306,7 @@ public class RpcClient {
         throw new NullPointerException("Response payload is null");
       if (payload instanceof ErrorResponse) {
         ErrorResponse errorResponse = (ErrorResponse) payload;
-        logger.warn(marker, "The connector {} responded with an error of type {}: {}", getConnector().remoteFunction.id, errorResponse.getError(),
+        logger.warn(marker, "The connector {} responded with an error of type {}: {}", getConnector().id, errorResponse.getError(),
             errorResponse.getErrorMessage());
 
         switch (errorResponse.getError()) {


### PR DESCRIPTION
Signed-off-by: Benjamin Rögner <benjamin.roegner@here.com>