### PR TITLE
Fix equals() method of Http Connector configuration

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/models/Connector.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/models/Connector.java
@@ -449,7 +449,7 @@ public class Connector {
         if (!(o instanceof Http)) return false;
         if (!super.equals(o)) return false;
         Http http = (Http) o;
-        return metricsActive == http.metricsActive && url.equals(http.url);
+        return metricsActive == http.metricsActive && url.toString().equals(http.url.toString());
       }
 
       @Override


### PR DESCRIPTION
The equals method was using the URL#equals() implementation which could end up in trying to resolve the host names of the involved URLs. Changed the implementation to compare only the string representation of the two URLs.

Signed-off-by: Benjamin Rögner <benjamin.roegner@here.com>