### PR TITLE
Make RelocationClient region-aware

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/RpcClient.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/RpcClient.java
@@ -419,11 +419,11 @@ public class RpcClient {
     Service.vertx.executeBlocking(
         future -> {
           try {
-            InputStream input = relocationClient.processRelocatedEvent(relocatedEvent);
+            InputStream input = relocationClient.processRelocatedEvent(relocatedEvent, getConnector().getRemoteFunction().getRegion());
             future.complete(ByteStreams.toByteArray(input));
           }
           catch (Exception e) {
-            logger.error("An error when processing a relocated response.", e);
+            logger.error("An error occurred when processing a relocated response.", e);
             future.fail(new HttpException(BAD_GATEWAY, "Unable to load the relocated event.", e));
           }
         },

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/models/Connector.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/models/Connector.java
@@ -32,6 +32,7 @@ import com.here.xyz.hub.connectors.models.Connector.RemoteFunctionConfig.AWSLamb
 import com.here.xyz.hub.connectors.models.Connector.RemoteFunctionConfig.Embedded;
 import com.here.xyz.hub.connectors.models.Connector.RemoteFunctionConfig.Http;
 import com.here.xyz.hub.rest.admin.Node;
+import com.here.xyz.hub.util.ARN;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.List;
@@ -281,10 +282,16 @@ public class Connector {
      * The ID of this remote function.
      */
     public String id;
+
     /**
      * The number of containers to keep warmed up.
      */
     public int warmUp;
+
+    @JsonIgnore
+    public String getRegion() {
+      return null;
+    }
 
     @Override
     public boolean equals(Object o) {
@@ -311,6 +318,12 @@ public class Connector {
        * See: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_terms-and-concepts.html#delegation
        */
       public String roleARN;
+
+      @JsonIgnore
+      @Override
+      public String getRegion() {
+        return new ARN(lambdaARN).getRegion();
+      }
 
       @Override
       public boolean equals(Object o) {


### PR DESCRIPTION
That fixes issues with relocated responses which are coming from connectors from other regions.

Signed-off-by: Benjamin Rögner <benjamin.roegner@here.com>