### PR TITLE
Fix flickering test "testCacheWithMvt"

### DIFF
--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/TTLTestsIT.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/TTLTestsIT.java
@@ -105,6 +105,12 @@ public class TTLTestsIT extends TestWithSpaceCleanup {
         .get("/spaces/" + RANDOM_FEATURE_SPACE + "/tile/web/0_0_0.mvt")
         .body().asByteArray();
 
+    try {
+      //Wait 1s to give the asynchronous cache-write some time.
+      Thread.sleep(1_000);
+    }
+    catch (InterruptedException e) {}
+
     byte[] body_cached = given()
         .headers(getAuthHeaders(AuthProfile.ACCESS_ALL))
         .contentType(APPLICATION_JSON)


### PR DESCRIPTION
Adding some wait time after the first retrieval of the data from the random-features-space to give the asynchronous cache-write the needed time and thus mitigate a race-condition.

Signed-off-by: Benjamin Rögner <benjamin.roegner@here.com>