### PR TITLE
Set keepalive-timeouts for all Redis clients …

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/cache/RedisCacheClient.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/cache/RedisCacheClient.java
@@ -25,6 +25,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.redis.RedisClient;
 import io.vertx.redis.RedisOptions;
 import io.vertx.redis.op.SetOptions;
+import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -48,6 +49,8 @@ public class RedisCacheClient implements CacheClient {
       }
 
       config.setTcpKeepAlive(true);
+      config.setIdleTimeout(30);
+      config.setIdleTimeoutUnit(TimeUnit.SECONDS);
       config.setConnectTimeout(2000);
       return RedisClient.create(Service.vertx, config);
     });

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/admin/messages/brokers/RedisMessageBroker.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/admin/messages/brokers/RedisMessageBroker.java
@@ -11,6 +11,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.redis.RedisClient;
 import io.vertx.redis.RedisOptions;
 import java.util.Collections;
+import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -38,6 +39,8 @@ public class RedisMessageBroker implements MessageBroker {
       }
 
       config.setTcpKeepAlive(true);
+      config.setIdleTimeout(30);
+      config.setIdleTimeoutUnit(TimeUnit.SECONDS);
       config.setConnectTimeout(2000);
       redis = RedisClient.create(Service.vertx, config);
 

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/task/FeatureTaskHandler.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/task/FeatureTaskHandler.java
@@ -818,7 +818,7 @@ public class FeatureTaskHandler {
         properties.putIfAbsent(XyzNamespace.XYZ_NAMESPACE, new HashMap<String, Object>());
       }
     } catch (Exception e) {
-      logger.error(task.getMarker(), e.getMessage(), e);
+      logger.warn(task.getMarker(), e.getMessage(), e);
       callback.exception(new HttpException(BAD_REQUEST, "Unable to process the request input."));
       return;
     }


### PR DESCRIPTION
… also change log level to warn for some connector parse-error log

Signed-off-by: Benjamin Rögner <benjamin.roegner@here.com>