### PR TITLE
Hotfix for accidentally sending SearchForFeaturesOrderByEvent

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/FeatureQueryApi.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/FeatureQueryApi.java
@@ -125,11 +125,9 @@ public class FeatureQueryApi extends SpaceBasedApi {
       Integer version = Query.getInteger(context, Query.VERSION, null);
 
       List<String> sort = Query.getSort(context);
-      String handle = Query.getString(context, Query.HANDLE, null);
-      PropertiesQuery pquery = Query.getPropertiesQuery(context);
+      PropertiesQuery propertiesQuery = Query.getPropertiesQuery(context);
 
-      if( sort != null || pquery != null || ( handle != null && handle.length() > 20 && handle.matches(".*[A-Za-z]+.*") ))
-      {
+      if (sort != null || propertiesQuery != null) {
         SearchForFeaturesOrderByEvent event = new SearchForFeaturesOrderByEvent();
         event.withLimit(getLimit(context))
             .withForce2D(force2D)


### PR DESCRIPTION
SearchForFeaturesOrderByEvent was sent to connectors in cases where an IterateFeaturesEvent was expected. This change reverts the FeatureQueryApi to its previous behavior.
Now it behaves like follows: if the "sort" query parameter was defined during the first iteration it has to be defined during following iterations as well.

Signed-off-by: Benjamin Rögner <benjamin.roegner@here.com>