### PR TITLE
Introduce consumePayload() method in OffHeapBuffer …

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/HTTPFunctionClient.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/HTTPFunctionClient.java
@@ -91,6 +91,10 @@ public class HTTPFunctionClient extends RemoteFunctionClient {
             }
             else {
               try {
+                fc.consumePayload();
+              }
+              catch (PayloadVanishedException ignore) {}
+              try {
                 byte[] responseBytes = ar.result().body().getBytes();
                 callback.handle(Future.succeededFuture(responseBytes));
               }

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/LambdaFunctionClient.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/LambdaFunctionClient.java
@@ -181,7 +181,7 @@ public class LambdaFunctionClient extends RemoteFunctionClient {
     try {
       invokeReq = new InvokeRequest()
           .withFunctionName(((AWSLambda) remoteFunction).lambdaARN)
-          .withPayload(ByteBuffer.wrap(fc.getPayload()))
+          .withPayload(ByteBuffer.wrap(fc.consumePayload()))
           .withInvocationType(fc.fireAndForget ? InvocationType.Event : InvocationType.RequestResponse);
     }
     catch (PayloadVanishedException e) {


### PR DESCRIPTION
…to free memory earlier in LambdaFunctionClient

Signed-off-by: Benjamin Rögner <benjamin.roegner@here.com>