### PR TITLE
Respond w/ correct status code when connector is not ready.

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/task/FeatureTaskHandler.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/task/FeatureTaskHandler.java
@@ -219,6 +219,12 @@ public class FeatureTaskHandler {
         callback.exception(new HttpException(BAD_REQUEST, e.getMessage(), e));
         return;
       }
+      catch (HttpException e) {
+        cancelRPC(responseContext.rpcContext);
+        logger.error(task.getMarker(), e.getMessage(), e);
+        callback.exception(e);
+        return;
+      }
       catch (Exception e) {
         cancelRPC(responseContext.rpcContext);
         logger.error(task.getMarker(), "Unexpected error executing the storage event.", e);

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/util/logging/AccessLog.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/util/logging/AccessLog.java
@@ -107,7 +107,6 @@ class AccessLogExtended {
   public String t = "STREAM";
   public String src;
   public String streamId;
-  public String streamInfo;
   public long unixtime;
   public long timestamp;
   public String time;


### PR DESCRIPTION
Also remove extra / unused streamInfo field from access log

Signed-off-by: Benjamin Rögner <benjamin.roegner@here.com>