### PR TITLE
Handle storage exception for all space based APIs correctly.

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/FeatureApi.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/FeatureApi.java
@@ -54,12 +54,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.Marker;
 
-public class FeatureApi extends Api {
+public class FeatureApi extends SpaceBasedApi {
 
   private static final Logger logger = LogManager.getLogger();
 

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/FeatureQueryApi.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/FeatureQueryApi.java
@@ -59,7 +59,7 @@ import java.io.IOException;
 import java.util.List;
 import org.apache.logging.log4j.Marker;
 
-public class FeatureQueryApi extends Api {
+public class FeatureQueryApi extends SpaceBasedApi {
 
   /**
    * The default limit for the number of features to load from the connector.

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/SpaceApi.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/SpaceApi.java
@@ -28,15 +28,12 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.here.xyz.hub.rest.ApiParam.Path;
 import com.here.xyz.hub.rest.ApiParam.Query;
-import com.here.xyz.hub.task.FeatureTaskHandler.InvalidStorageException;
 import com.here.xyz.hub.task.ModifyOp.IfExists;
 import com.here.xyz.hub.task.ModifyOp.IfNotExists;
 import com.here.xyz.hub.task.ModifySpaceOp;
 import com.here.xyz.hub.task.SpaceTask.ConditionalOperation;
 import com.here.xyz.hub.task.SpaceTask.MatrixReadQuery;
-import com.here.xyz.hub.task.Task;
 import com.here.xyz.models.hub.Space.Copyright;
-import com.here.xyz.responses.ErrorResponse;
 import io.vertx.core.json.DecodeException;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
@@ -45,7 +42,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-public class SpaceApi extends Api {
+public class SpaceApi extends SpaceBasedApi {
 
   public SpaceApi(OpenAPI3RouterFactory routerFactory) {
     routerFactory.addHandlerByOperationId("getSpace", this::getSpace);
@@ -94,7 +91,7 @@ public class SpaceApi extends Api {
     ModifySpaceOp modifyOp = new ModifySpaceOp(Collections.singletonList(input.getMap()), IfNotExists.CREATE, IfExists.ERROR, true);
 
     new ConditionalOperation(context, ApiResponseType.SPACE, modifyOp, false)
-        .execute(this::sendResponse, this::sendErrorResponseOnEdit);
+        .execute(this::sendResponse, this::sendErrorResponse);
   }
 
   /**
@@ -122,7 +119,7 @@ public class SpaceApi extends Api {
     ModifySpaceOp modifyOp = new ModifySpaceOp(Collections.singletonList(input.getMap()), IfNotExists.ERROR, IfExists.PATCH, true);
 
     new ConditionalOperation(context, ApiResponseType.SPACE, modifyOp, true)
-        .execute(this::sendResponse, this::sendErrorResponseOnEdit);
+        .execute(this::sendResponse, this::sendErrorResponse);
 
   }
 
@@ -138,20 +135,6 @@ public class SpaceApi extends Api {
         ? ApiResponseType.SPACE : ApiResponseType.EMPTY;
     new ConditionalOperation(context, responseType, modifyOp, true)
         .execute(this::sendResponse, this::sendErrorResponse);
-  }
-
-  /**
-   * Send an error response to the client when an exception occurred while processing a task.
-   *
-   * @param task the task for which to return an error response.
-   * @param e the exception that should be used to generate an {@link ErrorResponse}, if null an internal server error is returned.
-   */
-  public void sendErrorResponseOnEdit(final Task task, final Exception e) {
-    if (e instanceof InvalidStorageException) {
-      sendErrorResponse(task.context, new HttpException(BAD_REQUEST, "The resource definition contains an invalid storage ID."));
-    } else {
-      sendErrorResponse(task.context, e);
-    }
   }
 
   @JsonIgnoreProperties(ignoreUnknown = true)

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/SpaceBasedApi.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/SpaceBasedApi.java
@@ -1,0 +1,25 @@
+package com.here.xyz.hub.rest;
+
+import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+
+import com.here.xyz.hub.task.FeatureTaskHandler.InvalidStorageException;
+import com.here.xyz.hub.task.Task;
+import com.here.xyz.responses.ErrorResponse;
+
+public abstract class SpaceBasedApi extends Api {
+  /**
+   * Send an error response to the client when an exception occurred while processing a task.
+   *
+   * @param task the task for which to return an error response.
+   * @param e the exception that should be used to generate an {@link ErrorResponse}, if null an internal server error is returned.
+   */
+  @Override
+  public void sendErrorResponse(final Task task, final Exception e) {
+    if (e instanceof InvalidStorageException) {
+      super.sendErrorResponse(task.context, new HttpException(BAD_REQUEST, "The resource definition contains an invalid storage ID."));
+    }
+    else {
+      super.sendErrorResponse(task.context, e);
+    }
+  }
+}


### PR DESCRIPTION
- Pulled up sendErrorResponseOnEdit() method from SpaceApi into more generic SpacedBadedApi class and renamed to #sendErrorResponse() as it's as exceptions are not just edit related.

Signed-off-by: Benjamin Rögner <benjamin.roegner@here.com>