### PR TITLE
Use vertx' HttpClient rather than Webclient for HTTPFunctionClient

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/Service.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/Service.java
@@ -165,8 +165,6 @@ public class Service extends Core {
     connectorConfigClient = ConnectorConfigClient.getInstance();
 
     webClient = WebClient.create(vertx, new WebClientOptions()
-        .setMaxPoolSize(Service.configuration.MAX_GLOBAL_HTTP_CLIENT_CONNECTIONS)
-        .setHttp2MaxPoolSize(Service.configuration.MAX_GLOBAL_HTTP_CLIENT_CONNECTIONS)
         .setUserAgent(XYZ_HUB_USER_AGENT)
         .setTcpKeepAlive(configuration.HTTP_CLIENT_TCP_KEEPALIVE)
         .setIdleTimeout(configuration.HTTP_CLIENT_IDLE_TIMEOUT)


### PR DESCRIPTION
- This provides better control over actual HTTP client being in use
- The HttpClient does not hold a reference to the request body for inflight requests (memory optimization)

Signed-off-by: Benjamin Rögner <benjamin.roegner@here.com>