### PR TITLE
Handle InterruptedException in health-checks accordingly

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/util/health/checks/ExecutableCheck.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/util/health/checks/ExecutableCheck.java
@@ -131,6 +131,9 @@ public abstract class ExecutableCheck extends Check implements Runnable {
 				setResponse(null);
 			}
 		}
+		catch (InterruptedException ignored) {
+			//Nothing to do here.
+		}
 		catch (Exception e) {
 			logger.error("{}: Error when executing check", this.getClass().getSimpleName(), e);
 		}

--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/connectors/RFCMeasurement.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/connectors/RFCMeasurement.java
@@ -95,12 +95,11 @@ public class RFCMeasurement {
         assertEquals("throughput should match", expectedThroughput, Math.round(tp));
     }
 
-    @Test
+    //@Test
     public void checkMeasuringBelowLimits() throws InterruptedException {
         checkMeasuring(4, 200, 1000, 1300, 4, 4);
     }
 
-    //TODO: Write more tests
     //@Test
     public void checkMeasuringExceedConcurrencyLimit() throws InterruptedException {
         checkMeasuring(10,200, 1000, 1300, 10, RFC_MAX_CONNECTIONS);


### PR DESCRIPTION
Also deactivate obsolete checkMeasuringBelowLimits test

Signed-off-by: Benjamin Rögner <benjamin.roegner@here.com>