### PR TITLE
Respond with 404 instead of 400 when a connector was not found.

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/config/ConnectorConfigClient.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/config/ConnectorConfigClient.java
@@ -85,7 +85,8 @@ public abstract class ConnectorConfigClient implements Initializable {
         final Connector connector = ar.result();
         cache.put(connectorId, connector);
         handler.handle(Future.succeededFuture(connector));
-      } else {
+      }
+      else {
         logger.warn(marker, "storageId[{}]: Connector not found", connectorId);
         handler.handle(Future.failedFuture(ar.cause()));
       }

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/config/ConnectorConfigClient.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/config/ConnectorConfigClient.java
@@ -86,7 +86,7 @@ public abstract class ConnectorConfigClient implements Initializable {
         cache.put(connectorId, connector);
         handler.handle(Future.succeededFuture(connector));
       } else {
-        logger.error(marker, "storageId[{}]: Connector not found", connectorId);
+        logger.warn(marker, "storageId[{}]: Connector not found", connectorId);
         handler.handle(Future.failedFuture(ar.cause()));
       }
     });

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/models/Space.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/models/Space.java
@@ -80,7 +80,7 @@ public class Space extends com.here.xyz.models.hub.Space implements Cloneable {
   public static void resolveConnector(Marker marker, String connectorId, Handler<AsyncResult<Connector>> handler) {
     Service.connectorConfigClient.get(marker, connectorId, arStorage -> {
       if (arStorage.failed()) {
-        logger.error(marker, "Unable to load the connector definition for storage '{}'",
+        logger.warn(marker, "Unable to load the connector definition for storage '{}'",
             connectorId, arStorage.cause());
       } else {
         final Connector storage = arStorage.result();

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/SpaceBasedApi.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/SpaceBasedApi.java
@@ -1,6 +1,7 @@
 package com.here.xyz.hub.rest;
 
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 
 import com.here.xyz.hub.task.FeatureTaskHandler.InvalidStorageException;
 import com.here.xyz.hub.task.Task;
@@ -16,7 +17,7 @@ public abstract class SpaceBasedApi extends Api {
   @Override
   public void sendErrorResponse(final Task task, final Exception e) {
     if (e instanceof InvalidStorageException) {
-      super.sendErrorResponse(task.context, new HttpException(BAD_REQUEST, "The resource definition contains an invalid storage ID."));
+      super.sendErrorResponse(task.context, new HttpException(NOT_FOUND, "The resource definition contains an invalid storage ID."));
     }
     else {
       super.sendErrorResponse(task.context, e);

--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/ErrorResponseTestIT.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/ErrorResponseTestIT.java
@@ -24,6 +24,7 @@ import static com.here.xyz.hub.rest.Api.HeaderValues.APPLICATION_JSON;
 import static com.jayway.restassured.RestAssured.given;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_GATEWAY;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -64,7 +65,7 @@ public class ErrorResponseTestIT extends TestSpaceWithFeature {
         headers(getAuthHeaders(AuthProfile.ACCESS_ALL)).
         body(Json.encode(space)).
         when().post("/spaces").then().
-        statusCode(BAD_REQUEST.code());
+        statusCode(NOT_FOUND.code());
   }
 
   @Test


### PR DESCRIPTION
Also only write WARN logs instead of ERROR in that case.

Signed-off-by: Benjamin Rögner <benjamin.roegner@here.com>