### PR TITLE
Fix JDK9+ compilation, operation without Redis and more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@
 .idea/
 target/
 file-uploads/
+static/
 release.properties

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,3 +26,41 @@ An example signed commit message:
 Git has the `-s` flag that can sign a commit for you, see example below:
 
 `$ git commit -s -m 'README.md: Fix minor spelling mistake'`
+
+# Before making a pull-request
+
+Eventually, before making a pull request, start the XYZ-Hub and the HTTP-connector and then execute 
+the tests:
+
+```bash
+mvn clean install
+java -jar xyz-hub-service/target/xyz-hub-service.jar >xyz-hub.txt 2>&1 &
+java -cp xyz-hub-service/target/xyz-hub-service.jar com.here.xyz.hub.HttpConnector >xyz-http-connector.txt 2>&1 &
+mvn verify -DskipTests=false
+kill $(ps a | grep xyz-hub-service.jar | grep -E "[/]xyz-hub-service.jar" | grep -Eo "[0-9]+ pts" | grep -Eo "[0-9]+" | xargs) 2>/dev/null
+```
+
+**Note**: You need to have Redis installed locally.
+
+# Run and test in IntelliJ IDEA
+
+Open as project from existing code (`File->New->Project from Existing Sources...`) using `Maven`. Make copies of the configuration files:
+
+```bash
+mkdir .vertx
+cp xyz-hub-service/src/main/resources/config.json .vertx/
+cp xyz-hub-service/src/main/resources/connector-config.json .vertx/ 
+```
+
+Adjust the settings to your needs.
+
+Create run profiles for the [XYZ-Hub Service](xyz-hub-service/src/main/java/com/here/xyz/hub/Core.java) and the [HTTP PSQL-Connector](xyz-hub-service/src/main/java/com/here/xyz/hub/HttpConnector.java), setting the environment variable `XYZ_CONFIG_PATH=$PROJECT_DIR$/.vertx/`. When running the tests in the IDE, ensure that the service and connector are running and that you provide the same environment variable to the tests.
+
+If you do not run Redis, change the settings in the `config.json`:
+
+```json
+{
+  "XYZ_HUB_REDIS_URI": "null",
+  "DEFAULT_MESSAGE_BROKER": "Noop"
+}
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ mvn verify -DskipTests=false
 kill -9 $(ps a | grep xyz-hub-service.jar | grep -E "[/]xyz-hub-service.jar" | grep -Eo "[0-9]+ pts" | grep -Eo "[0-9]+" | xargs) 2>/dev/null
 ```
 
-**Note**: You need to have [Redis installed locally](https://redis.io/docs/getting-started/).
+**Note**: You need to have [Redis installed](https://redis.io/docs/getting-started/).
 
 # Run and test in IntelliJ IDEA
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,18 +29,20 @@ Git has the `-s` flag that can sign a commit for you, see example below:
 
 # Before making a pull-request
 
-Eventually, before making a pull request, start the XYZ-Hub and the HTTP-connector and then execute 
-the tests:
+Eventually, before making a pull request, start the XYZ-Hub, the HTTP-connector and then execute the 
+integration tests. Within Linux, you can open a shell in the project root and do:
 
 ```bash
 mvn clean install
-java -jar xyz-hub-service/target/xyz-hub-service.jar >xyz-hub.txt 2>&1 &
-java -cp xyz-hub-service/target/xyz-hub-service.jar com.here.xyz.hub.HttpConnector >xyz-http-connector.txt 2>&1 &
+export FS_WEB_ROOT=$(pwd)/static
+mkdir $FS_WEB_ROOT 2>/dev/null
+java -jar xyz-hub-service/target/xyz-hub-service.jar >static/xyz-hub.out.txt 2>&1 &
+java -cp xyz-hub-service/target/xyz-hub-service.jar com.here.xyz.hub.HttpConnector >static/xyz-http-connector.out.txt 2>&1 &
 mvn verify -DskipTests=false
-kill $(ps a | grep xyz-hub-service.jar | grep -E "[/]xyz-hub-service.jar" | grep -Eo "[0-9]+ pts" | grep -Eo "[0-9]+" | xargs) 2>/dev/null
+kill -9 $(ps a | grep xyz-hub-service.jar | grep -E "[/]xyz-hub-service.jar" | grep -Eo "[0-9]+ pts" | grep -Eo "[0-9]+" | xargs) 2>/dev/null
 ```
 
-**Note**: You need to have Redis installed locally.
+**Note**: You need to have [Redis installed locally](https://redis.io/docs/getting-started/).
 
 # Run and test in IntelliJ IDEA
 
@@ -54,7 +56,7 @@ cp xyz-hub-service/src/main/resources/connector-config.json .vertx/
 
 Adjust the settings to your needs.
 
-Create run profiles for the [XYZ-Hub Service](xyz-hub-service/src/main/java/com/here/xyz/hub/Core.java) and the [HTTP PSQL-Connector](xyz-hub-service/src/main/java/com/here/xyz/hub/HttpConnector.java), setting the environment variable `XYZ_CONFIG_PATH=$PROJECT_DIR$/.vertx/`. When running the tests in the IDE, ensure that the service and connector are running and that you provide the same environment variable to the tests.
+Create run profiles for the [XYZ-Hub Service](xyz-hub-service/src/main/java/com/here/xyz/hub/Core.java) and the [HTTP PSQL-Connector](xyz-hub-service/src/main/java/com/here/xyz/hub/HttpConnector.java), setting the environment variables `XYZ_CONFIG_PATH=$PROJECT_DIR$/.vertx/;FS_WEB_ROOT=$PROJECT_DIR$/static/`. When running the tests in the IDE, ensure that the service and connector are running and that you provide the same environment variable to the tests.
 
 If you do not run Redis, change the settings in the `config.json`:
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,28 @@ java -DHTTP_PORT=8080 -jar xyz-hub-service/target/xyz-hub-service.jar
 ### Configuration options
 The service start parameters could be specified by editing the [default config file](./xyz-hub-service/src/main/resources/config.json), using environment variables or system properties. See the default list of  [configuration parameters](https://github.com/heremaps/xyz-hub/wiki/Configuration-parameters) and their default values.
 
+### Run and test in IntelliJ IDE
+Open as project from existing code (`File->New->Project from Existing Sources...`) using `Maven`. Make copies of the configuration files:
+
+```bash
+mkdir .vertx
+cp xyz-hub-service/src/main/resources/config.json .vertx/
+cp xyz-hub-service/src/main/resources/connector-config.json .vertx/ 
+```
+
+Adjust the settings to your needs.
+
+Create run profiles for the [XYZ-Hub Service](xyz-hub-service/src/main/java/com/here/xyz/hub/Core.java) and the [HTTP PSQL-Connector](xyz-hub-service/src/main/java/com/here/xyz/hub/HttpConnector.java), setting the environment variable `XYZ_CONFIG_PATH=$PROJECT_DIR$/.vertx/`. When running the tests in the IDE, ensure that the service and connector are running and that you provide the same environment variable to the tests.
+
+If you do not run Redis, change the settings in the `config.json`:
+
+```json
+{
+  "XYZ_HUB_REDIS_URI": "null",
+  "DEFAULT_MESSAGE_BROKER": "Noop"
+}
+```
+
 # Usage
 
 Start using the service by creating a _space_:

--- a/README.md
+++ b/README.md
@@ -72,28 +72,6 @@ java -DHTTP_PORT=8080 -jar xyz-hub-service/target/xyz-hub-service.jar
 ### Configuration options
 The service start parameters could be specified by editing the [default config file](./xyz-hub-service/src/main/resources/config.json), using environment variables or system properties. See the default list of  [configuration parameters](https://github.com/heremaps/xyz-hub/wiki/Configuration-parameters) and their default values.
 
-### Run and test in IntelliJ IDE
-Open as project from existing code (`File->New->Project from Existing Sources...`) using `Maven`. Make copies of the configuration files:
-
-```bash
-mkdir .vertx
-cp xyz-hub-service/src/main/resources/config.json .vertx/
-cp xyz-hub-service/src/main/resources/connector-config.json .vertx/ 
-```
-
-Adjust the settings to your needs.
-
-Create run profiles for the [XYZ-Hub Service](xyz-hub-service/src/main/java/com/here/xyz/hub/Core.java) and the [HTTP PSQL-Connector](xyz-hub-service/src/main/java/com/here/xyz/hub/HttpConnector.java), setting the environment variable `XYZ_CONFIG_PATH=$PROJECT_DIR$/.vertx/`. When running the tests in the IDE, ensure that the service and connector are running and that you provide the same environment variable to the tests.
-
-If you do not run Redis, change the settings in the `config.json`:
-
-```json
-{
-  "XYZ_HUB_REDIS_URI": "null",
-  "DEFAULT_MESSAGE_BROKER": "Noop"
-}
-```
-
 # Usage
 
 Start using the service by creating a _space_:

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/Service.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/Service.java
@@ -142,10 +142,8 @@ public class Service extends Core {
    */
   public static void main(String[] arguments) {
     boolean debug = Arrays.asList(arguments).contains("--debug");
-    VertxOptions vertxOptions = new VertxOptions()
-        .setMetricsOptions(new MetricsOptions()
-          .setEnabled(true)
-          .setFactory(new HubMetricsFactory()));
+    VertxOptions vertxOptions = new VertxOptions().setMetricsOptions(
+        new MetricsOptions().setEnabled(true).setFactory(new HubMetricsFactory()));
     initialize(vertxOptions, debug, CONFIG_FILE, Service::onConfigLoaded);
   }
 
@@ -163,14 +161,10 @@ public class Service extends Core {
     spaceConfigClient = SpaceConfigClient.getInstance();
     connectorConfigClient = ConnectorConfigClient.getInstance();
 
-    webClient = WebClient.create(vertx, new WebClientOptions()
-        .setUserAgent(XYZ_HUB_USER_AGENT)
-        .setTcpKeepAlive(configuration.HTTP_CLIENT_TCP_KEEPALIVE)
-        .setIdleTimeout(configuration.HTTP_CLIENT_IDLE_TIMEOUT)
-        .setTcpQuickAck(true)
-        .setTcpFastOpen(true)
-        .setPipelining(Service.configuration.HTTP_CLIENT_PIPELINING)
-    );
+    webClient = WebClient.create(vertx,
+        new WebClientOptions().setUserAgent(XYZ_HUB_USER_AGENT).setTcpKeepAlive(configuration.HTTP_CLIENT_TCP_KEEPALIVE)
+            .setIdleTimeout(configuration.HTTP_CLIENT_IDLE_TIMEOUT).setTcpQuickAck(true).setTcpFastOpen(true)
+            .setPipelining(Service.configuration.HTTP_CLIENT_PIPELINING));
 
     globalRouter = Router.router(vertx);
 
@@ -219,10 +213,7 @@ public class Service extends Core {
 
     final List<String> verticlesClassNames = Arrays.asList(Service.configuration.VERTICLES_CLASS_NAMES.split(","));
     int numInstances = Runtime.getRuntime().availableProcessors() * 2 / verticlesClassNames.size();
-    final DeploymentOptions options = new DeploymentOptions()
-        .setConfig(config)
-        .setWorker(false)
-        .setInstances(numInstances);
+    final DeploymentOptions options = new DeploymentOptions().setConfig(config).setWorker(false).setInstances(numInstances);
 
     final Promise<Void> sharedDataPromise = Promise.promise();
     final Future<Void> sharedDataFuture = sharedDataPromise.future();
@@ -256,8 +247,7 @@ public class Service extends Core {
     });
 
     //Shared data initialization
-    vertx.sharedData()
-        .getAsyncMap(SHARED_DATA, asyncMapResult -> asyncMapResult.result().put(SHARED_DATA, sharedData, sharedDataPromise));
+    vertx.sharedData().getAsyncMap(SHARED_DATA, asyncMapResult -> asyncMapResult.result().put(SHARED_DATA, sharedData, sharedDataPromise));
 
     Thread.setDefaultUncaughtExceptionHandler((thread, t) -> logger.error("Uncaught exception: ", t));
 
@@ -325,13 +315,14 @@ public class Service extends Core {
   }
 
   public static int getPublicPort() {
-    if (configuration.XYZ_HUB_PUBLIC_ENDPOINT == null) return configuration.HTTP_PORT;
+    if (configuration.XYZ_HUB_PUBLIC_ENDPOINT == null) {
+      return configuration.HTTP_PORT;
+    }
     try {
       URI endpoint = new URI(configuration.XYZ_HUB_PUBLIC_ENDPOINT);
       int port = endpoint.getPort();
       return port > 0 ? port : 80;
-    }
-    catch (URISyntaxException e) {
+    } catch (URISyntaxException e) {
       return configuration.HTTP_PORT;
     }
   }
@@ -340,8 +331,12 @@ public class Service extends Core {
    * @return The "environment ID" of this service deployment.
    */
   public static String getEnvironmentIdentifier() {
-    if (configuration.ENVIRONMENT_NAME == null) return "default";
-    if (configuration.AWS_REGION != null) return configuration.ENVIRONMENT_NAME + "_" + configuration.AWS_REGION;
+    if (configuration.ENVIRONMENT_NAME == null) {
+      return "default";
+    }
+    if (configuration.AWS_REGION != null) {
+      return configuration.ENVIRONMENT_NAME + "_" + configuration.AWS_REGION;
+    }
     return configuration.ENVIRONMENT_NAME;
   }
 
@@ -415,6 +410,7 @@ public class Service extends Core {
 
     /**
      * Adds backward-compatibility for the deprecated environment variables XYZ_HUB_REDIS_HOST & XYZ_HUB_REDIS_PORT.
+     *
      * @return
      */
     //TODO: Remove this workaround after the deprecation period
@@ -424,9 +420,9 @@ public class Service extends Core {
         String protocol = XYZ_HUB_REDIS_AUTH_TOKEN != null ? "rediss" : "redis";
         int port = XYZ_HUB_REDIS_PORT != 0 ? XYZ_HUB_REDIS_PORT : 6379;
         return protocol + "://" + XYZ_HUB_REDIS_HOST + ":" + port;
-      }
-      else
+      } else {
         return XYZ_HUB_REDIS_URI;
+      }
     }
 
     /**
@@ -436,8 +432,9 @@ public class Service extends Core {
     private List<String> hubRemoteServiceUrls;
 
     public List<String> getHubRemoteServiceUrls() {
-      if (hubRemoteServiceUrls == null)
+      if (hubRemoteServiceUrls == null) {
         hubRemoteServiceUrls = XYZ_HUB_REMOTE_SERVICE_URLS == null ? null : Arrays.asList(XYZ_HUB_REMOTE_SERVICE_URLS.split(";"));
+      }
       return hubRemoteServiceUrls;
     }
 
@@ -453,6 +450,7 @@ public class Service extends Core {
 
     /**
      * Adds backward-compatibility for public keys without header & footer.
+     *
      * @return
      */
     //TODO: Remove this workaround after the deprecation period
@@ -460,10 +458,12 @@ public class Service extends Core {
     public String getJwtPubKey() {
       String jwtPubKey = JWT_PUB_KEY;
       if (jwtPubKey != null) {
-        if (!jwtPubKey.startsWith("-----"))
+        if (!jwtPubKey.startsWith("-----")) {
           jwtPubKey = "-----BEGIN PUBLIC KEY-----\n" + jwtPubKey;
-        if (!jwtPubKey.endsWith("-----"))
+        }
+        if (!jwtPubKey.endsWith("-----")) {
           jwtPubKey = jwtPubKey + "\n-----END PUBLIC KEY-----";
+        }
       }
       return jwtPubKey;
     }
@@ -474,8 +474,8 @@ public class Service extends Core {
     public boolean INSERT_LOCAL_CONNECTORS;
 
     /**
-     * If set to true, the connectors will receive health checks. Further an unhealthy connector gets deactivated
-     * automatically if the connector config does not include skipAutoDisable.
+     * If set to true, the connectors will receive health checks. Further an unhealthy connector gets deactivated automatically if the
+     * connector config does not include skipAutoDisable.
      */
     public boolean ENABLE_CONNECTOR_HEALTH_CHECKS;
 
@@ -550,14 +550,14 @@ public class Service extends Core {
     public int REMOTE_FUNCTION_REQUEST_TIMEOUT; //seconds
 
     /**
-     * OPTIONAL: The maximum timeout for remote function requests in seconds.
-     * If not specified, the value of {@link #REMOTE_FUNCTION_REQUEST_TIMEOUT} will be used.
+     * OPTIONAL: The maximum timeout for remote function requests in seconds. If not specified, the value of
+     * {@link #REMOTE_FUNCTION_REQUEST_TIMEOUT} will be used.
      */
     public int REMOTE_FUNCTION_MAX_REQUEST_TIMEOUT; //seconds
 
     /**
-     * @return the value of {@link #REMOTE_FUNCTION_MAX_REQUEST_TIMEOUT} if specified.
-     *  The value of {@link #REMOTE_FUNCTION_REQUEST_TIMEOUT} otherwise.
+     * @return the value of {@link #REMOTE_FUNCTION_MAX_REQUEST_TIMEOUT} if specified. The value of {@link #REMOTE_FUNCTION_REQUEST_TIMEOUT}
+     * otherwise.
      */
     @JsonIgnore
     public int getRemoteFunctionMaxRequestTimeout() {
@@ -660,29 +660,30 @@ public class Service extends Core {
     public String MSE_NOTIFICATION_TOPIC;
 
     /**
-     * The maximum size of an event transiting between connector -> service -> client.
-     * Validation is only applied when MAX_SERVICE_RESPONSE_SIZE is bigger than zero.
+     * The maximum size of an event transiting between connector -> service -> client. Validation is only applied when
+     * MAX_SERVICE_RESPONSE_SIZE is bigger than zero.
+     *
      * @deprecated Use instead MAX_UNCOMPRESSED_RESPONSE_SIZE
      */
     public int MAX_SERVICE_RESPONSE_SIZE;
 
     /**
-     * The maximum uncompressed request size in bytes supported on API calls.
-     * If uncompressed request size is bigger than MAX_UNCOMPRESSED_REQUEST_SIZE, an error with status code 413 will be sent.
+     * The maximum uncompressed request size in bytes supported on API calls. If uncompressed request size is bigger than
+     * MAX_UNCOMPRESSED_REQUEST_SIZE, an error with status code 413 will be sent.
      */
     public long MAX_UNCOMPRESSED_REQUEST_SIZE;
 
     /**
-     * The maximum uncompressed response size in bytes supported on API calls.
-     * If uncompressed response size is bigger than MAX_UNCOMPRESSED_RESPONSE_SIZE, an error with status code 513 will be sent.
+     * The maximum uncompressed response size in bytes supported on API calls. If uncompressed response size is bigger than
+     * MAX_UNCOMPRESSED_RESPONSE_SIZE, an error with status code 513 will be sent.
      */
     public long MAX_UNCOMPRESSED_RESPONSE_SIZE;
 
 
     /**
-     * The maximum http response size in bytes supported on API calls.
-     * If response size is bigger than MAX_HTTP_RESPONSE_SIZE, an error with status code 513 will be sent.
-     * Validation is only applied when MAX_HTTP_RESPONSE_SIZE is bigger than zero.
+     * The maximum http response size in bytes supported on API calls. If response size is bigger than MAX_HTTP_RESPONSE_SIZE, an error with
+     * status code 513 will be sent. Validation is only applied when MAX_HTTP_RESPONSE_SIZE is bigger than zero.
+     *
      * @deprecated Use instead MAX_UNCOMPRESSED_RESPONSE_SIZE
      */
     public int MAX_HTTP_RESPONSE_SIZE;
@@ -698,8 +699,8 @@ public class Service extends Core {
     public boolean HTTP_CLIENT_TCP_KEEPALIVE = true;
 
     /**
-     * The idle connection timeout in seconds for the HTTP client of the service.
-     * Setting it to 0 will make the connections not timing out at all.
+     * The idle connection timeout in seconds for the HTTP client of the service. Setting it to 0 will make the connections not timing out
+     * at all.
      */
     public int HTTP_CLIENT_IDLE_TIMEOUT = 120;
 
@@ -721,7 +722,7 @@ public class Service extends Core {
 
     public boolean containsFeatureNamespaceOptionalField(String field) {
       if (FEATURE_NAMESPACE_OPTIONAL_FIELDS_MAP == null) {
-        FEATURE_NAMESPACE_OPTIONAL_FIELDS_MAP = new HashMap<String,Object>() {{
+        FEATURE_NAMESPACE_OPTIONAL_FIELDS_MAP = new HashMap<String, Object>() {{
           FEATURE_NAMESPACE_OPTIONAL_FIELDS.forEach(k -> put(k, null));
         }};
       }
@@ -739,7 +740,7 @@ public class Service extends Core {
    * That message can be used to change the log-level of one or more service-nodes. The specified level must be a valid log-level. As this
    * is a {@link RelayedMessage} it can be sent to a specific service-node or to all service-nodes regardless of the first service node by
    * which it was received.
-   *
+   * <p>
    * Specifying the property {@link RelayedMessage#relay} to true will relay the message to the specified destination. If no destination is
    * specified the message will be relayed to all service-nodes (broadcast).
    */

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/XYZHubRESTVerticle.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/XYZHubRESTVerticle.java
@@ -161,7 +161,11 @@ public class XYZHubRESTVerticle extends AbstractHttpServerVerticle {
             //noinspection ResultOfMethodCallIgnored
             new File(Service.configuration.FS_WEB_ROOT).mkdirs();
             router.route("/hub/static/*")
-                .handler(StaticHandler.create(Service.configuration.FS_WEB_ROOT).setIndexPage("index.html"));
+                .handler(StaticHandler.create()
+                    .setAllowRootFileSystemAccess(true)
+                    .setWebRoot(Service.configuration.FS_WEB_ROOT)
+                    .setIndexPage("index.html")
+                );
           }
 
           //Add default handlers

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/cache/CacheClient.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/cache/CacheClient.java
@@ -20,6 +20,8 @@
 package com.here.xyz.hub.cache;
 
 import io.vertx.core.Future;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nonnull;
 
 public interface CacheClient {
 
@@ -35,9 +37,30 @@ public interface CacheClient {
 
 	void remove(String key);
 
+	@Nonnull
 	static CacheClient getInstance() {
 		return new MultiLevelCacheClient(OHCacheClient.getInstance(), RedisCacheClient.getInstance());
 	}
+
+	/**
+	 * Acquire a distributed lock for the given, which should automatically be released after the
+	 * given TTL.
+	 *
+	 * @param key the key
+	 * @param ttl the time-to-live.
+	 * @param ttlUnit the unit in which the TTL was provided.
+	 * @return true if the lock was acquired; false otherwise.
+	 */
+	default boolean acquireLock(@Nonnull String key, long ttl, @Nonnull TimeUnit ttlUnit) {
+		return false;
+	}
+
+	/**
+	 * Releases the lock acquired by {@link #acquireLock(String, long, TimeUnit)}. The key must match
+	 * with the lock acquired previously.
+	 * @param key the key which the lock was acquired
+	 */
+	default void releaseLock(@Nonnull String key) {}
 
 	void shutdown();
 

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/cache/MultiLevelCacheClient.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/cache/MultiLevelCacheClient.java
@@ -23,11 +23,11 @@ import io.vertx.core.Future;
 import java.util.Arrays;
 import java.util.List;
 
-public class MultiLevelCacheClient implements CacheClient {
+class MultiLevelCacheClient implements CacheClient {
 
   final List<CacheClient> clients;
 
-  public MultiLevelCacheClient(CacheClient... clients) {
+  MultiLevelCacheClient(CacheClient... clients) {
     this.clients = Arrays.asList(clients);
   }
 
@@ -66,6 +66,6 @@ public class MultiLevelCacheClient implements CacheClient {
 
   @Override
   public void shutdown() {
-    clients.forEach(c -> c.shutdown());
+    clients.forEach(CacheClient::shutdown);
   }
 }

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/cache/NoopCacheClient.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/cache/NoopCacheClient.java
@@ -21,7 +21,7 @@ package com.here.xyz.hub.cache;
 
 import io.vertx.core.Future;
 
-public class NoopCacheClient implements CacheClient {
+class NoopCacheClient implements CacheClient {
 
 	@Override
 	public Future<byte[]> get(String key) {

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/cache/OHCacheClient.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/cache/OHCacheClient.java
@@ -26,6 +26,7 @@ import java.nio.ByteBuffer;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.Nonnull;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.caffinitas.ohc.CacheSerializer;
@@ -42,7 +43,7 @@ public class OHCacheClient implements CacheClient {
   private final ScheduledExecutorService executors;
   private OHCache<byte[], byte[]> cache;
 
-  public static synchronized OHCacheClient getInstance() {
+  static synchronized OHCacheClient getInstance() {
     if (client == null) client = new OHCacheClient();
     return client;
   }
@@ -86,7 +87,7 @@ public class OHCacheClient implements CacheClient {
   public static OHCache<byte[], byte[]> createCache(int size, ScheduledExecutorService executors, boolean withTimeouts) {
     CacheSerializer<byte[]> serializer = new Serializer();
     OHCacheBuilder<byte[], byte[]> builder = OHCacheBuilder.newBuilder();
-    return builder.capacity(size * 1024 * 1024)
+    return builder.capacity(size * 1024L * 1024L)
         .eviction(Eviction.W_TINY_LFU)
         .keySerializer(serializer)
         .valueSerializer(serializer)

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/config/MaintenanceClient.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/config/MaintenanceClient.java
@@ -54,7 +54,7 @@ import static com.here.xyz.psql.config.DatabaseSettings.*;
 
 public class MaintenanceClient {
 
-    private static Map<String, MaintenanceInstance> dbInstanceMap = new HashMap<>();
+    private static final Map<String, MaintenanceInstance> dbInstanceMap = new HashMap<>();
     private static final String C3P0EXT_CONFIG_SCHEMA = "config.schema()";
 
     private static final String[] extensionList = new String[]{"postgis","postgis_topology","tsm_system_rows","dblink"};
@@ -375,7 +375,7 @@ public class MaintenanceClient {
 
         for (String key : decodedEcps.keySet()) {
             switch (key) {
-                case DatabaseSettings.PSQL_DB:
+                case PSQL_DB:
                     databaseSettings.setDb((String) decodedEcps.get(PSQL_DB));
                     break;
                 case PSQL_HOST:

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/WarmupRemoteFunctionThread.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/WarmupRemoteFunctionThread.java
@@ -21,12 +21,13 @@ package com.here.xyz.hub.connectors;
 
 import com.here.xyz.events.HealthCheckEvent;
 import com.here.xyz.hub.Core;
-import com.here.xyz.hub.cache.RedisCacheClient;
+import com.here.xyz.hub.cache.CacheClient;
 import com.here.xyz.hub.connectors.models.Connector;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.MarkerManager.Log4jMarker;
@@ -128,11 +129,10 @@ public class WarmupRemoteFunctionThread extends Thread {
   }
 
   private boolean acquireLock() {
-    if (RedisCacheClient.getInstance() instanceof RedisCacheClient) {
-      RedisCacheClient redisCacheClient = ((RedisCacheClient) RedisCacheClient.getInstance());
-      return redisCacheClient.acquireLock(RFC_WARMUP_CACHE_KEY, (CONNECTOR_WARMUP_INTERVAL / 1000) - 1); // expires 1 second earlier
-    }
-
-    return true;
+    return CacheClient.getInstance()
+        .acquireLock(
+            RFC_WARMUP_CACHE_KEY,
+            CONNECTOR_WARMUP_INTERVAL - TimeUnit.SECONDS.toMillis(1),
+            TimeUnit.MILLISECONDS);
   }
 }

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/test/InMemoryStorage.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/test/InMemoryStorage.java
@@ -49,6 +49,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 
 public class InMemoryStorage extends StorageConnector {
 
@@ -140,5 +141,5 @@ public class InMemoryStorage extends StorageConnector {
   }
 
   @Override
-  protected void initialize(Event event) throws Exception {}
+  protected void initialize(@Nonnull Event event) throws Exception {}
 }

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/admin/MessageBroker.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/admin/MessageBroker.java
@@ -24,23 +24,21 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.here.xyz.hub.Service;
 import com.here.xyz.hub.rest.AdminApi;
 import com.here.xyz.hub.rest.admin.messages.RelayedMessage;
-import com.here.xyz.hub.rest.admin.messages.brokers.RedisMessageBroker;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
-import io.vertx.core.Future;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.net.impl.ConnectionBase;
+import javax.annotation.Nonnull;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 /**
  * The MessageBroker provides the infrastructural implementation of how to send & receive {@link AdminMessage}s.
- *
- * NOTE: The {@link MessageBroker#getInstance()} method decides which implementation to return as the default implementation.
  */
 public interface MessageBroker {
 
@@ -161,9 +159,10 @@ public interface MessageBroker {
     }
   }
 
-  static Future<? extends MessageBroker> getInstance() {
-    //Return an instance of the default implementation
-    return RedisMessageBroker.getInstance();
-  }
-
+  /**
+   * Asynchronously detect the amount of subscribers to admin messages. This is the node number.
+   * @return the future of the result.
+   */
+  @Nonnull
+  Future<Integer> fetchSubscriberCount();
 }

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/admin/messages/brokers/Broker.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/admin/messages/brokers/Broker.java
@@ -1,0 +1,39 @@
+package com.here.xyz.hub.rest.admin.messages.brokers;
+
+import com.here.xyz.hub.rest.admin.MessageBroker;
+import io.vertx.core.Future;
+import java.util.concurrent.Callable;
+import java.util.function.Supplier;
+import javax.annotation.Nonnull;
+
+/**
+ * The enumeration about all possible message broker implementation. The name can be used in the
+ * configuration file.
+ */
+public enum Broker {
+  Redis(RedisMessageBroker.class, RedisMessageBroker::getInstance),
+  Sns(SnsMessageBroker.class, SnsMessageBroker::getInstance),
+  Noop(NoopBroker.class, NoopBroker::getInstance);
+
+  Broker(
+      final @Nonnull Class<? extends MessageBroker> brokerClass,
+      final @Nonnull Supplier<Future<? extends MessageBroker>> instance
+      ) {
+    this.brokerClass = brokerClass;
+    this.instance = instance;
+  }
+
+  /**
+   * The class that implements this message broker.
+   */
+  @Nonnull
+  public final Class<? extends MessageBroker> brokerClass;
+
+  /**
+   * A reference to the supplier that returns the broker singleton. If the broker is not yet
+   * initialized, this will be done asynchronously.
+   */
+  @Nonnull
+  public final Supplier<Future<? extends MessageBroker>> instance;
+
+}

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/admin/messages/brokers/NoopBroker.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/admin/messages/brokers/NoopBroker.java
@@ -1,0 +1,62 @@
+package com.here.xyz.hub.rest.admin.messages.brokers;
+
+import com.here.xyz.hub.rest.admin.AdminMessage;
+import com.here.xyz.hub.rest.admin.MessageBroker;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import javax.annotation.Nonnull;
+
+/**
+ * The Noop message broker is a local message broker, it will only work for single instances.
+ */
+public class NoopBroker implements MessageBroker {
+
+  static Future<NoopBroker> getInstance() {
+    final Promise<NoopBroker> promise = Promise.promise();
+    promise.complete(new NoopBroker());
+    return promise.future();
+  }
+
+  @Override
+  public void sendRawMessage(String jsonMessage) {
+
+  }
+
+  @Override
+  public void sendMessage(AdminMessage message) {
+    MessageBroker.super.sendMessage(message);
+  }
+
+  @Override
+  public void sendRawMessagesToRemoteCluster(String jsonMessage, int tryCount) {
+    MessageBroker.super.sendRawMessagesToRemoteCluster(jsonMessage, tryCount);
+  }
+
+  @Override
+  public void receiveRawMessage(byte[] rawJsonMessage) {
+    MessageBroker.super.receiveRawMessage(rawJsonMessage);
+  }
+
+  @Override
+  public void receiveRawMessage(String jsonMessage) {
+    MessageBroker.super.receiveRawMessage(jsonMessage);
+  }
+
+  @Override
+  public AdminMessage deserializeMessage(String jsonMessage) {
+    return MessageBroker.super.deserializeMessage(jsonMessage);
+  }
+
+  @Override
+  public void receiveMessage(AdminMessage message) {
+    MessageBroker.super.receiveMessage(message);
+  }
+
+  @Nonnull
+  @Override
+  public Future<Integer> fetchSubscriberCount() {
+    final Promise<Integer> promise = Promise.promise();
+    promise.complete(1);
+    return promise.future();
+  }
+}

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/health/HealthApi.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/health/HealthApi.java
@@ -55,20 +55,23 @@ public class HealthApi extends Api {
   public static final String MAIN_HEALTCHECK_ENDPOINT = "/hub/";
   private static final URI NODE_HEALTHCHECK_ENDPOINT = getNodeHealthCheckEndpoint();
   public static final RemoteFunctionHealthAggregator rfcHcAggregator = new RemoteFunctionHealthAggregator();
-  private static MainHealthCheck healthCheck = new MainHealthCheck(true)
-      .withReporter(
-          new Reporter()
-              .withVersion(Service.BUILD_VERSION)
-              .withName("HERE XYZ Hub")
-              .withBuildDate(Core.BUILD_TIME)
-              .withUpSince(Core.START_TIME)
-              .withEndpoint(getPublicServiceEndpoint())
-      )
-      .add(new RedisHealthCheck(Service.configuration.getRedisUri()))
-      .add(new MemoryHealthCheck())
-      .add(new ClusterHealthCheck());
+  private static final MainHealthCheck healthCheck;
 
   static {
+    healthCheck = new MainHealthCheck(true)
+        .withReporter(
+            new Reporter()
+                .withVersion(Service.BUILD_VERSION)
+                .withName("HERE XYZ Hub")
+                .withBuildDate(Core.BUILD_TIME)
+                .withUpSince(Core.START_TIME)
+                .withEndpoint(getPublicServiceEndpoint())
+        );
+    if (Service.configuration.getRedisUri() != null) {
+      healthCheck.add(new RedisHealthCheck(Service.configuration.getRedisUri()));
+    }
+    healthCheck.add(new MemoryHealthCheck())
+        .add(new ClusterHealthCheck());
     if (Service.configuration.ENABLE_CONNECTOR_HEALTH_CHECKS){
       healthCheck.add(rfcHcAggregator);
     }

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/util/health/checks/RedisHealthCheck.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/util/health/checks/RedisHealthCheck.java
@@ -23,7 +23,7 @@ import static com.here.xyz.hub.util.health.schema.Status.Result.ERROR;
 import static com.here.xyz.hub.util.health.schema.Status.Result.OK;
 import static com.here.xyz.hub.util.health.schema.Status.Result.UNKNOWN;
 
-import com.here.xyz.hub.cache.RedisCacheClient;
+import com.here.xyz.hub.cache.CacheClient;
 import com.here.xyz.hub.util.health.schema.Response;
 import com.here.xyz.hub.util.health.schema.Status;
 import java.util.Arrays;
@@ -34,7 +34,7 @@ public class RedisHealthCheck extends ExecutableCheck {
 	private static final String HC_CACHE_KEY = "__SAMPLE_HEALTH_CHECK_KEY";
 	private static final byte[] HC_CACHE_VALUE = "someValue".getBytes();
 	private final String uri;
-	private RedisCacheClient client;
+	private CacheClient client;
 	private volatile byte[] lastReceivedValue;
 
 	public RedisHealthCheck(String uri) {
@@ -56,7 +56,7 @@ public class RedisHealthCheck extends ExecutableCheck {
 
 		try {
 			if (client == null) {
-				client = (RedisCacheClient) RedisCacheClient.getInstance();
+				client = CacheClient.getInstance();
 			}
 		}
 		catch (Throwable t) {

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/util/health/checks/RemoteFunctionHealthAggregator.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/util/health/checks/RemoteFunctionHealthAggregator.java
@@ -23,7 +23,7 @@ import static com.here.xyz.hub.util.health.schema.Status.Result.ERROR;
 import static com.here.xyz.hub.util.health.schema.Status.Result.OK;
 
 import com.here.xyz.hub.Service;
-import com.here.xyz.hub.cache.RedisCacheClient;
+import com.here.xyz.hub.cache.CacheClient;
 import com.here.xyz.hub.connectors.RemoteFunctionClient;
 import com.here.xyz.hub.connectors.models.Connector;
 import com.here.xyz.hub.rest.admin.Node;
@@ -45,7 +45,7 @@ import java.util.stream.Collectors;
 public class RemoteFunctionHealthAggregator extends GroupedHealthCheck {
 
   private static final String RFC_HC_CACHE_KEY = "RFC_HC_RESPONSE";
-  private Map<String, RemoteFunctionHealthCheck> checksByConnectorId = new HashMap<>();
+  private final Map<String, RemoteFunctionHealthCheck> checksByConnectorId = new HashMap<>();
 
   public RemoteFunctionHealthAggregator() {
     setName("Connectors");
@@ -126,7 +126,7 @@ public class RemoteFunctionHealthAggregator extends GroupedHealthCheck {
         s.setResult(ERROR);
       }
       //Write the new health-check response to the cache
-      RedisCacheClient.getInstance().set(RFC_HC_CACHE_KEY, res.toInternalResponseString().getBytes(),
+      CacheClient.getInstance().set(RFC_HC_CACHE_KEY, res.toInternalResponseString().getBytes(),
           TimeUnit.MILLISECONDS.toSeconds(checkInterval));
     }
 
@@ -152,7 +152,7 @@ public class RemoteFunctionHealthAggregator extends GroupedHealthCheck {
 
   private Response fetchResponseFromCache() {
     CompletableFuture<Response> f = new CompletableFuture<>();
-    RedisCacheClient.getInstance().get(RFC_HC_CACHE_KEY).onSuccess(r -> {
+    CacheClient.getInstance().get(RFC_HC_CACHE_KEY).onSuccess(r -> {
       Response response = null;
 
       try {

--- a/xyz-hub-service/src/main/resources/config.json
+++ b/xyz-hub-service/src/main/resources/config.json
@@ -2,7 +2,7 @@
   "LOG_CONFIG": "log4j2-console-plain.json",
 
   "INSTANCE_COUNT": 1,
-  "HOST_NAME": "127.0.0.1",
+  "HOST_NAME": "localhost",
   "HTTP_PORT": 8080,
   "ADMIN_MESSAGE_PORT": 8080,
   "MAX_GLOBAL_HTTP_CLIENT_CONNECTIONS": 1024,
@@ -11,6 +11,7 @@
   "XYZ_HUB_AUTH": "DUMMY",
 
   "XYZ_HUB_REDIS_URI": "redis://localhost",
+  "DEFAULT_MESSAGE_BROKER": "Redis",
 
   "OFF_HEAP_CACHE_SIZE_MB": 256,
 
@@ -19,7 +20,8 @@
   "STORAGE_DB_URL": "jdbc:postgresql://localhost/postgres",
   "STORAGE_DB_USER": "postgres",
   "STORAGE_DB_PASSWORD": "password",
-  "PSQL_HTTP_CONNECTOR_HOST" : "localhost",
+  "PSQL_HTTP_CONNECTOR_HOST": "localhost",
+  "PSQL_HTTP_CONNECTOR_PORT": 9090,
 
   "INSERT_LOCAL_CONNECTORS": true,
   "ENABLE_CONNECTOR_HEALTH_CHECKS" : false,

--- a/xyz-hub-service/src/main/resources/connectors.json
+++ b/xyz-hub-service/src/main/resources/connectors.json
@@ -358,7 +358,7 @@
       "local": {
         "id": "psql-http",
         "type": "Http",
-        "url": "http://${PSQL_HTTP_CONNECTOR_HOST}:9090/psql/event",
+        "url": "http://${PSQL_HTTP_CONNECTOR_HOST_AND_PORT}/psql/event",
         "protocolVersion": "0.6.0",
         "metricsActive": true
       }

--- a/xyz-hub-test/pom.xml
+++ b/xyz-hub-test/pom.xml
@@ -24,7 +24,6 @@
   <parent>
     <groupId>com.here.xyz</groupId>
     <artifactId>xyz-hub</artifactId>
-    <relativePath>../</relativePath>
     <version>1.24.1-SNAPSHOT</version>
   </parent>
 
@@ -46,16 +45,124 @@
     <skipTests>true</skipTests>
   </properties>
 
+  <profiles>
+    <profile>
+      <id>jdk8</id>
+      <activation>
+        <jdk>(,1.9)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <useIncrementalCompilation>false</useIncrementalCompilation>
+            </configuration>
+          </plugin>
+          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <groupId>org.apache.maven.plugins</groupId>
+            <configuration>
+              <includes>
+                <include>**/*.class</include>
+              </includes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>jdk9plus</id>
+      <activation>
+        <jdk>[1.9,)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <useIncrementalCompilation>false</useIncrementalCompilation>
+              <!-- This will be needed, when the target is JDK9
+              <compilerArgs>
+                <arg>- -add-exports java.base/java.lang=ALL-UNNAMED</arg>
+                <arg>- -add-exports java.base/java.util=ALL-UNNAMED</arg>
+                <arg>- -add-exports java.base/java.util.regex=ALL-UNNAMED</arg>
+                <arg>- -add-exports java.base/java.io=ALL-UNNAMED</arg>
+                <arg>- -add-exports java.base/java.nio.charset=ALL-UNNAMED</arg>
+                <arg>- -add-exports java.base/java.math=ALL-UNNAMED</arg>
+                <arg>- -add-exports java.base/java.net=ALL-UNNAMED</arg>
+                <arg>- -add-exports java.base/sun.net.spi=ALL-UNNAMED</arg>
+                <arg>- -add-exports java.base/sun.nio.cs=ALL-UNNAMED</arg>
+                <arg>- -add-exports java.base/jdk.internal.misc=ALL-UNNAMED</arg>
+              </compilerArgs>
+              -->
+            </configuration>
+          </plugin>
+          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <groupId>org.apache.maven.plugins</groupId>
+            <configuration>
+              <includes>
+                <include>**/*.class</include>
+              </includes>
+              <argLine>
+                --add-opens java.base/java.lang=ALL-UNNAMED
+                --add-opens java.base/java.util=ALL-UNNAMED
+                --add-opens java.base/java.util.regex=ALL-UNNAMED
+                --add-opens java.base/java.io=ALL-UNNAMED
+                --add-opens java.base/java.nio.charset=ALL-UNNAMED
+                --add-opens java.base/java.math=ALL-UNNAMED
+                --add-opens java.base/java.net=ALL-UNNAMED
+                --add-opens java.base/sun.net.spi=ALL-UNNAMED
+                --add-opens java.base/sun.nio.cs=ALL-UNNAMED
+                --add-opens java.base/jdk.internal.misc=ALL-UNNAMED
+              </argLine>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+      <dependencies>
+        <!-- JDK 11+ do no longer have the deprecated JAX-API -->
+        <dependency>
+          <artifactId>jaxb-api</artifactId>
+          <groupId>javax.xml.bind</groupId>
+          <version>2.3.1</version>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>com.sun.xml.bind</groupId>
+          <artifactId>jaxb-impl</artifactId>
+          <version>3.0.2</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
+
   <build>
     <plugins>
+      <!-- The Help Plugin has 7 goals:
+        help:active-profiles lists the profiles which are currently active for the build.
+        help:all-profiles lists the available profiles under the current project.
+        help:describe describes the attributes of a Plugin and/or a Mojo (Maven plain Old Java Object).
+        help:effective-pom displays the effective POM as an XML for the current build, with the active profiles factored in. If verbose, a comment is added to each XML element describing the origin of the line.
+        help:effective-settings displays the calculated settings as an XML for the project, given any profile enhancement and the inheritance of the global settings into the user-level settings.
+        help:evaluate evaluates Maven expressions given by the user in an interactive mode.
+        help:system displays a list of the platform details like system properties and environment variables.
+      -->
       <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
         <groupId>org.apache.maven.plugins</groupId>
-        <configuration>
-          <includes>
-            <include>**/*.class</include>
-          </includes>
-        </configuration>
+        <artifactId>maven-help-plugin</artifactId>
+        <version>3.2.0</version>
+        <executions>
+          <execution>
+            <id>show-profiles</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>active-profiles</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>

--- a/xyz-hub-test/pom.xml
+++ b/xyz-hub-test/pom.xml
@@ -68,6 +68,28 @@
               </includes>
             </configuration>
           </plugin>
+          <plugin>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <executions>
+              <execution>
+                <configuration>
+                  <encoding>UTF-8</encoding>
+                  <skip>${skipTests}</skip>
+                </configuration>
+                <goals>
+                  <goal>integration-test</goal>
+                </goals>
+                <id>integration-test</id>
+              </execution>
+              <execution>
+                <goals>
+                  <goal>verify</goal>
+                </goals>
+                <id>verify</id>
+              </execution>
+            </executions>
+            <groupId>org.apache.maven.plugins</groupId>
+          </plugin>
         </plugins>
       </build>
     </profile>
@@ -119,6 +141,40 @@
               </argLine>
             </configuration>
           </plugin>
+          <plugin>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <executions>
+              <execution>
+                <configuration>
+                  <encoding>UTF-8</encoding>
+                  <skip>${skipTests}</skip>
+                  <argLine>
+                    --add-opens java.base/java.lang=ALL-UNNAMED
+                    --add-opens java.base/java.util=ALL-UNNAMED
+                    --add-opens java.base/java.util.regex=ALL-UNNAMED
+                    --add-opens java.base/java.io=ALL-UNNAMED
+                    --add-opens java.base/java.nio.charset=ALL-UNNAMED
+                    --add-opens java.base/java.math=ALL-UNNAMED
+                    --add-opens java.base/java.net=ALL-UNNAMED
+                    --add-opens java.base/sun.net.spi=ALL-UNNAMED
+                    --add-opens java.base/sun.nio.cs=ALL-UNNAMED
+                    --add-opens java.base/jdk.internal.misc=ALL-UNNAMED
+                  </argLine>
+                </configuration>
+                <goals>
+                  <goal>integration-test</goal>
+                </goals>
+                <id>integration-test</id>
+              </execution>
+              <execution>
+                <goals>
+                  <goal>verify</goal>
+                </goals>
+                <id>verify</id>
+              </execution>
+            </executions>
+            <groupId>org.apache.maven.plugins</groupId>
+          </plugin>
         </plugins>
       </build>
       <dependencies>
@@ -163,28 +219,6 @@
             </goals>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <artifactId>maven-failsafe-plugin</artifactId>
-        <executions>
-          <execution>
-            <configuration>
-              <encoding>UTF-8</encoding>
-              <skip>${skipTests}</skip>
-            </configuration>
-            <goals>
-              <goal>integration-test</goal>
-            </goals>
-            <id>integration-test</id>
-          </execution>
-          <execution>
-            <goals>
-              <goal>verify</goal>
-            </goals>
-            <id>verify</id>
-          </execution>
-        </executions>
-        <groupId>org.apache.maven.plugins</groupId>
       </plugin>
     </plugins>
   </build>

--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/RestAssuredConfig.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/RestAssuredConfig.java
@@ -19,39 +19,122 @@
 
 package com.here.xyz.hub.rest;
 
-public class RestAssuredConfig {
-  public String baseURI;
-  public int hubPort;
-  public int connectorPort;
+
+import com.here.xyz.util.EnvName;
+import com.here.xyz.util.JsonConfigFile;
+import com.here.xyz.util.JsonName;
+import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.annotation.Nullable;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class RestAssuredConfig extends JsonConfigFile<RestAssuredConfig> {
+
+  private static final Logger logger = LogManager.getLogger();
+
+  // We annotate the well-known environment variable names and the JSON names from the XYZ-hub service config.
+  // Additionally, we define special environment names.
+
+  @EnvName("HOST_NAME") // config.json
+  @JsonName("HOST_NAME") // config.json
+  public String hubHost;
+  @EnvName("HTTP_HOST")
+  @EnvName("PSQL_HTTP_CONNECTOR_HOST") // config.json
+  @JsonName("PSQL_HTTP_CONNECTOR_HOST") // config.json
+  public String connectorHost = "localhost";
+  @EnvName("HTTP_PORT") // config.json and connector-config.json (both must run at different ports, but share an env-var!)
+  @JsonName("HTTP_PORT") // config.json
+  public int hubPort = 8080;
+  /**
+   * When the port is shared with the XYZ-Hub, then the embedded connector is tested. If that is not wished, you can use the environment
+   * variable HTTP_CONNECTOR_PORT to override the connector port to the one at which the standalone connector is running.
+   */
+  @EnvName("PSQL_HTTP_CONNECTOR_PORT") // config.json
+  @JsonName("PSQL_HTTP_CONNECTOR_PORT") // config.json
+  public int connectorPort = 9090;
+  @EnvName("ECPS_PHRASE") // connector-config.json
+  @JsonName("ECPS_PHRASE") // connector-config.json
+  @EnvName("DEFAULT_ECPS_PHRASE") // config.json
+  @JsonName("DEFAULT_ECPS_PHRASE") // config.json
+  public String ecpsPhrase = "local";
+  @EnvName("STORAGE_DB_URL")
+  public String STORAGE_DB_URL = "jdbc:postgresql://localhost/postgres";
+  @EnvName("STORAGE_DB_USER")
+  @EnvName("PSQL_USER")
+  public String STORAGE_DB_USER = "postgres";
+  @EnvName("STORAGE_DB_PASSWORD")
+  @EnvName("PSQL_PASSWORD")
+  public String STORAGE_DB_PASSWORD = "password";
+  @EnvName("PSQL_DB")
+  public String STORAGE_DB = "postgres";
+  @EnvName("PSQL_SCHEMA")
+  public String STORAGE_SCHEMA = "public";
+  @EnvName("PSQL_HOST")
+  public String STORAGE_HOST = "localhost";
+  @EnvName("PSQL_PORT")
+  public int STORAGE_PORT = 5432;
+  /**
+   * The unencrypted ECPS JSON.
+   */
+  public String ecpsJson;
   public String fullHubUri;
   public String fullHttpConnectorUri;
 
   private RestAssuredConfig() {
+    try {
+      load();
+    } catch (IOException e) {
+      throw new Error(e);
+    }
+    try {
+      final Pattern uriPattern = Pattern.compile("(jdbc):(postgresql)://([a-zA-Z0-9-.]+)(:[0-9]{1,5})?/([a-zA-Z0-9-.]+)");
+      final Matcher matcher = uriPattern.matcher(STORAGE_DB_URL);
+      if (matcher.find()) {
+        // psql = 1
+        // postgresql = 2
+        STORAGE_HOST = matcher.group(3);
+        final String port = matcher.group(4);
+        if (port != null) {
+          STORAGE_PORT = Integer.parseInt(port, 10);
+        }
+        STORAGE_DB = matcher.group(5);
+      }
+    } catch (Exception ignore) {
+    }
+    fullHubUri = "http://" + hubHost + ":" + hubPort + "/hub";
+    fullHttpConnectorUri = "http://" + connectorHost + ":" + connectorPort + "/psql";
+    ecpsJson = "{"
+        + "\"PSQL_HOST\":\"" + STORAGE_HOST + "\","
+        + "\"PSQL_PORT\":\"" + STORAGE_PORT + "\","
+        + "\"PSQL_DB\":\"" + STORAGE_DB + "\","
+        + "\"PSQL_USER\":\"" + STORAGE_DB_USER + "\","
+        + "\"PSQL_PASSWORD\":\"" + STORAGE_DB_PASSWORD + "\","
+        + "\"PSQL_SCHEMA\":\"" + STORAGE_SCHEMA + "\""
+        + "}";
   }
 
   private static RestAssuredConfig config = null;
 
   public static RestAssuredConfig config() {
     if (config == null) {
-      config = localConfig();
+      config = new RestAssuredConfig();
     }
     return config;
   }
 
-  private static RestAssuredConfig localConfig() {
-    RestAssuredConfig config = new RestAssuredConfig();
-    String envPort = System.getenv("HTTP_PORT");
-    String host = System.getenv().containsKey("HTTP_HOST") ? System.getenv("HTTP_HOST") : "localhost";
-    String service = System.getenv().containsKey("HTTP_SERVICE") ? System.getenv("HTTP_SERVICE") : "hub";
-    config.baseURI = "http://"+host+"/" + service;
-    config.hubPort = 8080;
-    config.connectorPort = 9090;
-    config.fullHubUri = "http://"+host+":"+config.hubPort +"/" + service;
-    config.fullHttpConnectorUri = "http://"+host+":"+config.connectorPort +"/psql";
-    try {
-      config.hubPort = Integer.parseInt(envPort);
-    }
-    catch (NumberFormatException ignore) {}
-    return config;
+  @Nullable
+  @Override
+  protected String defaultFile() {
+    return "config.json";
+  }
+
+  protected void info(String message) {
+    logger.info(message);
+  }
+
+  protected void error(String message, Throwable t) {
+    logger.error(message, t);
   }
 }

--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/RestAssuredConfig.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/RestAssuredConfig.java
@@ -83,6 +83,7 @@ public class RestAssuredConfig extends JsonConfigFile<RestAssuredConfig> {
   public String fullHttpConnectorUri;
 
   private RestAssuredConfig() {
+    super("config.json");
     try {
       load();
     } catch (IOException e) {
@@ -122,12 +123,6 @@ public class RestAssuredConfig extends JsonConfigFile<RestAssuredConfig> {
       config = new RestAssuredConfig();
     }
     return config;
-  }
-
-  @Nullable
-  @Override
-  protected String defaultFile() {
-    return "config.json";
   }
 
   protected void info(String message) {

--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/RestAssuredTest.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/RestAssuredTest.java
@@ -31,7 +31,7 @@ public class RestAssuredTest extends TestAuthenticator {
 
     @BeforeClass
     public static void configureRestAssured() {
-        RestAssured.baseURI = RestAssuredConfig.config().baseURI;
+        RestAssured.baseURI = RestAssuredConfig.config().fullHubUri;
         RestAssured.port = RestAssuredConfig.config().hubPort;
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
         RestAssured.config = RestAssured.config().httpClient(RestAssured.config().getHttpClientConfig().reuseHttpClientInstance());

--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/util/LimitedOffHeapQueueTest.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/util/LimitedOffHeapQueueTest.java
@@ -1,9 +1,5 @@
 package com.here.xyz.hub.util;
 
-import com.here.xyz.hub.Service;
-import com.here.xyz.hub.Service.Config;
-import org.junit.BeforeClass;
-
 public class LimitedOffHeapQueueTest extends LimitedQueueTest {
 
   @Override

--- a/xyz-models/src/main/java/com/here/xyz/util/EnvName.java
+++ b/xyz-models/src/main/java/com/here/xyz/util/EnvName.java
@@ -1,0 +1,30 @@
+package com.here.xyz.util;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation to read a property from a specific environment variable.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.TYPE})
+@Repeatable(EnvNames.class)
+public @interface EnvName {
+
+  /**
+   * The name of the environment variable.
+   *
+   * @return name of the environment variable.
+   */
+  String value() default "";
+
+  /**
+   * If the name should be prefixed.
+   *
+   * @return if the name should be prefixed.
+   */
+  boolean prefix() default false;
+}

--- a/xyz-models/src/main/java/com/here/xyz/util/EnvNames.java
+++ b/xyz-models/src/main/java/com/here/xyz/util/EnvNames.java
@@ -1,0 +1,14 @@
+package com.here.xyz.util;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface EnvNames {
+
+  EnvName[] value();
+
+}

--- a/xyz-models/src/main/java/com/here/xyz/util/FileOrResource.java
+++ b/xyz-models/src/main/java/com/here/xyz/util/FileOrResource.java
@@ -1,0 +1,164 @@
+package com.here.xyz.util;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.jar.JarFile;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * A file that is read either from disk or resources.
+ *
+ * @param <SELF> this type.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public abstract class FileOrResource<SELF extends FileOrResource<SELF>> {
+
+  protected FileOrResource(@Nonnull String filename) {
+    this(filename, null);
+  }
+
+  protected FileOrResource(@Nonnull String filename, @Nullable String searchPath) {
+    this.filename = filename;
+    this.searchPath = searchPath;
+  }
+
+  protected String filename;
+  protected String searchPath;
+
+  @Nullable
+  public String searchPath() {
+    return searchPath;
+  }
+
+  @Nonnull
+  @SuppressWarnings("unchecked")
+  public SELF withSearchPath(@Nullable String searchPath) {
+    this.searchPath = searchPath;
+    return (SELF) this;
+  }
+
+  @Nonnull
+  public String filename() {
+    return filename;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Nonnull
+  public SELF withFilename(@Nonnull String filename) {
+    final char firstChar = filename.charAt(0);
+    if (firstChar != '/' && firstChar != '\\') {
+      this.filename = '/' + filename;
+    } else {
+      this.filename = filename;
+    }
+    return (SELF) this;
+  }
+
+  @Nonnull
+  public InputStream open() throws NullPointerException, IOException {
+    return open(searchPath());
+  }
+
+  @Nonnull
+  public InputStream open(@Nullable String searchPath) throws NullPointerException, IOException {
+    String filePath = null;
+    try {
+      final Path path = (searchPath != null ? Paths.get(searchPath, filename) : Paths.get(filename)).toAbsolutePath();
+      final File file = path.toFile();
+      if (file.exists() && file.isFile()) {
+        filePath = path.toString();
+      } else {
+        // Try to load from resources (JAR).
+        URL url = getClass().getResource(filename);
+        if (url == null) {
+          final char firstChar = filename.charAt(0);
+          if (firstChar != '/' && firstChar != '\\') {
+            url = getClass().getResource('/' + filename);
+          }
+        }
+        filePath = url != null ? url.getPath() : null;
+      }
+    } catch (final Throwable t) {
+      error("Exception while opening file: " + filename, t);
+    }
+
+    if (filePath != null) {
+      try {
+        final InputStream in;
+        final int jarEnd = filePath.indexOf(".jar!");
+        if (filePath.startsWith("file:") && jarEnd > 0) {
+          final String jarPath = filePath.substring("file:".length(), jarEnd + ".jar".length());
+          filePath = filePath.substring(jarEnd + ".jar!".length());
+          if (filePath.startsWith("/")) {
+            filePath = filePath.substring(1);
+          }
+          info("Load file from JAR, jar-path: " + jarPath + ", file-path: " + filePath);
+          //noinspection resource
+          final JarFile jarFile = new JarFile(new File(jarPath), false, ZipFile.OPEN_READ);
+          final ZipEntry entry = jarFile.getEntry(filePath);
+          if (entry != null && entry.isDirectory()) {
+            throw new IOException("The file is a directory");
+          }
+          if (entry == null) {
+            throw new FileNotFoundException(filePath);
+          }
+          in = jarFile.getInputStream(entry);
+        } else {
+          info("Load file from disk: " + filePath);
+          in = Files.newInputStream(new File(filePath).toPath());
+        }
+        return in;
+      } catch (IOException e) {
+        throw e;
+      } catch (Throwable t) {
+        error("Exception while opening file: " + filename, t);
+      }
+    }
+    throw new FileNotFoundException("Failed to find file: " + filename);
+  }
+
+  public static byte[] readAllBytes(final @Nonnull InputStream in) throws IOException {
+    final ByteArrayOutputStream out = new ByteArrayOutputStream();
+    final byte[] buffer = new byte[1024];
+    int read;
+    while ((read = in.read(buffer, 0, buffer.length)) >= 0) {
+      out.write(buffer, 0, read);
+    }
+    out.flush();
+    return out.toByteArray();
+  }
+
+  public byte[] readAllBytes() throws IOException {
+    try (final InputStream in = open()) {
+      return readAllBytes(in);
+    }
+  }
+
+  /**
+   * A method that can be overridden to send information to a logger.
+   *
+   * @param message the message to log as information.
+   */
+  protected void info(String message) {
+  }
+
+  /**
+   * A method that can be overridden to send errors to a logger.
+   *
+   * @param message the message to log.
+   * @param cause   the cause.
+   */
+  protected void error(String message, Throwable cause) {
+  }
+}

--- a/xyz-models/src/main/java/com/here/xyz/util/JsonConfigFile.java
+++ b/xyz-models/src/main/java/com/here/xyz/util/JsonConfigFile.java
@@ -1,0 +1,337 @@
+package com.here.xyz.util;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.jar.JarFile;
+import java.util.zip.ZipEntry;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Base class of a configuration file that is read from a JSON file with optional override via environment variables. The environment
+ * variables are all required to be upper-cased and are optionally prefixed by a defined string. The configuration file should contain the
+ * member names in exact notation, unless annotated.
+ *
+ * @param <SELF> this type.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public abstract class JsonConfigFile<SELF extends JsonConfigFile<SELF>> {
+
+  /**
+   * Returns the name of the environment variable that should be used to define the search path for the configuration files.
+   * <p>
+   * Optionally it is possible to add an {@link EnvName} annotation to the class, then this defines the name of the environment variable
+   * that holds the search path.
+   * <p>
+   * In a nutshell, by default the method returns {@code XYZ_CONFIG_PATH}, if the {@link EnvName} annotation is found at the given class
+   * type, for example {@code @EnvName("MY_CONFIG_PATH")}, then the method returns exactly this: {@code MY_CONFIG_PATH}.
+   *
+   * @param classType the class for which to check the annotations.
+   * @return the name of the environment variable that holds the config file search path.
+   */
+  @Nonnull
+  public static String configPathEnvName(@Nullable Class<?> classType) {
+    while (classType != null) {
+      if (classType.isAnnotationPresent(EnvName.class)) {
+        final EnvName[] envNames = classType.getAnnotationsByType(EnvName.class);
+        return envNames[0].value();
+      }
+      classType = classType.getSuperclass();
+    }
+    return "XYZ_CONFIG_PATH";
+  }
+
+  /**
+   * An optional prefix to be placed in-front of all field names to be read from environment variables. So, the prefix "FOO_" will cause the
+   * property "bar" to be looked-up as "FOO_BAR". If no prefix is returned, the environment variable name must explicitly be declared using
+   * the annotation {@link EnvName}. Multiple names can be defined and combined with the prefix.
+   *
+   * @return a prefix or null.
+   */
+  @Nullable
+  protected String envPrefix() {
+    return null;
+  }
+
+  /**
+   * Return the default file name.
+   *
+   * @return the default file name; null if no such default exists.
+   */
+  @Nullable
+  abstract protected String defaultFile();
+
+  /**
+   * A helper method to detect pseudo null values in environment variables. Without this, you can never undefine (unset) a pre-defined value
+   * via environment variable. To allow this, this method treats an empty string and the string "null" as null (undefine).
+   *
+   * @param string the string that is read from the environment variable.
+   * @return null if the value represents null; otherwise the given value.
+   */
+  @Nullable
+  public static String nullable(@Nullable String string) {
+    return string == null || string.isEmpty() || "null".equalsIgnoreCase(string) ? null : string;
+  }
+
+  /**
+   * Used for Jackson to parse a JSON object into a map.
+   */
+  private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<Map<String, Object>>() {
+  };
+
+  /**
+   * Load the configuration from a disk file, a file in the resources (JAR) or from environment variables. Basically the order is to first
+   * read from a disk file, if not found, read from resources. In both cases, eventually the environment variables will override all values
+   * being read from the configuration file.
+   *
+   * @return this.
+   * @throws IOException if any error occurred while reading from disk or resources.
+   */
+  public final SELF load() throws IOException {
+    return load(System::getenv);
+  }
+
+  /**
+   * Load the configuration from a disk file, a file in the resources (JAR) or from environment variables. Basically the order is to first
+   * read from a disk file, if not found, read from resources. In both cases, eventually the environment variables will override all values
+   * being read from the configuration file.
+   *
+   * @param getEnv the reference to the method that reads environment variables.
+   * @return this.
+   * @throws IOException          if any error occurred while reading from disk or resources.
+   * @throws NullPointerException if getEnv is null.
+   */
+  public final SELF load(final @Nonnull Function<String, String> getEnv) throws IOException {
+    Map<String, Object> configValues = null;
+
+    final String configPath = nullable(getEnv.apply(configPathEnvName(getClass())));
+    final String configFile = nullable(defaultFile());
+    if (configFile != null) {
+      String filePath;
+      try {
+        final Path path = (configPath != null ? Paths.get(configPath, configFile) : Paths.get(configFile)).toAbsolutePath();
+        final File file = path.toFile();
+        if (file.exists() && file.isFile()) {
+          filePath = path.toString();
+        } else {
+          // Try to load from resources (JAR).
+          URL url = getClass().getResource(configFile);
+          if (url == null && !configFile.startsWith("/")) {
+            url = getClass().getResource("/" + configFile);
+          }
+          filePath = url != null ? url.getPath() : null;
+        }
+      } catch (final Throwable t) {
+        error("Failed to load config file: " + configFile, t);
+        filePath = null;
+      }
+
+      if (filePath != null) {
+        try {
+          final InputStream in;
+          final int jarEnd = filePath.indexOf(".jar!");
+          if (filePath.startsWith("file:") && jarEnd > 0) {
+            final String jarPath = filePath.substring("file:".length(), jarEnd + ".jar".length());
+            filePath = filePath.substring(jarEnd + ".jar!".length());
+            if (filePath.startsWith("/")) {
+              filePath = filePath.substring(1);
+            }
+            info("Load configuration file from JAR, jar-path: " + jarPath + ", file-path: " + filePath);
+            try (final JarFile jarFile = new JarFile(jarPath)) {
+              final ZipEntry entry = jarFile.getEntry(filePath);
+              if (entry != null && entry.isDirectory()) {
+                throw new IOException("Config file is directory");
+              }
+              if (entry == null) {
+                throw new FileNotFoundException(filePath);
+              }
+              in = jarFile.getInputStream(entry);
+            }
+          } else {
+            info("Load configuration file from disk: " + filePath);
+            in = Files.newInputStream(new File(filePath).toPath());
+          }
+          try {
+            configValues = new ObjectMapper().readValue(in, MAP_TYPE);
+          } finally {
+            in.close();
+          }
+        } catch (Throwable t) {
+          error("Failed to load configuration file: " + configFile, t);
+        }
+      }
+    }
+    return load(configValues, getEnv);
+  }
+
+  /**
+   * Read the configuration from the given map and eventually use environment variables to override values.
+   *
+   * @param defaultValues the map to load values from.
+   * @return this.
+   */
+  @Nonnull
+  public final SELF load(@Nonnull Map<String, Object> defaultValues) {
+    return load(defaultValues, System::getenv);
+  }
+
+  /**
+   * Read the configuration from a given map and eventually use environment variables to override all values being read from the map.
+   *
+   * @param configValues the configuration values to use.
+   * @param getEnv       the reference to the method that reads the environment variable; if null, then no environment variables are read.
+   * @return this.
+   */
+  @Nonnull
+  public final SELF load(
+      @Nullable Map<String, Object> configValues, @Nullable Function<String, String> getEnv) {
+    final String prefix;
+    final int prefixLen;
+    final StringBuilder sb;
+    if (getEnv != null) {
+      sb = new StringBuilder(128);
+      prefix = envPrefix();
+      if (prefix != null) {
+        prefixLen = prefix.length();
+        for (int i = 0; i < prefix.length(); i++) {
+          sb.append(Character.toUpperCase(prefix.charAt(i)));
+        }
+      } else {
+        prefixLen = 0;
+      }
+    } else {
+      prefix = null;
+      prefixLen = 0;
+      sb = null;
+    }
+    Class<?> theClass = getClass();
+    do {
+      for (final Field field : theClass.getDeclaredFields()) {
+        String name = field.getName();
+        // @JsonProperty will rename the property.
+        if (field.isAnnotationPresent(JsonProperty.class)) {
+          name = field.getAnnotation(JsonProperty.class).value();
+        }
+
+        if (configValues != null) {
+          // If the property exists under its correct name, use this.
+          if (configValues.containsKey(name)) {
+            setField(field, configValues.get(name));
+          } else {
+            // Try all alternative names in the order in which they are annotated.
+            if (field.isAnnotationPresent(JsonName.class)) {
+              final JsonName[] jsonNames = field.getAnnotationsByType(JsonName.class);
+              for (final JsonName jsonName : jsonNames) {
+                if (configValues.containsKey(jsonName.value())) {
+                  setField(field, configValues.get(jsonName.value()));
+                  break;
+                }
+              }
+            }
+          }
+        }
+        if (getEnv != null) {
+          if (prefix != null) {
+            setFromEnv(sb, prefixLen, field, name, true, getEnv);
+          }
+          if (field.isAnnotationPresent(EnvName.class)) {
+            final EnvName[] envNames = field.getAnnotationsByType(EnvName.class);
+            for (final EnvName envName : envNames) {
+              setFromEnv(sb, prefixLen, field, envName.value(), envName.prefix(), getEnv);
+            }
+          }
+          // If the field is not annotated and no prefix is defined,
+          // then we do not read the value from the environment!
+        }
+      }
+      theClass = theClass.getSuperclass();
+    } while (theClass != null);
+    //noinspection unchecked
+    return (SELF) this;
+  }
+
+  private void setFromEnv(
+      @Nonnull StringBuilder sb,
+      int prefixLen,
+      @Nonnull Field field,
+      @Nonnull String name,
+      boolean withPrefix,
+      @Nonnull Function<String, String> getEnv) {
+    sb.setLength(prefixLen);
+    for (int i = 0; i < name.length(); i++) {
+      sb.append(Character.toUpperCase(name.charAt(i)));
+    }
+    final String envName = withPrefix ? sb.toString() : sb.substring(prefixLen, sb.length());
+    final String envValue = getEnv.apply(envName);
+    if (envValue != null) {
+      setField(field, envValue);
+    }
+  }
+
+  private void setField(@Nonnull Field field, @Nullable Object value) {
+    if (value instanceof String) {
+      value = nullable((String) value);
+    }
+    try {
+      final Class<?> fieldType = field.getType();
+      if (fieldType == int.class) {
+        if (value instanceof String) {
+          final int intValue = Integer.parseInt((String) value, 10);
+          field.setInt(this, intValue);
+        } else if (value instanceof Number) {
+          field.setInt(this, ((Number) value).intValue());
+        }
+      } else if (fieldType == String.class) {
+        if (value == null) {
+          field.set(this, null);
+        } else if (value instanceof String) {
+          field.set(this, value);
+        } else if (value instanceof Number) {
+          field.set(this, value.toString());
+        }
+      } else if (fieldType == boolean.class) {
+        if (value instanceof String) {
+          final String stringValue = (String) value;
+          final boolean boolValue =
+              !"false".equalsIgnoreCase(stringValue) && !"null".equalsIgnoreCase(stringValue);
+          field.setBoolean(this, boolValue);
+        } else if (value instanceof Number) {
+          field.setBoolean(this, ((Number) value).intValue() != 0);
+        } else if (value instanceof Boolean) {
+          field.setBoolean(this, (Boolean) value);
+        }
+      }
+    } catch (NullPointerException | NumberFormatException | IllegalAccessException ignore) {
+    }
+  }
+
+  /**
+   * A method that can be overridden to send information to a logger.
+   *
+   * @param message the message to log as information.
+   */
+  protected void info(String message) {
+  }
+
+  /**
+   * A method that can be overridden to send errors to a logger.
+   *
+   * @param message the message to log.
+   * @param cause   the cause.
+   */
+  protected void error(String message, Throwable cause) {
+  }
+}

--- a/xyz-models/src/main/java/com/here/xyz/util/JsonName.java
+++ b/xyz-models/src/main/java/com/here/xyz/util/JsonName.java
@@ -1,0 +1,27 @@
+package com.here.xyz.util;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation to read a property from a JSON object. This is defined as a name alias, so the
+ * property is read by its real name and then the alternatives are tried.
+ *
+ * To rename the property itself, please use the {@link JsonProperty} annotation.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD})
+@Repeatable(JsonNames.class)
+public @interface JsonName {
+
+  /**
+   * The name of the property in the JSON.
+   *
+   * @return name of the property in the JSON.
+   */
+  String value() default "";
+}

--- a/xyz-models/src/main/java/com/here/xyz/util/JsonNames.java
+++ b/xyz-models/src/main/java/com/here/xyz/util/JsonNames.java
@@ -1,0 +1,14 @@
+package com.here.xyz.util;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface JsonNames {
+
+  JsonName[] value();
+
+}

--- a/xyz-models/src/test/java/com/here/xyz/util/JsonConfigFileTest.java
+++ b/xyz-models/src/test/java/com/here/xyz/util/JsonConfigFileTest.java
@@ -19,6 +19,14 @@ public class JsonConfigFileTest {
   @EnvName("TEST_CONFIG_PATH")
   private static class TestConfig extends JsonConfigFile<TestConfig> {
 
+    TestConfig() {
+      super(test_config_file);
+    }
+
+    TestConfig(String filename) {
+      super(filename);
+    }
+
     protected void info(String message) {
       System.out.println(message);
     }
@@ -28,12 +36,6 @@ public class JsonConfigFileTest {
       if (t != null) {
         t.printStackTrace(System.err);
       }
-    }
-
-    @Nullable
-    @Override
-    protected String defaultFile() {
-      return test_config_file;
     }
 
     @Nullable
@@ -50,12 +52,9 @@ public class JsonConfigFileTest {
 
   public static class TestConfig2 extends TestConfig {
 
-    @Nullable
-    @Override
-    protected String defaultFile() {
-      return test_config_file2;
+    TestConfig2() {
+      super(test_config_file2);
     }
-
   }
 
   public static class TestConfigWithAnnotation extends TestConfig {

--- a/xyz-models/src/test/java/com/here/xyz/util/JsonConfigFileTest.java
+++ b/xyz-models/src/test/java/com/here/xyz/util/JsonConfigFileTest.java
@@ -1,0 +1,231 @@
+package com.here.xyz.util;
+
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.LinkedHashMap;
+import javax.annotation.Nullable;
+import org.junit.Test;
+
+@SuppressWarnings("DuplicatedCode")
+public class JsonConfigFileTest {
+
+  private static final String test_config_file = "/test_config_file.json";
+  private static final String test_config_file2 = "/test_config_file2.json";
+
+  @EnvName("TEST_CONFIG_PATH")
+  private static class TestConfig extends JsonConfigFile<TestConfig> {
+
+    protected void info(String message) {
+      System.out.println(message);
+    }
+
+    protected void error(String message, Throwable t) {
+      System.err.println(message);
+      if (t != null) {
+        t.printStackTrace(System.err);
+      }
+    }
+
+    @Nullable
+    @Override
+    protected String defaultFile() {
+      return test_config_file;
+    }
+
+    @Nullable
+    @Override
+    protected String envPrefix() {
+      return "TEST_";
+    }
+
+    public int theInt = 1;
+    public boolean theBool = false;
+    public String theString = "foo";
+    public String env = "env-default";
+  }
+
+  public static class TestConfig2 extends TestConfig {
+
+    @Nullable
+    @Override
+    protected String defaultFile() {
+      return test_config_file2;
+    }
+
+  }
+
+  public static class TestConfigWithAnnotation extends TestConfig {
+
+    @EnvName(value = "BAR", prefix = true)
+    public String testAnnotation = "foo";
+  }
+
+  public static class TestConfigWithAnnotationWithoutPrefix extends TestConfig {
+
+    @EnvName("BAR")
+    public String testAnnotation = "foo";
+  }
+
+  @Test
+  public void test_defaults() {
+    final TestConfig testConfig = new TestConfig();
+    assertEquals(1, testConfig.theInt);
+    assertFalse(testConfig.theBool);
+    assertEquals("foo", testConfig.theString);
+    assertEquals("env-default", testConfig.env);
+  }
+
+  @Test
+  public void test_withMap() {
+    final TestConfig testConfig = new TestConfig();
+    final LinkedHashMap<String, Object> testValues = new LinkedHashMap<>();
+    testValues.put("theInt", 5);
+    testValues.put("theBool", true);
+    testValues.put("theString", "string");
+    testValues.put("env", "env");
+    testConfig.load(testValues, null);
+    assertEquals(5, testConfig.theInt);
+    assertTrue(testConfig.theBool);
+    assertEquals("string", testConfig.theString);
+    assertEquals("env", testConfig.env);
+  }
+
+  @Nullable
+  private static String test_withMapAndEnv_getEnv(String key) {
+    if ("TEST_ENV".equals(key)) {
+      return "env-overridden";
+    }
+    if ("TEST_THESTRING".equals(key)) {
+      return "null";
+    }
+    return null;
+  }
+
+  @Test
+  public void test_withMapAndEnv() {
+    final TestConfig testConfig = new TestConfig();
+    final LinkedHashMap<String, Object> testValues = new LinkedHashMap<>();
+    testValues.put("theInt", 5);
+    testValues.put("theBool", true);
+    testValues.put("theString", "string");
+    testValues.put("env", "env");
+    testConfig.load(testValues, JsonConfigFileTest::test_withMapAndEnv_getEnv);
+    assertEquals(5, testConfig.theInt);
+    assertTrue(testConfig.theBool);
+    assertNull(testConfig.theString);
+    assertEquals("env-overridden", testConfig.env);
+  }
+
+  @Nullable
+  private static String test_config_file_getEnv(String key) {
+    return null;
+  }
+
+  @Test
+  public void test_config_file() throws Exception {
+    final TestConfig testConfig = new TestConfig();
+    testConfig.load(JsonConfigFileTest::test_config_file_getEnv);
+    assertEquals(100, testConfig.theInt);
+    assertTrue(testConfig.theBool);
+    assertEquals("Hello World!", testConfig.theString);
+    assertEquals("default", testConfig.env);
+  }
+
+  @Nullable
+  private static String test_env_getEnv(String key) {
+    if ("TEST_ENV".equals(key)) {
+      return "noDefault";
+    }
+    if ("TEST_THEINT".equals(key)) {
+      return "10";
+    }
+    if ("TEST_THEBOOL".equals(key)) {
+      return "false";
+    }
+    if ("TEST_THESTRING".equals(key)) {
+      return "boobar";
+    }
+    return null;
+  }
+
+  @Test
+  public void test_env() throws Exception {
+    final TestConfig testConfig = new TestConfig();
+    testConfig.load(JsonConfigFileTest::test_env_getEnv);
+    assertEquals(10, testConfig.theInt);
+    assertFalse(testConfig.theBool);
+    assertEquals("boobar", testConfig.theString);
+    assertEquals("noDefault", testConfig.env);
+  }
+
+  @Nullable
+  private static String test_config_file2_getEnv(String key) {
+    if ("TEST_CONFIG_PATH".equals(key)) {
+      return "/";
+    }
+    return null;
+  }
+
+  @Test
+  public void test_config_file2() throws Exception {
+    final TestConfig2 testConfig = new TestConfig2();
+    testConfig.load(JsonConfigFileTest::test_config_file2_getEnv);
+    assertEquals(-100, testConfig.theInt);
+    assertTrue(testConfig.theBool);
+    assertEquals("Hello World!", testConfig.theString);
+    assertEquals("default", testConfig.env);
+  }
+
+  @Nullable
+  private static String test_nullable_getEnv(String key) {
+    if ("TEST_THESTRING".equals(key)) {
+      return "null";
+    }
+    return null;
+  }
+
+  @Test
+  public void test_nullable() throws Exception {
+    final TestConfig testConfig = new TestConfig();
+    testConfig.load(JsonConfigFileTest::test_nullable_getEnv);
+    assertEquals(100, testConfig.theInt);
+    assertTrue(testConfig.theBool);
+    assertNull(testConfig.theString);
+    assertEquals("default", testConfig.env);
+  }
+
+  @Nullable
+  private static String test_annotationWithPrefix_getEnv(String key) {
+    if ("TEST_BAR".equals(key)) {
+      return "bar";
+    }
+    return null;
+  }
+
+  @Test
+  public void test_annotationWithPrefix() throws Exception {
+    final TestConfigWithAnnotation testConfig = new TestConfigWithAnnotation();
+    testConfig.load(JsonConfigFileTest::test_annotationWithPrefix_getEnv);
+    assertEquals("bar", testConfig.testAnnotation);
+  }
+
+  @Nullable
+  private static String test_annotationWithoutPrefix_getEnv(String key) {
+    if ("BAR".equals(key)) {
+      return "bar";
+    }
+    return null;
+  }
+
+  @Test
+  public void test_annotationWithoutPrefix() throws Exception {
+    final TestConfigWithAnnotationWithoutPrefix testConfig = new TestConfigWithAnnotationWithoutPrefix();
+    testConfig.load(JsonConfigFileTest::test_annotationWithoutPrefix_getEnv);
+    assertEquals("bar", testConfig.testAnnotation);
+  }
+
+}

--- a/xyz-models/src/test/resources/test_config_file.json
+++ b/xyz-models/src/test/resources/test_config_file.json
@@ -1,0 +1,6 @@
+{
+  "theInt": 100,
+  "theBool": true,
+  "theString": "Hello World!",
+  "env": "default"
+}

--- a/xyz-models/src/test/resources/test_config_file2.json
+++ b/xyz-models/src/test/resources/test_config_file2.json
@@ -1,0 +1,6 @@
+{
+  "theInt": -100,
+  "theBool": true,
+  "theString": "Hello World!",
+  "env": "default"
+}

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseHandler.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseHandler.java
@@ -172,7 +172,7 @@ public abstract class DatabaseHandler extends StorageConnector {
     }
 
     @Override
-    protected synchronized void initialize(@Nonnull Event<?> event) {
+    protected synchronized void initialize(@Nonnull Event event) {
         this.event = event;
         this.config= new PSQLConfig(event, context, traceItem);
         String connectorId = traceItem.getConnectorId();


### PR DESCRIPTION
This holds all kind of changes that fix, when running without Redis, compiling and testing with JDK9+ and when running the service at different ports or using different database credentials. It fixes as well creation of default tables, when the database is totally empty.