### PR TITLE
Improve connector queuing to store request payloads off-heap

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/cache/OHCacheClient.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/cache/OHCacheClient.java
@@ -32,29 +32,19 @@ import org.caffinitas.ohc.OHCacheBuilder;
 public class OHCacheClient implements CacheClient {
 
   private static OHCacheClient client;
-  private static OHCache<byte[], byte[]> cache;
+
+  private final ScheduledExecutorService executors;
+  private OHCache<byte[], byte[]> cache;
 
   public static synchronized OHCacheClient getInstance() {
-    if (client == null) {
-      client = new OHCacheClient();
-    }
-
+    if (client == null) client = new OHCacheClient();
     return client;
   }
 
   private OHCacheClient() {
-    CacheSerializer<byte[]> serializer = new Serializer();
-    executor = Executors.newScheduledThreadPool(2);
-        OHCacheBuilder<byte[], byte[]> builder = OHCacheBuilder.newBuilder();
-        cache = builder.capacity(Service.configuration.OFF_HEAP_CACHE_SIZE_MB * 1024 * 1024)
-        .eviction(Eviction.W_TINY_LFU)
-        .keySerializer(serializer)
-        .valueSerializer(serializer)
-        .executorService(executor)
-        .build();
+    executors = Executors.newScheduledThreadPool(2);
+    cache = createCache(Service.configuration.OFF_HEAP_CACHE_SIZE_MB, executors);
   }
-
-  private final ScheduledExecutorService executor;
 
   @Override
   public void get(String key, Handler<byte[]> handler) {
@@ -64,7 +54,7 @@ public class OHCacheClient implements CacheClient {
 
   @Override
   public void set(String key, byte[] value, long ttl) {
-    cache.put(key.getBytes(), value);
+    cache.put(key.getBytes(), value, ttl * 1000);
   }
 
   @Override
@@ -74,9 +64,26 @@ public class OHCacheClient implements CacheClient {
 
   @Override
   public void shutdown() {
-    executor.shutdown();
+    executors.shutdown();
   }
-  public static class Serializer implements CacheSerializer<byte[]> {
+
+  /**
+   * Creates an OHCache with the given size in MB
+   * @param size The size of the cache in MB
+   * @return The Cache instance
+   */
+  public static OHCache<byte[], byte[]> createCache(int size, ScheduledExecutorService executors) {
+    CacheSerializer<byte[]> serializer = new Serializer();
+    OHCacheBuilder<byte[], byte[]> builder = OHCacheBuilder.newBuilder();
+    return builder.capacity(size * 1024 * 1024)
+        .eviction(Eviction.W_TINY_LFU)
+        .keySerializer(serializer)
+        .valueSerializer(serializer)
+        .executorService(executors)
+        .build();
+  }
+
+  private static class Serializer implements CacheSerializer<byte[]> {
 
     @Override
     public void serialize(byte[] bytes, ByteBuffer byteBuffer) {

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/EmbeddedFunctionClient.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/EmbeddedFunctionClient.java
@@ -88,7 +88,8 @@ public class EmbeddedFunctionClient extends RemoteFunctionClient {
   @Override
   protected void invoke(FunctionCall fc, Handler<AsyncResult<byte[]>> callback) {
     final RemoteFunctionConfig remoteFunction = getConnectorConfig().remoteFunction;
-    logger.info(fc.marker, "Invoke embedded lambda '{}' for event: {}", remoteFunction.id, new String(fc.bytes));
+    Marker marker = fc.marker;
+    logger.info(marker, "Invoke embedded lambda '{}' for event: {}", remoteFunction.id, new String(fc.getPayload()));
     embeddedExecutor.execute(() -> {
       String className = null;
       try {
@@ -99,22 +100,25 @@ public class EmbeddedFunctionClient extends RemoteFunctionClient {
           ((AbstractConnectorHandler) reqHandler).setEmbedded(true);
         }
         final ByteArrayOutputStream output = new ByteArrayOutputStream();
-        reqHandler.handleRequest(new ByteArrayInputStream(fc.bytes), output,
-            new EmbeddedContext(fc.marker, remoteFunction.id,
+        reqHandler.handleRequest(new ByteArrayInputStream(fc.getPayload()), output,
+            new EmbeddedContext(marker, remoteFunction.id,
                 ((Connector.RemoteFunctionConfig.Embedded) remoteFunction).env));
-        logger.info(fc.marker, "Handling response of embedded lambda call to '{}'.", remoteFunction.id);
+        logger.info(marker, "Handling response of embedded lambda call to '{}'.", remoteFunction.id);
         byte[] responseBytes = output.toByteArray();
         callback.handle(Future.succeededFuture(responseBytes));
-      } catch (ClassNotFoundException e) {
-        logger.error(fc.marker, "Configuration error, the specified class '{}' was not found {}", className, e);
+      }
+      catch (ClassNotFoundException e) {
+        logger.error(marker, "Configuration error, the specified class '{}' was not found {}", className, e);
         callback.handle(Future.failedFuture(e));
-      } catch (NoClassDefFoundError e) {
-        logger.error(fc.marker, "Configuration error, the specified class '{}' is referring to '{}' which does not exist", className,
+      }
+      catch (NoClassDefFoundError e) {
+        logger.error(marker, "Configuration error, the specified class '{}' is referring to '{}' which does not exist", className,
             e.getMessage());
         callback.handle(Future.failedFuture(e));
-      } catch (Throwable e) {
+      }
+      catch (Throwable e) {
         logger
-            .error(fc.marker, "Exception occurred, while trying to execute embedded lambda with id '{}' {}", remoteFunction.id, e);
+            .error(marker, "Exception occurred, while trying to execute embedded lambda with id '{}' {}", remoteFunction.id, e);
         callback.handle(Future.failedFuture(e));
       }
     });

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/HTTPFunctionClient.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/HTTPFunctionClient.java
@@ -68,7 +68,8 @@ public class HTTPFunctionClient extends RemoteFunctionClient {
 
   private void invokeWithRetry(FunctionCall fc, int tryCount, Handler<AsyncResult<byte[]>> callback) {
     final RemoteFunctionConfig remoteFunction = getConnectorConfig().remoteFunction;
-    logger.info(fc.marker, "Invoke http remote function '{}' URL is: {} Event size is: {}", remoteFunction.id, url, fc.bytes.length);
+    logger.info(fc.marker, "Invoke http remote function '{}' URL is: {} Event size is: {}",
+        remoteFunction.id, url, fc.getByteSize());
 
     final int nextTryCount = tryCount + 1;
     try {
@@ -76,7 +77,7 @@ public class HTTPFunctionClient extends RemoteFunctionClient {
           .timeout(REQUEST_TIMEOUT)
           .putHeader(CONTENT_TYPE, "application/json; charset=" + Charset.defaultCharset().name())
           .putHeader(STREAM_ID, fc.marker.getName())
-          .sendBuffer(Buffer.buffer(fc.bytes), ar -> {
+          .sendBuffer(Buffer.buffer(fc.getPayload()), ar -> {
             if (fc.fireAndForget) return;
             if (ar.failed()) {
               if (ar.cause() instanceof TimeoutException) {

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/LambdaFunctionClient.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/LambdaFunctionClient.java
@@ -46,6 +46,7 @@ import com.here.xyz.hub.rest.HttpException;
 import com.here.xyz.hub.rest.admin.Node;
 import com.here.xyz.hub.util.ARN;
 import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import java.nio.ByteBuffer;
@@ -169,21 +170,23 @@ public class LambdaFunctionClient extends RemoteFunctionClient {
   @Override
   protected void invoke(final FunctionCall fc, final Handler<AsyncResult<byte[]>> callback) {
     final RemoteFunctionConfig remoteFunction = getConnectorConfig().remoteFunction;
-    logger.debug(fc.marker, "Invoking remote lambda function with id '{}' Event size is: {}", remoteFunction.id, fc.bytes.length);
+    Marker marker = fc.marker;
+    Context context = fc.context;
+    logger.debug(marker, "Invoking remote lambda function with id '{}' Event size is: {}", remoteFunction.id, fc.getByteSize());
 
     InvokeRequest invokeReq = new InvokeRequest()
         .withFunctionName(((AWSLambda) remoteFunction).lambdaARN)
-        .withPayload(ByteBuffer.wrap(fc.bytes))
+        .withPayload(ByteBuffer.wrap(fc.getPayload()))
         .withInvocationType(fc.fireAndForget ? InvocationType.Event : InvocationType.RequestResponse);
 
     java.util.concurrent.Future<InvokeResult> future = asyncClient.invokeAsync(invokeReq, new AsyncHandler<InvokeRequest, InvokeResult>() {
       @Override
       public void onError(Exception exception) {
         if (callback == null) {
-          logger.error(fc.marker, "Error sending event to remote lambda function", exception);
+          logger.error(marker, "Error sending event to remote lambda function", exception);
         }
         else {
-          fc.context.runOnContext(v -> callback.handle(Future.failedFuture(getHttpException(fc.marker, exception))));
+          fc.context.runOnContext(v -> callback.handle(Future.failedFuture(getHttpException(marker, exception))));
         }
       }
 
@@ -191,7 +194,7 @@ public class LambdaFunctionClient extends RemoteFunctionClient {
       public void onSuccess(InvokeRequest request, InvokeResult result) {
         byte[] responseBytes = new byte[result.getPayload().remaining()];
         result.getPayload().get(responseBytes);
-        fc.context.runOnContext(v -> callback.handle(Future.succeededFuture(responseBytes)));
+        context.runOnContext(v -> callback.handle(Future.succeededFuture(responseBytes)));
       }
     });
 

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/util/LimitedOffHeapQueue.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/util/LimitedOffHeapQueue.java
@@ -26,8 +26,8 @@ public class LimitedOffHeapQueue<E extends OffHeapBuffer> extends LimitedQueue<E
 
   private static final long OH_TTL = 32_000; //ms
   private static final ScheduledExecutorService executors = Executors.newScheduledThreadPool(2);
-  private static final OHCache<byte[], byte[]> ohStorage = OHCacheClient.createCache(Service.configuration.GLOBAL_MAX_QUEUE_SIZE,
-      executors);
+  private static final OHCache<byte[], byte[]> ohStorage = OHCacheClient.createCache(
+      (int) (Service.configuration.GLOBAL_MAX_QUEUE_SIZE * 1.1), executors);
 
   public LimitedOffHeapQueue(long maxSize, long maxByteSize) {
     super(maxSize, maxByteSize);

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/util/LimitedOffHeapQueue.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/util/LimitedOffHeapQueue.java
@@ -1,0 +1,120 @@
+package com.here.xyz.hub.util;
+
+import com.here.xyz.hub.Service;
+import com.here.xyz.hub.cache.OHCacheClient;
+import com.here.xyz.hub.util.LimitedOffHeapQueue.OffHeapBuffer;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicReference;
+import org.caffinitas.ohc.OHCache;
+
+/**
+ * An extended version of the {@link LimitedQueue} which stores binary data held by its elements in an off-heap storage during the time the
+ * elements are residing in this queue.
+ *
+ * When an element gets added to this queue its payload will taken from the heap and gets moved off-heap.
+ * Once removing / fetching back the element from this queue it will be restored so that the payload is accessible using
+ * {@link OffHeapBuffer#getPayload()}.
+ * During the time the element resides in this queue its payload is not accessible. The method {@link OffHeapBuffer#getPayload()} will
+ * throw an {@link IllegalStateException} when trying to access it.
+ *
+ * @param <E> The element type.
+ */
+public class LimitedOffHeapQueue<E extends OffHeapBuffer> extends LimitedQueue<E> {
+
+  private static final long OH_TTL = 32_000; //ms
+  private static final ScheduledExecutorService executors = Executors.newScheduledThreadPool(2);
+  private static final OHCache<byte[], byte[]> ohStorage = OHCacheClient.createCache(Service.configuration.GLOBAL_MAX_QUEUE_SIZE,
+      executors);
+
+  public LimitedOffHeapQueue(long maxSize, long maxByteSize) {
+    super(maxSize, maxByteSize);
+  }
+
+  @Override
+  public List<E> add(OffHeapBuffer element) {
+    moveOffHeap(element);
+    return super.add((E) element);
+  }
+
+  @Override
+  public E remove() {
+    E removed = super.remove();
+    if (removed != null)
+      ((OffHeapBuffer) removed).unStash();
+    return removed;
+  }
+
+  private void moveOffHeap(OffHeapBuffer element) {
+    byte[] stashedPayload = element.stash();
+    ohStorage.put(element.ohKey, stashedPayload, OH_TTL);
+  }
+
+  private static void discardOHElement(OffHeapBuffer element) {
+    if (element.payload.get() == null)
+      ohStorage.remove(element.ohKey);
+  }
+
+  public static class PayloadVanishedException extends RuntimeException {
+    public final String ohKey;
+
+    private PayloadVanishedException(OffHeapBuffer item) {
+      super("The item is not available in the off-heap queue anymore.");
+      ohKey = new String(item.ohKey);
+    }
+  }
+
+  public static class OffHeapBuffer implements ByteSizeAware {
+
+    private AtomicReference<byte[]> payload = new AtomicReference<>();
+    private byte[] ohKey;
+    private long payloadSize;
+
+    public OffHeapBuffer(byte[] payload) {
+      assert payload != null;
+      this.payload.set(payload);
+      payloadSize = payload.length;
+    }
+
+    @Override
+    public final long getByteSize() {
+      return payloadSize;
+    }
+
+    /**
+     * Will be called by an OffHeapQueue which wants to "stash" this OffHeapBuffer-item in the off-heap storage.
+     * The local reference to the payload will be dropped when stashing it.
+     * @return The bytes to be stored in the off-heap storage.
+     */
+    private byte[] stash() throws IllegalStateException {
+      byte[] tmpPayload = this.payload.getAndSet(null);
+      if (tmpPayload == null) throw new IllegalStateException("Payload was already stashed.");
+      ohKey = UUID.randomUUID().toString().getBytes();
+      return tmpPayload;
+    }
+
+    private void unStash() throws PayloadVanishedException {
+      byte[] tmpPayload = payload.get();
+      if (tmpPayload == null) {
+        tmpPayload = ohStorage.get(ohKey);
+        discardOHElement(this);
+      }
+
+      if (tmpPayload == null)
+        throw new PayloadVanishedException(this);
+
+      payload.set(tmpPayload);
+    }
+
+    public final byte[] getPayload() throws IllegalStateException {
+      byte[] payload = this.payload.get();
+      if (payload == null)
+        //Payload is still stashed and can't be accessed right now
+        throw new IllegalStateException("Payload is still stashed off-heap and can not be accessed.");
+
+      return payload;
+    }
+  }
+}

--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/connectors/RFCMeasurement.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/connectors/RFCMeasurement.java
@@ -52,6 +52,7 @@ public class RFCMeasurement {
         Service.configuration.INSTANCE_COUNT = 1;
         Service.configuration.REMOTE_FUNCTION_MAX_CONNECTIONS = 256;
         Service.configuration.REMOTE_FUNCTION_CONNECTION_HIGH_UTILIZATION_THRESHOLD = 0.75f;
+        Service.configuration.GLOBAL_MAX_QUEUE_SIZE = 1024;
 
         Connector s = new Connector();
         s.id = "testStorage";
@@ -74,10 +75,11 @@ public class RFCMeasurement {
 
     public void checkMeasuring(int concurrency, long offset, long interval, long measureDelay, int expectedArrivalRate,
                                int expectedThroughput) throws InterruptedException {
+        byte[] payload = new byte[0];
         ScheduledFuture<?> f = requesterPool.scheduleAtFixedRate(() -> {
             for (int i = 0; i < concurrency; i++) {
                 long now = Core.currentTimeMillis();
-                rfc.submit(null, null, false, false, r -> {
+                rfc.submit(null, payload, false, false, r -> {
                     //Nothing to do
                 });
             }


### PR DESCRIPTION
- Add new class LimitedOffHeapQueue which stores its elements off-heap as long as the elements reside within that queue
- Change RemoteFunctionClient to use the LimitedOffHeapQueue
- Enhance RFCMeasurement test

Signed-off-by: Benjamin Rögner <benjamin.roegner@here.com>