### PR TITLE
Throw error if jsonObject of connector can not be converted. 

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/task/ConnectorHandler.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/task/ConnectorHandler.java
@@ -144,7 +144,15 @@ public class ConnectorHandler {
 
   protected static void storeConnector(RoutingContext context, JsonObject connector, Handler<AsyncResult<Connector>> handler, Marker marker,
       AsyncResult<Connector> ar) {
-    Connector c = DatabindCodec.mapper().convertValue(connector, Connector.class);
+    Connector c;
+    try {
+      c = DatabindCodec.mapper().convertValue(connector, Connector.class);
+    }
+    catch (Exception e) {
+      logger.error(marker, "Could not convert resource.", e.getCause());
+      handler.handle(Future.failedFuture(new HttpException(BAD_REQUEST, "Could not convert resource.")));
+      return;
+    }
     DiffMap diffMap = (DiffMap) Patcher.getDifference(new HashMap<>(), asMap(connector));
 
     try {

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/task/ConnectorHandler.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/task/ConnectorHandler.java
@@ -149,8 +149,8 @@ public class ConnectorHandler {
       c = DatabindCodec.mapper().convertValue(connector, Connector.class);
     }
     catch (Exception e) {
-      logger.error(marker, "Could not convert resource.", e.getCause());
-      handler.handle(Future.failedFuture(new HttpException(BAD_REQUEST, "Could not convert resource.")));
+      logger.error(marker, "Invalid connector definition..", e.getCause());
+      handler.handle(Future.failedFuture(new HttpException(BAD_REQUEST, "Invalid connector definition..")));
       return;
     }
     DiffMap diffMap = (DiffMap) Patcher.getDifference(new HashMap<>(), asMap(connector));


### PR DESCRIPTION
e.g. wrong representation of a URL. (no protocol at beginning)

Signed-off-by: Marvin Gilbert <Marvin.Gilbert@here.com>