### PR TITLE
Fix bug in discarding of elements from LimitedOffHeapQueue

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/EmbeddedFunctionClient.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/EmbeddedFunctionClient.java
@@ -19,11 +19,15 @@
 
 package com.here.xyz.hub.connectors;
 
+import static io.netty.handler.codec.http.HttpResponseStatus.TOO_MANY_REQUESTS;
+
 import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
 import com.here.xyz.connectors.AbstractConnectorHandler;
 import com.here.xyz.connectors.SimulatedContext;
 import com.here.xyz.hub.connectors.models.Connector;
 import com.here.xyz.hub.connectors.models.Connector.RemoteFunctionConfig;
+import com.here.xyz.hub.rest.HttpException;
+import com.here.xyz.hub.util.LimitedOffHeapQueue.PayloadVanishedException;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -89,7 +93,16 @@ public class EmbeddedFunctionClient extends RemoteFunctionClient {
   protected void invoke(FunctionCall fc, Handler<AsyncResult<byte[]>> callback) {
     final RemoteFunctionConfig remoteFunction = getConnectorConfig().remoteFunction;
     Marker marker = fc.marker;
-    logger.info(marker, "Invoke embedded lambda '{}' for event: {}", remoteFunction.id, new String(fc.getPayload()));
+    byte[] payload;
+    try {
+      payload = fc.getPayload();
+    }
+    catch (PayloadVanishedException e) {
+      callback.handle(Future.failedFuture(new HttpException(TOO_MANY_REQUESTS, "Remote function is busy or cannot be invoked.")));
+      return;
+    }
+    logger.info(marker, "Invoke embedded lambda '{}' for event: {}", remoteFunction.id, new String(payload));
+
     embeddedExecutor.execute(() -> {
       String className = null;
       try {
@@ -100,7 +113,7 @@ public class EmbeddedFunctionClient extends RemoteFunctionClient {
           ((AbstractConnectorHandler) reqHandler).setEmbedded(true);
         }
         final ByteArrayOutputStream output = new ByteArrayOutputStream();
-        reqHandler.handleRequest(new ByteArrayInputStream(fc.getPayload()), output,
+        reqHandler.handleRequest(new ByteArrayInputStream(payload), output,
             new EmbeddedContext(marker, remoteFunction.id,
                 ((Connector.RemoteFunctionConfig.Embedded) remoteFunction).env));
         logger.info(marker, "Handling response of embedded lambda call to '{}'.", remoteFunction.id);
@@ -117,8 +130,7 @@ public class EmbeddedFunctionClient extends RemoteFunctionClient {
         callback.handle(Future.failedFuture(e));
       }
       catch (Throwable e) {
-        logger
-            .error(marker, "Exception occurred, while trying to execute embedded lambda with id '{}' {}", remoteFunction.id, e);
+        logger.error(marker, "Exception occurred, while trying to execute embedded lambda with id '{}' {}", remoteFunction.id, e);
         callback.handle(Future.failedFuture(e));
       }
     });

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/HTTPFunctionClient.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/HTTPFunctionClient.java
@@ -23,12 +23,14 @@ import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
 import static com.here.xyz.hub.rest.Api.HeaderValues.STREAM_ID;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_GATEWAY;
 import static io.netty.handler.codec.http.HttpResponseStatus.GATEWAY_TIMEOUT;
+import static io.netty.handler.codec.http.HttpResponseStatus.TOO_MANY_REQUESTS;
 
 import com.here.xyz.hub.Service;
 import com.here.xyz.hub.connectors.models.Connector;
 import com.here.xyz.hub.connectors.models.Connector.RemoteFunctionConfig;
 import com.here.xyz.hub.connectors.models.Connector.RemoteFunctionConfig.Http;
 import com.here.xyz.hub.rest.HttpException;
+import com.here.xyz.hub.util.LimitedOffHeapQueue.PayloadVanishedException;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -97,6 +99,9 @@ public class HTTPFunctionClient extends RemoteFunctionClient {
               }
             }
           });
+    }
+    catch (PayloadVanishedException e) {
+      callback.handle(Future.failedFuture(new HttpException(TOO_MANY_REQUESTS, "Remote function is busy or cannot be invoked.")));
     }
     catch (Exception e) {
       handleFailure(fc, nextTryCount, callback, e);

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/RemoteFunctionClient.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/RemoteFunctionClient.java
@@ -361,8 +361,6 @@ public abstract class RemoteFunctionClient {
   private void _invoke(final FunctionCall fc) {
     //long start = System.nanoTime();
     invoke(fc, r -> {
-      if (fc.cancelled)
-        return;
       //long end = System.nanoTime();
       //TODO: Activate performance calculation once it's implemented completely
       //recalculatePerformance(end - start, TimeUnit.NANOSECONDS);
@@ -374,7 +372,8 @@ public abstract class RemoteFunctionClient {
         }
       }
       try {
-        fc.callback.handle(r);
+        if (!fc.cancelled)
+          fc.callback.handle(r);
       }
       catch (Exception e) {
         logger.error(fc.marker, "Error while calling response handler", e);


### PR DESCRIPTION
- Also improve error handling for vanished off-heap-items. Now responding with an HTTP 429.
- Also improve RemoteFunctionClient to still continue dispatching enqueued function-calls even if the previous function-call was cancelled.

Signed-off-by: Benjamin Rögner <benjamin.roegner@here.com>