### PR TITLE
Introduce new connector param "ignoreCreateMse" and space property …

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/models/Space.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/models/Space.java
@@ -69,6 +69,10 @@ public class Space extends com.here.xyz.models.hub.Space implements Cloneable {
   @JsonView({Public.class, Static.class})
   public long contentUpdatedAt = 0;
 
+  @JsonInclude(Include.NON_DEFAULT)
+  @JsonView({Internal.class, Static.class})
+  public boolean notSendDeleteMse = false;
+
   /**
    * An indicator, if the data in the space is edited often (value tends to 1) or static (value tends to 0).
    */

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/task/SpaceTaskHandler.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/task/SpaceTaskHandler.java
@@ -383,6 +383,12 @@ public class SpaceTaskHandler {
     Entry<Space> entry = task.modifyOp.entries.get(0);
 
     Space space = task.isDelete() ? entry.head : entry.result;
+
+    if (task.isDelete() && space.notSendDeleteMse) {
+      callback.call(task);
+      return;
+    }
+
     final ModifySpaceEvent event = new ModifySpaceEvent()
         .withOperation(op)
         .withSpaceDefinition(space)

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/PSQLXyzConnector.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/PSQLXyzConnector.java
@@ -424,6 +424,10 @@ public class PSQLXyzConnector extends DatabaseHandler {
     try{
       logger.info("{} Received ModifySpaceEvent", traceItem);
 
+
+      if (config.getConnectorParams().isIgnoreCreateMse())
+        return new SuccessResponse().withStatus("OK");
+
       validateModifySpaceEvent(event);
 
       if(event.getSpaceDefinition() != null && event.getSpaceDefinition().isEnableHistory()){

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/config/ConnectorParameters.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/config/ConnectorParameters.java
@@ -36,6 +36,8 @@ public class ConnectorParameters {
     public final static String ENABLE_HASHED_SPACEID = "enableHashedSpaceId";
     public final static String COMPACT_HISTORY = "compactHistory";
     public final static String ON_DEMAND_IDX_LIMIT = "onDemandIdxLimit";
+    public final static String HRN_SHORTENING = "hrnShortening";
+    public final static String IGNORE_CREATE_MSE = "ignoreCreateMse";
 
     public final static String DB_INITIAL_POOL_SIZE = "dbInitialPoolSize";
     public final static String DB_MIN_POOL_SIZE = "dbMinPoolSize";
@@ -55,6 +57,8 @@ public class ConnectorParameters {
     private boolean enableHashedSpaceId = false;
     private boolean compactHistory = true;
     private int onDemandIdxLimit = 4;
+    private boolean hrnShortening = false;
+    private boolean ignoreCreateMse = false;
     private String ecps;
 
     /**
@@ -81,6 +85,8 @@ public class ConnectorParameters {
             this.enableHashedSpaceId = parseValue(connectorParams, Boolean.class, enableHashedSpaceId, ENABLE_HASHED_SPACEID);
             this.compactHistory = parseValue(connectorParams, Boolean.class, compactHistory, COMPACT_HISTORY);
             this.onDemandIdxLimit = parseValue(connectorParams, Integer.class, onDemandIdxLimit, ON_DEMAND_IDX_LIMIT);
+            hrnShortening = parseValue(connectorParams, Boolean.class, hrnShortening, HRN_SHORTENING);
+            ignoreCreateMse = parseValue(connectorParams, Boolean.class, ignoreCreateMse, IGNORE_CREATE_MSE);
 
             this.dbInitialPoolSize = parseValue(connectorParams, Integer.class, dbInitialPoolSize, DB_INITIAL_POOL_SIZE);
             this.dbMinPoolSize = parseValue(connectorParams, Integer.class, dbMinPoolSize, DB_MIN_POOL_SIZE);
@@ -143,6 +149,14 @@ public class ConnectorParameters {
 
     public int getOnDemandIdxLimit() {
         return onDemandIdxLimit;
+    }
+
+    public boolean isHrnShortening() {
+        return hrnShortening;
+    }
+
+    public boolean isIgnoreCreateMse() {
+        return ignoreCreateMse;
     }
 
     public int getDbInitialPoolSize() {

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/config/PSQLConfig.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/config/PSQLConfig.java
@@ -168,18 +168,21 @@ public class PSQLConfig {
 
   public String readTableFromEvent(Event event) {
     if (event != null && event.getSpace() != null && event.getSpace().length() > 0) {
-      return compareAndConvertTableName(event.getSpace());
+      if (connectorParams.isEnableHashedSpaceId()) {
+        return Hasher.getHash(event.getSpace());
+      }
+      else if (connectorParams.isHrnShortening()) {
+        String[] splitHrn = event.getSpace().split(":");
+        if (splitHrn.length > 0)
+          return splitHrn[splitHrn.length - 1];
+      }
+      else {
+        return event.getSpace();
+      }
     }
 
     return null;
   }
-
-  private String compareAndConvertTableName(String spaceId) {
-    if (connectorParams.isEnableHashedSpaceId())
-      spaceId = Hasher.getHash(spaceId);
-    return spaceId;
-  }
-
 
   /**
    * Encodes the connector ecps.


### PR DESCRIPTION
…notSendDeleteMse

Necessary to prevent sending / interpreting these ModifySpaceEvents under special circumstances.

Also introduce table name shortening of long space IDs.

Signed-off-by: Benjamin Rögner <benjamin.roegner@here.com>