### PR TITLE
logging: fix error 'Marker name cannot be null'

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/Api.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/Api.java
@@ -539,7 +539,8 @@ public abstract class Api {
       }
       Marker marker = context.get(MARKER);
       if (marker == null) {
-        marker = new Log4jMarker(context.request().getHeader(STREAM_ID));
+        String sid = context.request().getHeader(STREAM_ID);
+        marker = new Log4jMarker( sid != null ? sid : STREAM_ID + "-null" );
         context.put(MARKER, marker);
       }
       return marker;


### PR DESCRIPTION
Signed-off-by: qGYdXbY2 <47661341+qGYdXbY2@users.noreply.github.com>