### PR TITLE
Fix HTTPFunctionClient to not retry the request on errors in the response handling

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,13 @@
+name: Run XYZ Hub tests
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Start the XYZ Hub stack
+        run: mvn clean install -Pdocker -DskipTests=true -DdockerComposeFile=docker-compose-dynamodb.yml
+      - name: Run tests
+        run: mvn verify -DskipTests=false

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/HTTPFunctionClient.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/HTTPFunctionClient.java
@@ -123,6 +123,8 @@ public class HTTPFunctionClient extends RemoteFunctionClient {
       }
     }
     logger.warn(fc.marker, "Error sending event to remote http service", e);
-    callback.handle(Future.failedFuture(new HttpException(BAD_GATEWAY, "Connector error.", e)));
+    if (!(e instanceof HttpException))
+      e = new HttpException(BAD_GATEWAY, "Connector error.", e);
+    callback.handle(Future.failedFuture(e));
   }
 }

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/HTTPFunctionClient.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/HTTPFunctionClient.java
@@ -99,7 +99,8 @@ public class HTTPFunctionClient extends RemoteFunctionClient {
                 callback.handle(Future.succeededFuture(responseBytes));
               }
               catch (Exception e) {
-                handleFailure(fc, nextTryCount, callback, ConnectionBase.CLOSED_EXCEPTION);
+                handleFailure(fc, nextTryCount, callback,
+                    new HttpException(BAD_GATEWAY, "Error while handling response of HTTP connector.", e));
               }
             }
           });

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/util/LimitedOffHeapQueue.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/util/LimitedOffHeapQueue.java
@@ -106,6 +106,8 @@ public class LimitedOffHeapQueue<E extends OffHeapBuffer> extends LimitedQueue<E
     }
 
     public final byte[] getPayload() throws PayloadVanishedException {
+      if (consumed.get())
+        throw new IllegalStateException("Payload was already consumed.");
       byte[] payload = this.payload.get();
       if (payload == null) {
         //Payload is stashed and can't be accessed right now. Un-stashing it.


### PR DESCRIPTION
Also improve LimitedOffHeapQueue to throw a better error message in case the payload was already consumed when calling getPayload()

Signed-off-by: Benjamin Rögner <benjamin.roegner@here.com>