### PR TITLE
Read from primary after database update

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/task/FeatureTaskHandler.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/task/FeatureTaskHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2021 HERE Europe B.V.
+ * Copyright (C) 2017-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -384,6 +384,7 @@ public class FeatureTaskHandler {
       });
     }
     else {
+      task.getEvent().setPreferPrimaryDataSource(true);
       callback.call(task);
     }
   }


### PR DESCRIPTION
Set the "prefer primary data source" flag, when the space configuration indicates that cache should be avoided.

Signed-off-by: Dimitar Goshev <dimitar.goshev@here.com>