### PR TITLE
Do not handle PipelineCancelledExceptions

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/AbstractHttpServerVerticle.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/AbstractHttpServerVerticle.java
@@ -45,6 +45,7 @@ import static io.vertx.core.http.HttpMethod.PUT;
 
 import com.here.xyz.hub.rest.Api;
 import com.here.xyz.hub.rest.HttpException;
+import com.here.xyz.hub.task.TaskPipeline;
 import com.here.xyz.hub.util.logging.LogUtil;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.vertx.core.AbstractVerticle;
@@ -244,6 +245,10 @@ public abstract class AbstractHttpServerVerticle extends AbstractVerticle {
    * Creates and sends an error response to the client.
    */
   public static void sendErrorResponse(final RoutingContext context, final Throwable exception) {
+    //If the request was cancelled, neither a response has to be sent nor the error should be logged.
+    if (exception instanceof TaskPipeline.PipelineCancelledException)
+      return;
+
     ErrorMessage error;
 
     try {

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/Api.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/Api.java
@@ -45,6 +45,7 @@ import com.here.xyz.hub.rest.ApiParam.Query;
 import com.here.xyz.hub.task.FeatureTask;
 import com.here.xyz.hub.task.SpaceTask;
 import com.here.xyz.hub.task.Task;
+import com.here.xyz.hub.task.TaskPipeline;
 import com.here.xyz.hub.util.logging.AccessLog;
 import com.here.xyz.models.geojson.implementation.FeatureCollection;
 import com.here.xyz.models.hub.Space.Internal;
@@ -359,6 +360,8 @@ public abstract class Api {
    * @param e the exception that should be used to generate an {@link ErrorResponse}, if null an internal server error is returned.
    */
   protected void sendErrorResponse(final RoutingContext context, final Throwable e) {
+    if (e instanceof TaskPipeline.PipelineCancelledException)
+      return;
     if (e instanceof HttpException) {
       final HttpException httpException = (HttpException) e;
 
@@ -381,7 +384,7 @@ public abstract class Api {
       }
     }
 
-    // This is an exception that is not done by intention.
+    //This is an exception that is not done by intention.
     logger.error("Unintentional Error:", e);
     XYZHubRESTVerticle.sendErrorResponse(context, e);
   }


### PR DESCRIPTION
PipelineCancelledExceptions occur when the pipeline was cancelled by intention. This happens when a request was aborted and no response is expected anymore. The PipelineCancelledException is thrown to make sure the pipeline and all it steps will actually get a call-back and get into a "final" state to prevent resource leaks etc.

Signed-off-by: Benjamin Rögner <benjamin.roegner@here.com>