### PR TITLE
Exclude log4j2 from aws-lambda-java-log4j2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -379,6 +379,16 @@
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-lambda-java-log4j2</artifactId>
         <version>1.3.0</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <!-- Util -->


### PR DESCRIPTION
Exclude log4j2 from aws-lambda-java-log4j2 until Amazon releases a new version with log4j2 2.16.0.