### PR TITLE
Use a separate connection to listen for Redis messages

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/cache/RedisCacheClient.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/cache/RedisCacheClient.java
@@ -26,7 +26,6 @@ import io.vertx.redis.client.Command;
 import io.vertx.redis.client.Redis;
 import io.vertx.redis.client.RedisOptions;
 import io.vertx.redis.client.Request;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -47,7 +46,7 @@ public class RedisCacheClient implements CacheClient {
               .setConnectTimeout(2000));
 
       //Use redis auth token when available
-      if (!StringUtils.isEmpty(Service.configuration.XYZ_HUB_REDIS_AUTH_TOKEN))
+      if (Service.configuration.XYZ_HUB_REDIS_AUTH_TOKEN != null)
         config.setPassword(Service.configuration.XYZ_HUB_REDIS_AUTH_TOKEN);
 
       return Redis.createClient(Service.vertx, config);

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/admin/messages/brokers/RedisMessageBroker.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/admin/messages/brokers/RedisMessageBroker.java
@@ -1,6 +1,5 @@
 package com.here.xyz.hub.rest.admin.messages.brokers;
 
-import com.here.xyz.hub.Core;
 import com.here.xyz.hub.Service;
 import com.here.xyz.hub.rest.admin.MessageBroker;
 import com.here.xyz.hub.rest.admin.Node;
@@ -14,7 +13,6 @@ import io.vertx.redis.client.Redis;
 import io.vertx.redis.client.RedisConnection;
 import io.vertx.redis.client.RedisOptions;
 import io.vertx.redis.client.Request;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -22,43 +20,47 @@ public class RedisMessageBroker implements MessageBroker {
 
   private static final Logger logger = LogManager.getLogger();
 
-  private RedisOptions config;
-  private Redis redis;
-  private RedisConnection redisConnection;
+  private Redis client;
+  private Redis messageReceiverClient;
+  private RedisConnection messageReceiverConnection;
   public static final String CHANNEL = "XYZ_HUB_ADMIN_MESSAGES";
   private static int MAX_MESSAGE_SIZE = 1024 * 1024;
   private static volatile RedisMessageBroker instance;
   private static int CONNECTION_KEEP_ALIVE = 30; //s
-  private static int MSG_CONNECTION_PING_PERIOD = (CONNECTION_KEEP_ALIVE - 10) * 1000;
 
   public RedisMessageBroker() {
     try {
-      config = new RedisOptions()
-          .setConnectionString(Service.configuration.getRedisUri())
-          .setNetClientOptions(new NetClientOptions()
-              .setTcpKeepAlive(true)
-              .setIdleTimeout(30)
-              .setConnectTimeout(2000));
-
-      //Use redis auth token when available
-      if (!StringUtils.isEmpty(Service.configuration.XYZ_HUB_REDIS_AUTH_TOKEN))
-        config.setPassword(Service.configuration.XYZ_HUB_REDIS_AUTH_TOKEN);
-
-      redis = Redis.createClient(Service.vertx, config);
+      client = Redis.createClient(Service.vertx, getClientConfig(true));
+      messageReceiverClient = Redis.createClient(Service.vertx, getClientConfig(false));
     }
     catch (Exception e) {
       logger.error("Error while subscribing node in Redis.", e);
     }
   }
 
+  private RedisOptions getClientConfig(boolean withIdleTimeout) {
+    RedisOptions config = new RedisOptions()
+        .setConnectionString(Service.configuration.getRedisUri())
+        .setNetClientOptions(new NetClientOptions()
+            .setTcpKeepAlive(true)
+            .setIdleTimeout(withIdleTimeout ? CONNECTION_KEEP_ALIVE : 0)
+            .setConnectTimeout(2000));
+
+    //Use redis auth token when available
+    if (Service.configuration.XYZ_HUB_REDIS_AUTH_TOKEN != null)
+      config.setPassword(Service.configuration.XYZ_HUB_REDIS_AUTH_TOKEN);
+
+    return config;
+  }
+
   private synchronized Future<Void> connect() {
     Promise p = Promise.promise();
-    if (redisConnection != null) {
+    if (messageReceiverConnection != null) {
       p.complete();
       return p.future();
     }
-    redis.connect().onComplete(ar -> {
-      redisConnection = ar.result();
+    messageReceiverClient.connect().onComplete(ar -> {
+      messageReceiverConnection = ar.result();
       subscribeOwnNode(ar);
       p.complete();
     });
@@ -67,11 +69,11 @@ public class RedisMessageBroker implements MessageBroker {
 
   public void fetchSubscriberCount(Handler<AsyncResult<Integer>> handler) {
     Request req = Request.cmd(Command.PUBSUB).arg("NUMSUB").arg(CHANNEL);
-    if (redis == null) {
+    if (client == null) {
       handler.handle(Future.failedFuture("No redis connection was established."));
       return;
     }
-    redis.send(req).onComplete(ar -> {
+    client.send(req).onComplete(ar -> {
       if (ar.succeeded())
         //The 2nd array element contains the channel-subscriber count
         handler.handle(Future.succeededFuture(ar.result().get(1).toInteger()));
@@ -86,17 +88,16 @@ public class RedisMessageBroker implements MessageBroker {
     String errMsg = "The Node could not be subscribed as AdminMessage listener. No AdminMessages will be received by this node.";
     if (ar.succeeded()) {
       //That defines the handler for incoming messages on the connection
-      redisConnection.handler(message -> {
+      messageReceiverConnection.handler(message -> {
         if (message.size() >= 3 && "message".equals(message.get(0).toString()) && CHANNEL.equals(message.get(1).toString())) {
           String rawMessage = message.get(2).toString();
           receiveRawMessage(rawMessage);
         }
       });
       Request req = Request.cmd(Command.SUBSCRIBE).arg(CHANNEL);
-      redisConnection.send(req).onComplete(arSub -> {
+      messageReceiverConnection.send(req).onComplete(arSub -> {
         if (arSub.succeeded()) {
           logger.info("Subscription succeeded for NODE=" + Node.OWN_INSTANCE.getUrl());
-          startPinging();
         }
         else
           logger.error(errMsg, arSub.cause());
@@ -106,20 +107,9 @@ public class RedisMessageBroker implements MessageBroker {
       logger.error(errMsg, ar.cause());
   }
 
-  private void startPinging() {
-    if (Core.vertx != null) Core.vertx.setPeriodic(MSG_CONNECTION_PING_PERIOD, timerId -> ping());
-  }
-
-  /**
-   * Pings through the redisConnection to keep it alive at both ends.
-   */
-  private void ping() {
-    redisConnection.send(Request.cmd(Command.PING)).onComplete(r -> {});
-  }
-
   @Override
   public void sendRawMessage(String jsonMessage) {
-    if (redis == null) {
+    if (client == null) {
       logger.warn("The AdminMessage can not be sent as the MessageBroker is not ready. Message was: {}", jsonMessage);
       return;
     }
@@ -128,7 +118,7 @@ public class RedisMessageBroker implements MessageBroker {
     }
     //Send using Redis client
     Request req = Request.cmd(Command.PUBLISH).arg(CHANNEL).arg(jsonMessage);
-    redis.send(req).onComplete(ar -> {
+    client.send(req).onComplete(ar -> {
       if (ar.succeeded())
         logger.debug("Message has been sent with following content: {}", jsonMessage);
       else


### PR DESCRIPTION
That fixes concurrency issues with interfering outgoing messages or commands.

Signed-off-by: Benjamin Rögner <benjamin.roegner@here.com>