### PR TITLE
Make sure exception handler is called when the pipeline is cancelled

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/task/TaskPipeline.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/task/TaskPipeline.java
@@ -182,6 +182,17 @@ public class TaskPipeline<V> {
 
   void cancel() {
     state.isCancelled = true;
+    PipelineCancelledException e = new PipelineCancelledException();
+    try {
+      finishException.call(state.value, e);
+    }
+    catch (Throwable throwable) {
+      state.exception = e;
+    }
+  }
+
+  public static class PipelineCancelledException extends RuntimeException {
+
   }
 
   /**


### PR DESCRIPTION
Signed-off-by: Benjamin Rögner <benjamin.roegner@here.com>