### PR TITLE
Improve error message for failed node-health-check due to different node-ID

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/util/health/checks/RemoteFunctionHealthAggregator.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/util/health/checks/RemoteFunctionHealthAggregator.java
@@ -121,7 +121,7 @@ public class RemoteFunctionHealthAggregator extends GroupedHealthCheck {
         toAdd.forEach(this::addRfcHc);
       }
       catch (Exception e) {
-        res = res.withMessage("Error when trying to gather remote functions info: " + e.getMessage());
+        res = res.withMessage("Error when trying to gather remote functions info: (" + e.getClass().getSimpleName() + ") " + e.getMessage());
         s.setResult(ERROR);
       }
       //Write the new health-check response to the cache

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/util/health/checks/RemoteFunctionHealthCheck.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/util/health/checks/RemoteFunctionHealthCheck.java
@@ -127,6 +127,7 @@ public class RemoteFunctionHealthCheck extends ExecutableCheck {
     cachedResponse = r;
   }
 
+  @JsonIgnore
   public int getConsecutiveErrors() {
     return consecutiveErrors;
   }


### PR DESCRIPTION
- Also remove redundant "consecutiveErrors"-field from RFC health-checks

Signed-off-by: Benjamin Rögner <benjamin.roegner@here.com>