### PR TITLE
Forward 504 status code for upstream timeouts of HTTP connectors

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/HTTPFunctionClient.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/HTTPFunctionClient.java
@@ -123,6 +123,8 @@ public class HTTPFunctionClient extends RemoteFunctionClient {
       HttpResponseStatus upstreamStatus = Strings.isNullOrEmpty(response.statusMessage()) ?
           HttpResponseStatus.valueOf(response.statusCode()) : new HttpResponseStatus(response.statusCode(), response.statusMessage());
       HttpException upstreamHttpEx = new HttpException(upstreamStatus, "Remote HTTP connector service responded with: " + upstreamStatus);
+      if (upstreamStatus == GATEWAY_TIMEOUT)
+        throw upstreamHttpEx;
       throw new HttpException(BAD_GATEWAY, "Remote HTTP connector service did not respond with 200(OK)", upstreamHttpEx);
     }
     else if (response.body() == null)


### PR DESCRIPTION
Signed-off-by: Benjamin Rögner <benjamin.roegner@here.com>