### PR TITLE
Improve HTTP webclient client settings and remove retries from HTTP RFC

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/Service.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/Service.java
@@ -164,9 +164,11 @@ public class Service extends Core {
     connectorConfigClient = ConnectorConfigClient.getInstance();
 
     webClient = WebClient.create(vertx, new WebClientOptions()
-//        .setMaxPoolSize(Service.configuration.MAX_GLOBAL_HTTP_CLIENT_CONNECTIONS)
+        .setMaxPoolSize(Service.configuration.MAX_GLOBAL_HTTP_CLIENT_CONNECTIONS)
+        .setHttp2MaxPoolSize(Service.configuration.MAX_GLOBAL_HTTP_CLIENT_CONNECTIONS)
         .setUserAgent(XYZ_HUB_USER_AGENT)
-//        .setTcpKeepAlive(true)
+        .setTcpKeepAlive(configuration.HTTP_CLIENT_TCP_KEEPALIVE)
+        .setIdleTimeout(configuration.HTTP_CLIENT_IDLE_TIMEOUT)
         .setTcpQuickAck(true)
         .setTcpFastOpen(true)
         .setTryUseCompression(true)
@@ -619,6 +621,17 @@ public class Service extends Core {
      * Whether to activate pipelining for the HTTP client of the service.
      */
     public boolean HTTP_CLIENT_PIPELINING;
+
+    /**
+     * Whether to activate TCP keepalive for the HTTP client of the service.
+     */
+    public boolean HTTP_CLIENT_TCP_KEEPALIVE = true;
+
+    /**
+     * The idle connection timeout in seconds for the HTTP client of the service.
+     * Setting it to 0 will make the connections not timing out at all.
+     */
+    public int HTTP_CLIENT_IDLE_TIMEOUT = 120;
 
     /**
      * List of fields, separated by comma, which are optional on feature's namespace property.

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/HTTPFunctionClient.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/HTTPFunctionClient.java
@@ -44,6 +44,7 @@ import java.nio.charset.Charset;
 import java.util.concurrent.TimeoutException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.Marker;
 
 public class HTTPFunctionClient extends RemoteFunctionClient {
 
@@ -69,43 +70,31 @@ public class HTTPFunctionClient extends RemoteFunctionClient {
   }
 
   protected void invoke(FunctionCall fc, Handler<AsyncResult<byte[]>> callback) {
-    invokeWithRetry(fc, 0, callback);
-  }
-
-  private void invokeWithRetry(FunctionCall fc, int tryCount, Handler<AsyncResult<byte[]>> callback) {
     final RemoteFunctionConfig remoteFunction = getConnectorConfig().getRemoteFunction();
     logger.info(fc.marker, "Invoke http remote function '{}' URL is: {} Event size is: {}",
         remoteFunction.id, url, fc.getByteSize());
 
-    final int nextTryCount = tryCount + 1;
     try {
       Service.webClient.postAbs(url)
           .timeout(REQUEST_TIMEOUT)
           .putHeader(CONTENT_TYPE, "application/json; charset=" + Charset.defaultCharset().name())
           .putHeader(STREAM_ID, fc.marker.getName())
-          .sendBuffer(Buffer.buffer(fc.getPayload()), ar -> {
+          .sendBuffer(Buffer.buffer(fc.consumePayload()), ar -> {
             if (fc.fireAndForget) return;
             if (ar.failed()) {
-              if (ar.cause() instanceof TimeoutException) {
+              if (ar.cause() instanceof TimeoutException)
                 callback.handle(Future.failedFuture(new HttpException(GATEWAY_TIMEOUT, "Connector timeout error.")));
-              }
-              else {
-                handleFailure(fc, nextTryCount, callback, new RuntimeException(ar.cause()));
-              }
+              else
+                handleFailure(fc.marker, callback, new RuntimeException(ar.cause()));
             }
             else {
-              try {
-                fc.consumePayload();
-              }
-              catch (PayloadVanishedException ignore) {}
               try {
                 validateHttpStatus(ar.result());
                 byte[] responseBytes = ar.result().body().getBytes();
                 callback.handle(Future.succeededFuture(responseBytes));
               }
               catch (Exception e) {
-                handleFailure(fc, nextTryCount, callback,
-                    new HttpException(BAD_GATEWAY, "Error while handling response of HTTP connector.", e));
+                handleFailure(fc.marker, callback, new HttpException(BAD_GATEWAY, "Error while handling response of HTTP connector.", e));
               }
             }
           });
@@ -114,7 +103,7 @@ public class HTTPFunctionClient extends RemoteFunctionClient {
       callback.handle(Future.failedFuture(new HttpException(TOO_MANY_REQUESTS, "Remote function is busy or cannot be invoked.")));
     }
     catch (Exception e) {
-      handleFailure(fc, nextTryCount, callback, e);
+      handleFailure(fc.marker, callback, e);
     }
   }
 
@@ -131,16 +120,10 @@ public class HTTPFunctionClient extends RemoteFunctionClient {
       throw new HttpException(BAD_GATEWAY, "Response body from remote HTTP connector service was empty.");
   }
 
-  private void handleFailure(FunctionCall fc, int tryCount, Handler<AsyncResult<byte[]>> callback, Exception e) {
-    if (e == ConnectionBase.CLOSED_EXCEPTION) {
+  private void handleFailure(Marker marker, Handler<AsyncResult<byte[]>> callback, Exception e) {
+    if (e == ConnectionBase.CLOSED_EXCEPTION)
       e = new RuntimeException("Connection was already closed.", e);
-      if (tryCount <= 1) {
-        logger.warn(fc.marker, e.getMessage() + " Retrying ...", e);
-        invokeWithRetry(fc, tryCount, callback);
-        return;
-      }
-    }
-    logger.warn(fc.marker, "Error while calling remote HTTP service", e);
+    logger.warn(marker, "Error while calling remote HTTP service", e);
     if (e instanceof TimeoutException)
       e = new HttpException(GATEWAY_TIMEOUT, "Timeout while calling HTTP connector.", e);
     if (!(e instanceof HttpException))


### PR DESCRIPTION
Set correct connection pool size & re-activate keep alive for vertx webclient and remove retry mechanism from HTTPFunctionClient.