### PR TITLE
Fix bug with selection when getting features by ID

### DIFF
--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/ReadFeatureApiIT.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/ReadFeatureApiIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2021 HERE Europe B.V.
+ * Copyright (C) 2017-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -352,6 +352,20 @@ public class ReadFeatureApiIT extends TestSpaceWithFeature {
         statusCode(OK.code()).
         body("id", equalTo("Q2838923")).
         body("properties.name", equalTo("Estadio Universidad San Marcos"));
+  }
+
+  @Test
+  public void testFeatureByIdWithSelection() {
+    given()
+        .accept(APPLICATION_GEO_JSON)
+        .headers(getAuthHeaders(AuthProfile.ACCESS_OWNER_1_ADMIN))
+        .when()
+        .get(getSpacesPath() + "/x-psql-test/features/Q2838923?selection=p.name").
+        then()
+        .statusCode(OK.code())
+        .body("id", equalTo("Q2838923"))
+        .body("properties.name", equalTo("Estadio Universidad San Marcos"))
+        .body("properties.sport", equalTo(null));
   }
 
   @Test

--- a/xyz-models/src/main/java/com/here/xyz/events/GetFeaturesByIdEvent.java
+++ b/xyz-models/src/main/java/com/here/xyz/events/GetFeaturesByIdEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,10 +26,9 @@ import java.util.List;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeName(value = "GetFeaturesByIdEvent")
 @SuppressWarnings({"WeakerAccess", "unused"})
-public final class GetFeaturesByIdEvent extends ContextAwareEvent<GetFeaturesByIdEvent> {
+public final class GetFeaturesByIdEvent extends SelectiveEvent<GetFeaturesByIdEvent> {
 
   private List<String> ids;
-  private List<String> selection;
   private boolean force2D;
 
   public List<String> getIds() {
@@ -42,19 +41,6 @@ public final class GetFeaturesByIdEvent extends ContextAwareEvent<GetFeaturesByI
 
   public GetFeaturesByIdEvent withIds(List<String> ids) {
     setIds(ids);
-    return this;
-  }
-
-  public List<String> getSelection() {
-    return this.selection;
-  }
-
-  public void setSelection(List<String> selection) {
-    this.selection = selection;
-  }
-
-  public GetFeaturesByIdEvent withSelection(List<String> selection) {
-    setSelection(selection);
     return this;
   }
 

--- a/xyz-models/src/main/java/com/here/xyz/events/SelectiveEvent.java
+++ b/xyz-models/src/main/java/com/here/xyz/events/SelectiveEvent.java
@@ -19,38 +19,25 @@
 
 package com.here.xyz.events;
 
-public abstract class QueryEvent<T extends QueryEvent> extends SelectiveEvent<T> {
+import java.util.List;
 
-  private TagsQuery tags;
-  private PropertiesQuery propertiesQuery;
+public class SelectiveEvent<T extends ContextAwareEvent> extends ContextAwareEvent<T> {
 
-  public TagsQuery getTags() {
-    return this.tags;
-  }
-
-  public void setTags(TagsQuery tags) {
-    this.tags = tags;
-  }
+  private List<String> selection;
 
   @SuppressWarnings("unused")
-  public T withTags(TagsQuery tags) {
-    setTags(tags);
-    return (T)this;
-  }
-
-  @SuppressWarnings("unused")
-  public PropertiesQuery getPropertiesQuery() {
-    return this.propertiesQuery;
+  public List<String> getSelection() {
+    return this.selection;
   }
 
   @SuppressWarnings("WeakerAccess")
-  public void setPropertiesQuery(PropertiesQuery propertiesQuery) {
-    this.propertiesQuery = propertiesQuery;
+  public void setSelection(List<String> selection) {
+    this.selection = selection;
   }
 
   @SuppressWarnings("unused")
-  public T withPropertiesQuery(PropertiesQuery propertiesQuery) {
-    setPropertiesQuery(propertiesQuery);
+  public T withSelection(List<String> selection) {
+    setSelection(selection);
     return (T)this;
   }
 }

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeatures.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeatures.java
@@ -23,10 +23,10 @@ import static com.here.xyz.events.ContextAwareEvent.SpaceContext.DEFAULT;
 
 import com.here.xyz.connectors.ErrorResponseException;
 import com.here.xyz.events.ContextAwareEvent;
-import com.here.xyz.events.Event;
 import com.here.xyz.events.GetFeaturesByIdEvent;
 import com.here.xyz.events.QueryEvent;
 import com.here.xyz.events.SearchForFeaturesEvent;
+import com.here.xyz.events.SelectiveEvent;
 import com.here.xyz.models.geojson.implementation.FeatureCollection;
 import com.here.xyz.psql.DatabaseHandler;
 import com.here.xyz.psql.SQLQuery;
@@ -67,8 +67,8 @@ public abstract class GetFeatures<E extends ContextAwareEvent> extends ExtendedS
               + "    WHERE ${{filterWhereClause}} ${{orderBy}} ${{limit}} ${{offset}}");
     }
 
-    if (event instanceof QueryEvent)
-      query.setQueryFragment("selection", buildSelectionFragment((QueryEvent) event));
+    if (event instanceof SelectiveEvent)
+      query.setQueryFragment("selection", buildSelectionFragment((SelectiveEvent) event));
     else
       query.setQueryFragment("selection", "jsondata");
 
@@ -126,7 +126,7 @@ public abstract class GetFeatures<E extends ContextAwareEvent> extends ExtendedS
     return dbHandler.defaultFeatureResultSetHandler(rs);
   }
 
-  protected static SQLQuery buildSelectionFragment(QueryEvent event) {
+  protected static SQLQuery buildSelectionFragment(SelectiveEvent event) {
     if (event.getSelection() == null || event.getSelection().size() == 0)
       return new SQLQuery("jsondata");
 


### PR DESCRIPTION
- Introduce new base event type "SelectiveEvent" which is the new super class of QueryEvent & GetFeaturesByIdEvent to not have a redundant definition of "selection"
- Adjusted "GetFeatures" query-runner to support selection for all "SelectiveEvents"
- Also added according integration test

Signed-off-by: Benjamin Rögner <benjamin.roegner@here.com>