### PR TITLE
Mulitple remote functions per connector

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/Service.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/Service.java
@@ -326,6 +326,15 @@ public class Service extends Core {
   }
 
   /**
+   * @return The "environment ID" of this service deployment.
+   */
+  public static String getEnvironmentIdentifier() {
+    if (configuration.ENVIRONMENT_NAME == null) return "default";
+    if (configuration.AWS_REGION != null) return configuration.ENVIRONMENT_NAME + "_" + configuration.AWS_REGION;
+    return configuration.ENVIRONMENT_NAME;
+  }
+
+  /**
    * The service configuration.
    */
   @JsonIgnoreProperties(ignoreUnknown = true)
@@ -473,6 +482,11 @@ public class Service extends Core {
      * @see Config#REMOTE_FUNCTION_MAX_CONNECTIONS
      */
     public float REMOTE_FUNCTION_CONNECTION_HIGH_UTILIZATION_THRESHOLD;
+
+    /**
+     * The remote function pool ID to be used to select the according remote functions for this Service environment.
+     */
+    public String REMOTE_FUNCTION_POOL_ID;
 
     /**
      * The web root for serving static resources from the file system.

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/config/ConnectorConfigClient.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/config/ConnectorConfigClient.java
@@ -201,9 +201,9 @@ public abstract class ConnectorConfigClient implements Initializable {
       }
     }, "$encrypt(", ")");
 
-    if (connector.remoteFunction instanceof Embedded) {
+    if (connector.getRemoteFunction() instanceof Embedded) {
       Map<String, String> varValues = getPsqlVars();
-      replaceVarsInMap(((Embedded) connector.remoteFunction).env, varName -> varValues.get(varName), "${", "}");
+      replaceVarsInMap(((Embedded) connector.getRemoteFunction()).env, varName -> varValues.get(varName), "${", "}");
     }
   }
 

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/BurstAndUpdateThread.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/BurstAndUpdateThread.java
@@ -143,8 +143,8 @@ public class BurstAndUpdateThread extends Thread {
         newConnector = oldConnector;
       }
 
-      if (newConnector.remoteFunction.warmUp > 0) {
-        final int minInstances = newConnector.remoteFunction.warmUp;
+      if (newConnector.getRemoteFunction().warmUp > 0) {
+        final int minInstances = newConnector.getRemoteFunction().warmUp;
         try {
           final AtomicInteger requestCount = new AtomicInteger(minInstances);
           logger.info("Send {} health status requests to connector '{}'", requestCount, newConnector.id);

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/EmbeddedFunctionClient.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/EmbeddedFunctionClient.java
@@ -62,7 +62,7 @@ public class EmbeddedFunctionClient extends RemoteFunctionClient {
   }
 
   private void createExecutorService() {
-    if (!(getConnectorConfig().remoteFunction instanceof RemoteFunctionConfig.Embedded)) {
+    if (!(getConnectorConfig().getRemoteFunction() instanceof RemoteFunctionConfig.Embedded)) {
       throw new IllegalArgumentException("Invalid remoteFunctionConfig argument, must be an instance of Embedded");
     }
     int maxConnections = getMaxConnections();
@@ -91,7 +91,7 @@ public class EmbeddedFunctionClient extends RemoteFunctionClient {
 
   @Override
   protected void invoke(FunctionCall fc, Handler<AsyncResult<byte[]>> callback) {
-    final RemoteFunctionConfig remoteFunction = getConnectorConfig().remoteFunction;
+    final RemoteFunctionConfig remoteFunction = getConnectorConfig().getRemoteFunction();
     Marker marker = fc.marker;
     byte[] payload;
     try {

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/HTTPFunctionClient.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/HTTPFunctionClient.java
@@ -53,10 +53,10 @@ public class HTTPFunctionClient extends RemoteFunctionClient {
   @Override
   synchronized void setConnectorConfig(final Connector newConnectorConfig) throws NullPointerException, IllegalArgumentException {
     super.setConnectorConfig(newConnectorConfig);
-    if (!(getConnectorConfig().remoteFunction instanceof Http)) {
+    if (!(getConnectorConfig().getRemoteFunction() instanceof Http)) {
       throw new IllegalArgumentException("Invalid remoteFunctionConfig argument, must be an instance of HTTP");
     }
-    url = ((Http) getConnectorConfig().remoteFunction).url.toString();
+    url = ((Http) getConnectorConfig().getRemoteFunction()).url.toString();
   }
 
   @Override
@@ -69,7 +69,7 @@ public class HTTPFunctionClient extends RemoteFunctionClient {
   }
 
   private void invokeWithRetry(FunctionCall fc, int tryCount, Handler<AsyncResult<byte[]>> callback) {
-    final RemoteFunctionConfig remoteFunction = getConnectorConfig().remoteFunction;
+    final RemoteFunctionConfig remoteFunction = getConnectorConfig().getRemoteFunction();
     logger.info(fc.marker, "Invoke http remote function '{}' URL is: {} Event size is: {}",
         remoteFunction.id, url, fc.getByteSize());
 

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/LambdaFunctionClient.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/LambdaFunctionClient.java
@@ -118,13 +118,13 @@ public class LambdaFunctionClient extends RemoteFunctionClient {
   }
 
   private void updateClient(Connector oldConnectorConfig) {
-    RemoteFunctionConfig remoteFunction = getConnectorConfig().remoteFunction;
+    RemoteFunctionConfig remoteFunction = getConnectorConfig().getRemoteFunction();
     if (!(remoteFunction instanceof AWSLambda)) {
       throw new IllegalArgumentException("Invalid remoteFunctionConfig argument, must be an instance of AWSLambda");
     }
     asyncClient = getLambdaClient((AWSLambda) remoteFunction, getConnectorConfig().id);
     if (oldConnectorConfig != null)
-      releaseClient(getClientKey((AWSLambda) oldConnectorConfig.remoteFunction));
+      releaseClient(getClientKey((AWSLambda) oldConnectorConfig.getRemoteFunction()));
   }
 
   private static AWSLambdaAsync createClient(AWSLambda remoteFunction) {
@@ -164,7 +164,7 @@ public class LambdaFunctionClient extends RemoteFunctionClient {
   @Override
   synchronized void destroy() {
     super.destroy();
-    releaseClient(getClientKey((AWSLambda) getConnectorConfig().remoteFunction));
+    releaseClient(getClientKey((AWSLambda) getConnectorConfig().getRemoteFunction()));
   }
 
   /**
@@ -172,7 +172,7 @@ public class LambdaFunctionClient extends RemoteFunctionClient {
    */
   @Override
   protected void invoke(final FunctionCall fc, final Handler<AsyncResult<byte[]>> callback) {
-    final RemoteFunctionConfig remoteFunction = getConnectorConfig().remoteFunction;
+    final RemoteFunctionConfig remoteFunction = getConnectorConfig().getRemoteFunction();
     Marker marker = fc.marker;
     Context context = fc.context;
     logger.debug(marker, "Invoking remote lambda function with id '{}' Event size is: {}", remoteFunction.id, fc.getByteSize());

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/RpcClient.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/RpcClient.java
@@ -42,6 +42,7 @@ import com.here.xyz.events.RelocatedEvent;
 import com.here.xyz.hub.Service;
 import com.here.xyz.hub.connectors.RemoteFunctionClient.FunctionCall;
 import com.here.xyz.hub.connectors.models.Connector;
+import com.here.xyz.hub.connectors.models.Connector.RemoteFunctionConfig;
 import com.here.xyz.hub.connectors.models.Connector.RemoteFunctionConfig.Http;
 import com.here.xyz.hub.rest.HttpException;
 import com.here.xyz.hub.rest.Api;
@@ -81,13 +82,14 @@ public class RpcClient {
       throw new NullPointerException("Can not create RpcClient without connector configuration.");
     }
 
-    if (connector.remoteFunction instanceof Connector.RemoteFunctionConfig.AWSLambda) {
+    final RemoteFunctionConfig remoteFunction = connector.getRemoteFunction();
+    if (remoteFunction instanceof Connector.RemoteFunctionConfig.AWSLambda) {
       this.functionClient = new LambdaFunctionClient(connector);
     }
-    else if (connector.remoteFunction instanceof Connector.RemoteFunctionConfig.Embedded) {
+    else if (remoteFunction instanceof Connector.RemoteFunctionConfig.Embedded) {
       this.functionClient = new EmbeddedFunctionClient(connector);
     }
-    else if (connector.remoteFunction instanceof Http) {
+    else if (remoteFunction instanceof Http) {
       this.functionClient = new HTTPFunctionClient(connector);
     }
     else {
@@ -291,10 +293,10 @@ public class RpcClient {
       if (r.failed()) {
         if (r.cause() instanceof HttpException
             && ((HttpException) r.cause()).status.code() >= 400 && ((HttpException) r.cause()).status.code() <= 499) {
-          logger.warn(marker, "Failed to send event to remote function {}.", connector.remoteFunction.id, r.cause());
+          logger.warn(marker, "Failed to send event to remote function {}.", connector.getRemoteFunction().id, r.cause());
         }
         else
-          logger.error(marker, "Failed to send event to remote function {}.", connector.remoteFunction.id, r.cause());
+          logger.error(marker, "Failed to send event to remote function {}.", connector.getRemoteFunction().id, r.cause());
       }
     });
     return context;

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/models/Connector.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/models/Connector.java
@@ -159,6 +159,7 @@ public class Connector {
         && trusted == other.trusted)
         && Objects.equals(params, other.params)
         && Objects.equals(capabilities, other.capabilities)
+        && Objects.equals(getRemoteFunction(), other.getRemoteFunction()) //TODO: Kept for backwards compatibility
         && Objects.equals(remoteFunctions, other.remoteFunctions)
         && Objects.equals(connectionSettings, other.connectionSettings)
         && Objects.equals(defaultEventTypes, other.defaultEventTypes)

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/models/Connector.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/models/Connector.java
@@ -88,8 +88,7 @@ public class Connector {
   /**
    * Arbitrary parameters to be provided to the remote function with the event.
    */
-  @JsonInclude(Include.NON_NULL)
-  private RemoteFunctionConfig remoteFunction;
+  private RemoteFunctionConfig _remoteFunction;
 
   /**
    * Returns the remote function pool ID to be used for this Service environment.
@@ -102,17 +101,21 @@ public class Connector {
     return Service.getEnvironmentIdentifier();
   }
 
+  private void setRemoteFunction(RemoteFunctionConfig remoteFunction) {
+    _remoteFunction = remoteFunction;
+  }
+
   /**
    * @see Service#getEnvironmentIdentifier()
    *
    * @return The according remote function for this environment or - if there is no special function
    * for this environment - any remote function from the {@link #remoteFunctions} map.
    */
-  @JsonIgnore
+  @JsonInclude(Include.NON_NULL)
   public RemoteFunctionConfig getRemoteFunction() {
     if (remoteFunctions == null || remoteFunctions.isEmpty()) {
-      if (remoteFunction == null) throw new RuntimeException("No remote functions are defined for connector with ID " + id);
-      return remoteFunction;
+      if (_remoteFunction == null) throw new RuntimeException("No remote functions are defined for connector with ID " + id);
+      return _remoteFunction;
     }
 
     String rfPoolId = getRemoteFunctionPoolId();

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/models/Connector.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/models/Connector.java
@@ -83,7 +83,7 @@ public class Connector {
    *
    * @see Service#getEnvironmentIdentifier()
    */
-  protected Map<String, RemoteFunctionConfig> remoteFunctions = new HashMap<>();
+  public Map<String, RemoteFunctionConfig> remoteFunctions = new HashMap<>();
 
   /**
    * Arbitrary parameters to be provided to the remote function with the event.

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/models/Connector.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/models/Connector.java
@@ -21,6 +21,8 @@ package com.here.xyz.hub.connectors.models;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
@@ -81,12 +83,13 @@ public class Connector {
    *
    * @see Service#getEnvironmentIdentifier()
    */
-  public Map<String, RemoteFunctionConfig> remoteFunctions = new HashMap<>();
+  protected Map<String, RemoteFunctionConfig> remoteFunctions = new HashMap<>();
 
   /**
    * Arbitrary parameters to be provided to the remote function with the event.
    */
-  public RemoteFunctionConfig remoteFunction;
+  @JsonInclude(Include.NON_NULL)
+  private RemoteFunctionConfig remoteFunction;
 
   /**
    * Returns the remote function pool ID to be used for this Service environment.
@@ -107,7 +110,10 @@ public class Connector {
    */
   @JsonIgnore
   public RemoteFunctionConfig getRemoteFunction() {
-    if (remoteFunctions.isEmpty()) throw new RuntimeException("No remote functions are defined for connector with ID " + id);
+    if (remoteFunctions == null || remoteFunctions.isEmpty()) {
+      if (remoteFunction == null) throw new RuntimeException("No remote functions are defined for connector with ID " + id);
+      return remoteFunction;
+    }
 
     String rfPoolId = getRemoteFunctionPoolId();
     if (!remoteFunctions.containsKey(rfPoolId)) throw new RuntimeException("No matching remote function is defined for connector with ID "

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/util/health/checks/RemoteFunctionHealthCheck.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/util/health/checks/RemoteFunctionHealthCheck.java
@@ -28,12 +28,12 @@ import com.here.xyz.events.HealthCheckEvent;
 import com.here.xyz.hub.connectors.RemoteFunctionClient;
 import com.here.xyz.hub.connectors.RpcClient;
 import com.here.xyz.hub.connectors.models.Connector;
+import com.here.xyz.hub.connectors.models.Connector.RemoteFunctionConfig;
 import com.here.xyz.hub.connectors.models.Connector.RemoteFunctionConfig.AWSLambda;
 import com.here.xyz.hub.connectors.models.Connector.RemoteFunctionConfig.Embedded;
 import com.here.xyz.hub.connectors.models.Connector.RemoteFunctionConfig.Http;
 import com.here.xyz.hub.util.health.schema.Response;
 import com.here.xyz.hub.util.health.schema.Status;
-import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -51,7 +51,7 @@ public class RemoteFunctionHealthCheck extends ExecutableCheck {
     this.connector = connector;
     setName(connector.id);
     setRole(Role.CUSTOM);
-    setTarget(connector.remoteFunction instanceof Embedded ? Target.LOCAL : Target.REMOTE);
+    setTarget(connector.getRemoteFunction() instanceof Embedded ? Target.LOCAL : Target.REMOTE);
   }
 
   @JsonIgnore
@@ -136,14 +136,15 @@ public class RemoteFunctionHealthCheck extends ExecutableCheck {
     Response r = new Response();
     try {
       RemoteFunctionClient rfc = getClient().getFunctionClient();
+      final RemoteFunctionConfig remoteFunction = connector.getRemoteFunction();
 
-      rfcData.put("id", connector.remoteFunction.id);
-      rfcData.put("type", connector.remoteFunction.getClass().getSimpleName());
-      if (connector.remoteFunction instanceof AWSLambda) {
-        rfcData.put("lambdaARN", ((AWSLambda) connector.remoteFunction).lambdaARN);
+      rfcData.put("id", remoteFunction.id);
+      rfcData.put("type", remoteFunction.getClass().getSimpleName());
+      if (remoteFunction instanceof AWSLambda) {
+        rfcData.put("lambdaARN", ((AWSLambda) remoteFunction).lambdaARN);
       }
-      else if (connector.remoteFunction instanceof Http) {
-        rfcData.put("url", ((Http) connector.remoteFunction).url);
+      else if (remoteFunction instanceof Http) {
+        rfcData.put("url", ((Http) remoteFunction).url);
       }
       rfcData.put("maxQueueSize", rfc.getMaxQueueSize());
       rfcData.put("queueSize", rfc.getQueueSize());

--- a/xyz-hub-service/src/main/resources/connectors.json
+++ b/xyz-hub-service/src/main/resources/connectors.json
@@ -17,18 +17,20 @@
     "connectionSettings": {
       "maxConnections": 32
     },
-    "remoteFunction": {
-      "type": "Embedded",
-      "id": "xyz-psql-local",
-      "warmUp": 1,
-      "className": "com.here.xyz.psql.PSQLXyzConnector",
-      "env": {
-        "PSQL_HOST": "${PSQL_HOST}",
-        "PSQL_PORT": "${PSQL_PORT}",
-        "PSQL_DB"  : "${PSQL_DB}",
-        "PSQL_USER": "${PSQL_USER}",
-        "PSQL_PASSWORD": "${PSQL_PASSWORD}",
-        "PSQL_MAX_CONN": 32
+    "remoteFunctions": {
+      "local": {
+        "type": "Embedded",
+        "id": "xyz-psql-local",
+        "warmUp": 1,
+        "className": "com.here.xyz.psql.PSQLXyzConnector",
+        "env": {
+          "PSQL_HOST": "${PSQL_HOST}",
+          "PSQL_PORT": "${PSQL_PORT}",
+          "PSQL_DB"  : "${PSQL_DB}",
+          "PSQL_USER": "${PSQL_USER}",
+          "PSQL_PASSWORD": "${PSQL_PASSWORD}",
+          "PSQL_MAX_CONN": 32
+        }
       }
     }
   },
@@ -44,12 +46,14 @@
     "connectionSettings": {
       "maxConnections": 32
     },
-    "remoteFunction": {
-      "type": "Embedded",
-      "id": "xyz-failing-local1",
-      "warmUp": 1,
-      "className": "com.here.xyz.hub.connectors.test.FailingPreProcessor",
-      "env": {
+    "remoteFunctions": {
+      "local": {
+        "type": "Embedded",
+        "id": "xyz-failing-local1",
+        "warmUp": 1,
+        "className": "com.here.xyz.hub.connectors.test.FailingPreProcessor",
+        "env": {
+        }
       }
     }
   },
@@ -65,12 +69,14 @@
     "connectionSettings": {
       "maxConnections": 32
     },
-    "remoteFunction": {
-      "type": "Embedded",
-      "id": "xyz-failing-local2",
-      "warmUp": 1,
-      "className": "com.here.xyz.hub.connectors.test.FailingPreProcessor",
-      "env": {
+    "remoteFunctions": {
+      "local": {
+        "type": "Embedded",
+        "id": "xyz-failing-local2",
+        "warmUp": 1,
+        "className": "com.here.xyz.hub.connectors.test.FailingPreProcessor",
+        "env": {
+        }
       }
     }
   },
@@ -86,12 +92,14 @@
     "connectionSettings": {
       "maxConnections": 32
     },
-    "remoteFunction": {
-      "type": "Embedded",
-      "id": "xyz-error-local",
-      "warmUp": 1,
-      "className": "com.here.xyz.hub.connectors.test.ErrorPreProcessor",
-      "env": {
+    "remoteFunctions": {
+      "local": {
+        "type": "Embedded",
+        "id": "xyz-error-local",
+        "warmUp": 1,
+        "className": "com.here.xyz.hub.connectors.test.ErrorPreProcessor",
+        "env": {
+        }
       }
     }
   },
@@ -107,12 +115,14 @@
     "connectionSettings": {
       "maxConnections": 32
     },
-    "remoteFunction": {
-      "type": "Embedded",
-      "id": "xyz-exception-local",
-      "warmUp": 1,
-      "className": "com.here.xyz.hub.connectors.test.ExceptionPreProcessor",
-      "env": {
+    "remoteFunctions": {
+      "local": {
+        "type": "Embedded",
+        "id": "xyz-exception-local",
+        "warmUp": 1,
+        "className": "com.here.xyz.hub.connectors.test.ExceptionPreProcessor",
+        "env": {
+        }
       }
     }
   },
@@ -123,13 +133,15 @@
       "maxUncompressedSize": 1,
       "preserializedResponseSupport": true
     },
-    "remoteFunction": {
-      "id": "xyz-rule-tagger",
-      "type": "Embedded",
-      "warmUp": 0,
-      "className": "com.here.xyz.hub.connectors.test.DummyPreProcessor",
-      "env": {
-        "ECPS_PHRASE": "testing"
+    "remoteFunctions": {
+      "local": {
+        "id": "xyz-rule-tagger",
+        "type": "Embedded",
+        "warmUp": 0,
+        "className": "com.here.xyz.hub.connectors.test.DummyPreProcessor",
+        "env": {
+          "ECPS_PHRASE": "testing"
+        }
       }
     },
     "defaultEventTypes": [
@@ -151,17 +163,19 @@
     "connectionSettings": {
       "maxConnections": 32
     },
-    "remoteFunction": {
-      "type": "Embedded",
-      "id": "xyz-psql-local",
-      "warmUp": 0,
-      "className": "com.here.xyz.psql.PSQLXyzConnector",
-      "env": {
-        "PSQL_HOST": "${PSQL_HOST}",
-        "PSQL_PORT": "${PSQL_PORT}",
-        "PSQL_DB"  : "${PSQL_DB}",
-        "PSQL_USER": "${PSQL_USER}",
-        "PSQL_PASSWORD": "${PSQL_PASSWORD}"
+    "remoteFunctions": {
+      "local": {
+        "type": "Embedded",
+        "id": "xyz-psql-local",
+        "warmUp": 0,
+        "className": "com.here.xyz.psql.PSQLXyzConnector",
+        "env": {
+          "PSQL_HOST": "${PSQL_HOST}",
+          "PSQL_PORT": "${PSQL_PORT}",
+          "PSQL_DB": "${PSQL_DB}",
+          "PSQL_USER": "${PSQL_USER}",
+          "PSQL_PASSWORD": "${PSQL_PASSWORD}"
+        }
       }
     }
   },
@@ -172,24 +186,28 @@
     "connectionSettings": {
       "maxConnections": 32
     },
-    "remoteFunction": {
-      "type": "Embedded",
-      "id": "xyz-test-local",
-      "warmUp": 0,
-      "className": "com.here.xyz.hub.connectors.test.TestStorageConnector",
-      "env": {}
+    "remoteFunctions": {
+      "local": {
+        "type": "Embedded",
+        "id": "xyz-test-local",
+        "warmUp": 0,
+        "className": "com.here.xyz.hub.connectors.test.TestStorageConnector",
+        "env": {}
+      }
     }
   },
   {
     "id": "listener-test",
     "params": {},
     "capabilities": {},
-    "remoteFunction": {
-      "type": "Embedded",
-      "id": "xyz-listener-local",
-      "warmUp": 0,
-      "className": "com.here.xyz.hub.connectors.test.DummyListener",
-      "env": {}
+    "remoteFunctions": {
+      "local": {
+        "type": "Embedded",
+        "id": "xyz-listener-local",
+        "warmUp": 0,
+        "className": "com.here.xyz.hub.connectors.test.DummyListener",
+        "env": {}
+      }
     }
   },
   {
@@ -219,10 +237,12 @@
       "autoIndexing": true,
       "propertySearch": true
     },
-    "remoteFunction": {
-      "id": "psql-http",
-      "type": "Http",
-      "url": "http://localhost:9090/psql"
+    "remoteFunctions": {
+      "local": {
+        "id": "psql-http",
+        "type": "Http",
+        "url": "http://localhost:9090/psql"
+      }
     },
     "trusted": true
   }


### PR DESCRIPTION
Change Connector definition to contain a map of target remoteFunctions rather than only having one. Which one to pick depends on the newly introduced "RFC pool ID".