### PR TITLE
Fixed, log level is not configurable in Log4j2, BroadcastLog and inva…

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/Service.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/Service.java
@@ -59,10 +59,12 @@ import java.util.List;
 import java.util.Properties;
 import java.util.UUID;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.LoggerConfig;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.config.Configurator;
 
 public class Service extends Core {
 
@@ -543,7 +545,13 @@ public class Service extends Core {
     @Override
     protected void handleAtDestination() {
       logger.info("LOG LEVEL UPDATE requested. New level will be: " + level);
-      Configurator.setAllLevels(LogManager.getRootLogger().getName(), Level.getLevel(level));
+      LoggerContext context = (LoggerContext) LogManager.getContext(false);
+      Configuration config = context.getConfiguration();
+      LoggerConfig rootConfig = config.getLoggerConfig(LogManager.ROOT_LOGGER_NAME);
+      rootConfig.setLevel(Level.getLevel(level));
+
+      // This causes all Loggers to re-fetch information from their LoggerConfig.
+      context.updateLoggers();
       logger.info("LOG LEVEL UPDATE performed. New level is now: " + level);
     }
   }

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/config/ConnectorConfigClient.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/config/ConnectorConfigClient.java
@@ -23,7 +23,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.here.xyz.hub.Service;
 import com.here.xyz.hub.connectors.models.Connector;
 import com.here.xyz.hub.connectors.models.Connector.RemoteFunctionConfig.Embedded;
-import com.here.xyz.hub.rest.admin.AdminMessage;
+import com.here.xyz.hub.rest.admin.messages.RelayedMessage;
 import com.here.xyz.psql.ECPSTool;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
@@ -264,9 +264,17 @@ public abstract class ConnectorConfigClient implements Initializable {
     new InvalidateConnectorCacheMessage().withId(id).withBroadcastIncludeLocalNode(true).broadcast();
   }
 
-  public static class InvalidateConnectorCacheMessage extends AdminMessage {
+  public static class InvalidateConnectorCacheMessage extends RelayedMessage {
 
     String id;
+
+    public String getId() {
+      return id;
+    }
+
+    public void setId(String id) {
+      this.id = id;
+    }
 
     public InvalidateConnectorCacheMessage withId(String id) {
       this.id = id;
@@ -274,7 +282,7 @@ public abstract class ConnectorConfigClient implements Initializable {
     }
 
     @Override
-    protected void handle() {
+    protected void handleAtDestination() {
       cache.remove(id);
     }
   }

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/admin/messages/BroadcastLog.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/admin/messages/BroadcastLog.java
@@ -18,8 +18,7 @@
  */
 
 package com.here.xyz.hub.rest.admin.messages;
-
-import com.here.xyz.hub.rest.admin.messages.RelayedMessage;
+import com.here.xyz.hub.rest.admin.AdminMessage;
 import com.here.xyz.hub.rest.admin.Node;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -27,7 +26,7 @@ import org.apache.logging.log4j.Logger;
 /**
  * A message which can be used to write a log on all nodes at (nearly) the same time.
  */
-public class BroadcastLog extends RelayedMessage {
+public class BroadcastLog extends AdminMessage {
 
   private static final Logger logger = LogManager.getLogger();
 
@@ -44,7 +43,7 @@ public class BroadcastLog extends RelayedMessage {
   }
 
   @Override
-  protected void handleAtDestination() {
+  protected void handle() {
     logger.info("[BROADCAST from " + source.id + " (" + source.ip + ")] " + logMessage);
   }
 }

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/admin/messages/BroadcastLog.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/admin/messages/BroadcastLog.java
@@ -19,7 +19,7 @@
 
 package com.here.xyz.hub.rest.admin.messages;
 
-import com.here.xyz.hub.rest.admin.AdminMessage;
+import com.here.xyz.hub.rest.admin.messages.RelayedMessage;
 import com.here.xyz.hub.rest.admin.Node;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -27,7 +27,7 @@ import org.apache.logging.log4j.Logger;
 /**
  * A message which can be used to write a log on all nodes at (nearly) the same time.
  */
-public class BroadcastLog extends AdminMessage {
+public class BroadcastLog extends RelayedMessage {
 
   private static final Logger logger = LogManager.getLogger();
 
@@ -44,7 +44,7 @@ public class BroadcastLog extends AdminMessage {
   }
 
   @Override
-  protected void handle() {
+  protected void handleAtDestination() {
     logger.info("[BROADCAST from " + source.id + " (" + source.ip + ")] " + logMessage);
   }
 }


### PR DESCRIPTION
…lidteConnectorCacheMessage can not be relayed.

Signed-off-by: Xue, Haifeng <haifeng.xue@here.com>