### PR TITLE
Always set streamId for new requests. Otherwise, it is only set on in…

### DIFF
--- a/xyz-connectors/src/main/java/com/here/xyz/connectors/AbstractConnectorHandler.java
+++ b/xyz-connectors/src/main/java/com/here/xyz/connectors/AbstractConnectorHandler.java
@@ -207,8 +207,7 @@ public abstract class AbstractConnectorHandler implements RequestStreamHandler {
         Event event = readEvent(input);
 
         String connectorId = null;
-        if(this.streamId == null)
-          this.streamId = streamId != null ? streamId : event.getStreamId();
+        this.streamId = streamId != null ? streamId : event.getStreamId();
 
         if (event.getConnectorParams() != null  && event.getConnectorParams().get("connectorId") != null)
           connectorId = (String) event.getConnectorParams().get("connectorId");


### PR DESCRIPTION
…itial request and reused on every lambda instance.

Signed-off-by: Marvin Gilbert <Marvin.Gilbert@here.com>