### PR TITLE
Further refactoring to prepare for spatial search on composite spaces

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/FeatureQueryApi.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/FeatureQueryApi.java
@@ -39,6 +39,7 @@ import com.here.xyz.events.GetStatisticsEvent;
 import com.here.xyz.events.IterateFeaturesEvent;
 import com.here.xyz.events.PropertiesQuery;
 import com.here.xyz.events.SearchForFeaturesEvent;
+import com.here.xyz.events.SelectiveEvent;
 import com.here.xyz.hub.Service;
 import com.here.xyz.hub.rest.ApiParam.Path;
 import com.here.xyz.hub.rest.ApiParam.Query;
@@ -103,9 +104,9 @@ public class FeatureQueryApi extends SpaceBasedApi {
 
       final SearchForFeaturesEvent event = new SearchForFeaturesEvent();
       event.withLimit(getLimit(context))
-          .withForce2D(force2D)
           .withTags(Query.getTags(context))
           .withPropertiesQuery(Query.getPropertiesQuery(context))
+          .withForce2D(force2D)
           .withSelection(Query.getSelection(context));
 
       final SearchQuery task = new SearchQuery(event, context, ApiResponseType.FEATURE_COLLECTION, skipCache);

--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/ModifyFeatureCompositeSpaceIT.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/ModifyFeatureCompositeSpaceIT.java
@@ -296,4 +296,8 @@ public class ModifyFeatureCompositeSpaceIT extends TestCompositeSpace {
         .body("features.size()", equalTo(1))
         .body("features[0].id", equalTo(f1.getId()));
   }
+
+  //TODO: Add tests for iteration on a composite space
+  //TODO: Add tests for spatial search on a composite space
+
 }

--- a/xyz-models/src/main/java/com/here/xyz/events/GetFeaturesByIdEvent.java
+++ b/xyz-models/src/main/java/com/here/xyz/events/GetFeaturesByIdEvent.java
@@ -29,7 +29,6 @@ import java.util.List;
 public final class GetFeaturesByIdEvent extends SelectiveEvent<GetFeaturesByIdEvent> {
 
   private List<String> ids;
-  private boolean force2D;
 
   public List<String> getIds() {
     return this.ids;
@@ -41,21 +40,6 @@ public final class GetFeaturesByIdEvent extends SelectiveEvent<GetFeaturesByIdEv
 
   public GetFeaturesByIdEvent withIds(List<String> ids) {
     setIds(ids);
-    return this;
-  }
-
-  public boolean isForce2D() {
-    return force2D;
-  }
-
-  @SuppressWarnings("WeakerAccess")
-  public void setForce2D(boolean force2D) {
-    this.force2D = force2D;
-  }
-
-  @SuppressWarnings("unused")
-  public GetFeaturesByIdEvent withForce2D(boolean force2D) {
-    setForce2D(force2D);
     return this;
   }
 }

--- a/xyz-models/src/main/java/com/here/xyz/events/SearchForFeaturesEvent.java
+++ b/xyz-models/src/main/java/com/here/xyz/events/SearchForFeaturesEvent.java
@@ -30,7 +30,6 @@ public class SearchForFeaturesEvent<T extends SearchForFeaturesEvent> extends Qu
   private static final long MAX_LIMIT = 100_000L;
 
   private long limit = DEFAULT_LIMIT;
-  private boolean force2D;
 
   public long getLimit() {
     return limit;
@@ -44,23 +43,6 @@ public class SearchForFeaturesEvent<T extends SearchForFeaturesEvent> extends Qu
   @SuppressWarnings("unused")
   public T withLimit(long limit) {
     setLimit(limit);
-    //noinspection unchecked
-    return (T) this;
-  }
-
-  @SuppressWarnings("WeakerAccess")
-  public boolean isForce2D() {
-    return force2D;
-  }
-
-  @SuppressWarnings("WeakerAccess")
-  public void setForce2D(boolean force2D) {
-    this.force2D = force2D;
-  }
-
-  @SuppressWarnings("unused")
-  public T withForce2D(boolean force2D) {
-    setForce2D(force2D);
     //noinspection unchecked
     return (T) this;
   }

--- a/xyz-models/src/main/java/com/here/xyz/events/SelectiveEvent.java
+++ b/xyz-models/src/main/java/com/here/xyz/events/SelectiveEvent.java
@@ -21,9 +21,10 @@ package com.here.xyz.events;
 
 import java.util.List;
 
-public class SelectiveEvent<T extends ContextAwareEvent> extends ContextAwareEvent<T> {
+public class SelectiveEvent<T extends SelectiveEvent> extends ContextAwareEvent<T> {
 
   private List<String> selection;
+  private boolean force2D;
 
   @SuppressWarnings("unused")
   public List<String> getSelection() {
@@ -39,5 +40,22 @@ public class SelectiveEvent<T extends ContextAwareEvent> extends ContextAwareEve
   public T withSelection(List<String> selection) {
     setSelection(selection);
     return (T)this;
+  }
+
+  @SuppressWarnings("WeakerAccess")
+  public boolean isForce2D() {
+    return force2D;
+  }
+
+  @SuppressWarnings("WeakerAccess")
+  public void setForce2D(boolean force2D) {
+    this.force2D = force2D;
+  }
+
+  @SuppressWarnings("unused")
+  public T withForce2D(boolean force2D) {
+    setForce2D(force2D);
+    //noinspection unchecked
+    return (T) this;
   }
 }

--- a/xyz-models/src/main/java/com/here/xyz/events/SpatialQueryEvent.java
+++ b/xyz-models/src/main/java/com/here/xyz/events/SpatialQueryEvent.java
@@ -22,7 +22,7 @@ package com.here.xyz.events;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class SpatialQueryEvent<T extends SpatialQueryEvent> extends SearchForFeaturesEvent<T> {
+public abstract class SpatialQueryEvent<T extends SpatialQueryEvent> extends SearchForFeaturesEvent<T> {
 
   private boolean clip;
 

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseHandler.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseHandler.java
@@ -51,8 +51,8 @@ import com.here.xyz.psql.query.ExtendedSpace;
 import com.here.xyz.psql.query.ModifySpace;
 import com.here.xyz.psql.query.helpers.FetchExistingIds;
 import com.here.xyz.psql.query.helpers.FetchExistingIds.FetchIdsInput;
+import com.here.xyz.psql.tools.DhString;
 import com.here.xyz.responses.BinaryResponse;
-import com.here.xyz.responses.CountResponse;
 import com.here.xyz.responses.ErrorResponse;
 import com.here.xyz.responses.HealthStatus;
 import com.here.xyz.responses.HistoryStatisticsResponse;
@@ -63,7 +63,6 @@ import com.here.xyz.responses.XyzResponse;
 import com.here.xyz.responses.changesets.Changeset;
 import com.here.xyz.responses.changesets.ChangesetCollection;
 import com.here.xyz.responses.changesets.CompactChangeset;
-import com.here.xyz.psql.tools.DhString;
 import com.mchange.v2.c3p0.AbstractConnectionCustomizer;
 import com.mchange.v2.c3p0.ComboPooledDataSource;
 import com.mchange.v2.c3p0.PooledDataSource;
@@ -94,7 +93,6 @@ public abstract class DatabaseHandler extends StorageConnector {
     private static final Logger logger = LogManager.getLogger();
 
     private static final Pattern pattern = Pattern.compile("^BOX\\(([-\\d\\.]*)\\s([-\\d\\.]*),([-\\d\\.]*)\\s([-\\d\\.]*)\\)$");
-    private static final int MAX_PRECISE_STATS_COUNT = 10_000;
     private static final String C3P0EXT_CONFIG_SCHEMA = "config.schema()";
     public static final String HISTORY_TABLE_SUFFIX = "_hst";
 
@@ -469,7 +467,7 @@ public abstract class DatabaseHandler extends StorageConnector {
      */
     protected List<Feature> fetchOldStates(String[] idsToFetch) throws Exception {
         List<Feature> oldFeatures = null;
-        FeatureCollection oldFeaturesCollection = executeQueryWithRetry(SQLQueryBuilder.generateLoadOldFeaturesQuery(idsToFetch, dataSource));
+        FeatureCollection oldFeaturesCollection = executeQueryWithRetry(SQLQueryBuilder.generateLoadOldFeaturesQuery(idsToFetch));
 
         if (oldFeaturesCollection != null) {
             oldFeatures = oldFeaturesCollection.getFeatures();

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseHandler.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseHandler.java
@@ -316,7 +316,9 @@ public abstract class DatabaseHandler extends StorageConnector {
      */
     protected <T> T executeQueryWithRetry(SQLQuery query, ResultSetHandler<T> handler, boolean useReadReplica) throws SQLException {
         try {
+            query.replaceUnnamedParameters();
             query.replaceFragments();
+            query.replaceNamedParameters();
             return executeQuery(query, handler, useReadReplica ? readDataSource : dataSource);
         } catch (Exception e) {
             try {

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/PSQLXyzConnector.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/PSQLXyzConnector.java
@@ -160,11 +160,7 @@ public class PSQLXyzConnector extends DatabaseHandler {
   protected XyzResponse processGetFeaturesByGeometryEvent(GetFeaturesByGeometryEvent event) throws Exception {
     try {
       logger.info("{} Received GetFeaturesByGeometryEvent", traceItem);
-
-      if (event.getParams() != null && event.getParams().containsKey("extends") && event.getContext() == DEFAULT)
         return new GetFeaturesByGeometry(event, this).run();
-
-      return executeQueryWithRetry(SQLQueryBuilder.buildGetFeaturesByGeometryQuery(event));
     }catch (SQLException e){
       return checkSQLException(e, config.readTableFromEvent(event));
     }finally {

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/PSQLXyzConnector.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/PSQLXyzConnector.java
@@ -51,6 +51,7 @@ import com.here.xyz.psql.factory.H3SQL;
 import com.here.xyz.psql.factory.QuadbinSQL;
 import com.here.xyz.psql.factory.TweaksSQL;
 import com.here.xyz.psql.query.GetFeaturesByBBox;
+import com.here.xyz.psql.query.GetFeaturesByGeometry;
 import com.here.xyz.psql.query.GetFeaturesById;
 import com.here.xyz.psql.query.GetStorageStatistics;
 import com.here.xyz.psql.query.IterateFeatures;
@@ -159,6 +160,10 @@ public class PSQLXyzConnector extends DatabaseHandler {
   protected XyzResponse processGetFeaturesByGeometryEvent(GetFeaturesByGeometryEvent event) throws Exception {
     try {
       logger.info("{} Received GetFeaturesByGeometryEvent", traceItem);
+
+      if (event.getParams() != null && event.getParams().containsKey("extends") && event.getContext() == DEFAULT)
+        return new GetFeaturesByGeometry(event, this).run();
+
       return executeQueryWithRetry(SQLQueryBuilder.buildGetFeaturesByGeometryQuery(event));
     }catch (SQLException e){
       return checkSQLException(e, config.readTableFromEvent(event));

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/PSQLXyzConnector.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/PSQLXyzConnector.java
@@ -337,10 +337,10 @@ public class PSQLXyzConnector extends DatabaseHandler {
         {
           case H3SQL.HEXBIN :
            if( !bMvtRequested )
-            return executeQueryWithRetry(SQLQueryBuilder.buildHexbinClusteringQuery(event, bbox, clusteringParams,dataSource));
+            return executeQueryWithRetry(SQLQueryBuilder.buildHexbinClusteringQuery(event, bbox, clusteringParams));
            else
             return executeBinQueryWithRetry(
-             SQLQueryBuilder.buildMvtEncapsuledQuery(event.getSpace(), SQLQueryBuilder.buildHexbinClusteringQuery(event, bbox, clusteringParams,dataSource), mercatorTile, hereTile, bbox, mvtMargin, bMvtFlattend ) );
+             SQLQueryBuilder.buildMvtEncapsuledQuery(event.getSpace(), SQLQueryBuilder.buildHexbinClusteringQuery(event, bbox, clusteringParams), mercatorTile, hereTile, bbox, mvtMargin, bMvtFlattend ) );
 
           case QuadbinSQL.QUAD :
            final int relResolution = ( clusteringParams.get(QuadbinSQL.QUADBIN_RESOLUTION) != null ? (int) clusteringParams.get(QuadbinSQL.QUADBIN_RESOLUTION) :

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/SQLQuery.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/SQLQuery.java
@@ -281,6 +281,22 @@ public class SQLQuery {
     namedParameters = null;
   }
 
+  //TODO: Can be removed after completion of refactoring
+  @Deprecated
+  public void replaceUnnamedParameters() {
+    if (parameters() == null || parameters().size() == 0)
+      return;
+    List<Object> params = parameters();
+    //Clear all un-named parameters
+    parameters = new ArrayList<>();
+    int i = 0;
+    for (Object paramValue : params) {
+      String paramName = "param" + ++i;
+      setNamedParameter(paramName, paramValue);
+      setText(text().replaceFirst(Pattern.quote("?"), "#{" + paramName + "}"));
+    }
+  }
+
   public static SQLQuery selectJson(QueryEvent event) {
     return GetFeatures.buildSelectionFragmentBWC(event);
   }

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/SQLQuery.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/SQLQuery.java
@@ -376,7 +376,7 @@ public class SQLQuery {
     if (fragment == null)
       return;
     if (fragment.parameters() != null && fragment.parameters().size() > 0)
-      throw new RuntimeException("No query fragments can be used inside queries which use parameters. Use named parameters instead!");
+      throw new RuntimeException("Query which use parameters can't be added as query fragment to a query. Use named parameters instead!");
     if (fragment.queryFragments != null)
       checkForUnnamedParametersInFragments(fragment.queryFragments.values());
   }

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/SQLQueryBuilder.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/SQLQueryBuilder.java
@@ -29,7 +29,6 @@ import com.here.xyz.events.IterateFeaturesEvent;
 import com.here.xyz.events.IterateHistoryEvent;
 import com.here.xyz.events.PropertiesQuery;
 import com.here.xyz.events.QueryEvent;
-import com.here.xyz.events.SpatialQueryEvent;
 import com.here.xyz.models.geojson.HQuad;
 import com.here.xyz.models.geojson.WebMercatorTile;
 import com.here.xyz.models.geojson.coordinates.BBox;
@@ -37,7 +36,7 @@ import com.here.xyz.psql.config.PSQLConfig;
 import com.here.xyz.psql.factory.H3SQL;
 import com.here.xyz.psql.factory.QuadbinSQL;
 import com.here.xyz.psql.factory.TweaksSQL;
-import com.here.xyz.psql.query.GetFeaturesByGeometry;
+import com.here.xyz.psql.query.GetFeaturesByBBox;
 import com.here.xyz.psql.query.ModifySpace;
 import com.here.xyz.psql.query.SearchForFeatures;
 import com.here.xyz.psql.tools.DhString;
@@ -720,7 +719,7 @@ public class SQLQueryBuilder {
     { return generateCombinedQueryTweaks(event, indexedQuery, tweaksgeo, bTestTweaksGeoIfNull, -1.0f, false );  }
 
   private static SQLQuery generateCombinedQuery(GetFeaturesByBBoxEvent event, SQLQuery indexedQuery) {
-      return GetFeaturesByGeometry.generateCombinedQueryBWC(event, indexedQuery);
+      return GetFeaturesByBBox.generateCombinedQueryBWC(event, indexedQuery);
   }
 
 

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/SQLQueryBuilder.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/SQLQueryBuilder.java
@@ -45,7 +45,6 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Map;
-import javax.sql.DataSource;
 
 public class SQLQueryBuilder {
     public static final long GEOMETRY_DECIMAL_DIGITS = 8;
@@ -99,7 +98,7 @@ public class SQLQueryBuilder {
 
     public static SQLQuery buildHexbinClusteringQuery(
             GetFeaturesByBBoxEvent event, BBox bbox,
-            Map<String, Object> clusteringParams, DataSource dataSource) {
+            Map<String, Object> clusteringParams) {
 
         int zLevel = (event instanceof GetFeaturesByTileEvent ? ((GetFeaturesByTileEvent) event).getLevel() : H3SQL.bbox2zoom(bbox)),
             defaultResForLevel = H3SQL.zoom2resolution(zLevel),
@@ -729,7 +728,7 @@ public class SQLQueryBuilder {
       return SearchForFeatures.generateSearchQueryBWC(event);
   }
 
-    protected static SQLQuery generateLoadOldFeaturesQuery(final String[] idsToFetch, final DataSource dataSource) {
+    protected static SQLQuery generateLoadOldFeaturesQuery(final String[] idsToFetch) {
         return new SQLQuery("SELECT jsondata, replace(ST_AsGeojson(ST_Force3D(geo),"+GEOMETRY_DECIMAL_DIGITS+"),'nan','0') FROM ${schema}.${table} WHERE jsondata->>'id' = ANY(?)", (Object) idsToFetch);
     }
 

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/SQLQueryBuilder.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/SQLQueryBuilder.java
@@ -526,7 +526,10 @@ public class SQLQueryBuilder {
 
     public static SQLQuery buildMvtEncapsuledQuery( String spaceId, SQLQuery dataQry, WebMercatorTile mvtTile, HQuad hereTile, BBox eventBbox, int mvtMargin, boolean bFlattend )
     {
+      //TODO: The following is a workaround for backwards-compatibility and can be removed after completion of refactoring
+      dataQry.replaceUnnamedParameters();
       dataQry.replaceFragments();
+      dataQry.replaceNamedParameters();
       int extend = 4096, buffer = (extend / WebMercatorTile.TileSizeInPixel) * mvtMargin;
       BBox b = ( mvtTile != null ? mvtTile.getBBox(false) : ( hereTile != null ? hereTile.getBoundingBox() : eventBbox) ); // pg ST_AsMVTGeom expects tiles bbox without buffer.
 

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/SQLQueryBuilder.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/SQLQueryBuilder.java
@@ -719,7 +719,7 @@ public class SQLQueryBuilder {
     private static SQLQuery generateCombinedQueryTweaks(GetFeaturesByBBoxEvent event, SQLQuery indexedQuery, String tweaksgeo, boolean bTestTweaksGeoIfNull)
     { return generateCombinedQueryTweaks(event, indexedQuery, tweaksgeo, bTestTweaksGeoIfNull, -1.0f, false );  }
 
-  private static SQLQuery generateCombinedQuery(SpatialQueryEvent event, SQLQuery indexedQuery) {
+  private static SQLQuery generateCombinedQuery(GetFeaturesByBBoxEvent event, SQLQuery indexedQuery) {
       return GetFeaturesByGeometry.generateCombinedQueryBWC(event, indexedQuery);
   }
 

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeatures.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeatures.java
@@ -156,6 +156,6 @@ public abstract class GetFeatures<E extends ContextAwareEvent> extends ExtendedS
   protected String buildGeoFragment(E event) {
     boolean isForce2D = event instanceof SelectiveEvent ? ((SelectiveEvent) event).isForce2D() : false;
     return "replace(ST_AsGeojson(" + (isForce2D ? "ST_Force2D" : "ST_Force3D") + "(geo), "
-        + SQLQueryBuilder.GEOMETRY_DECIMAL_DIGITS + "), 'nan', '0')";
+        + SQLQueryBuilder.GEOMETRY_DECIMAL_DIGITS + "), 'nan', '0') as geo";
   }
 }

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeatures.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeatures.java
@@ -154,12 +154,8 @@ public abstract class GetFeatures<E extends ContextAwareEvent> extends ExtendedS
   }
 
   protected String buildGeoFragment(E event) {
-    boolean isForce2D = false;
-    if (event instanceof GetFeaturesByIdEvent)
-      isForce2D = ((GetFeaturesByIdEvent) event).isForce2D();
-    else if (event instanceof SearchForFeaturesEvent)
-      isForce2D = ((SearchForFeaturesEvent<?>) event).isForce2D();
-
-    return "replace(ST_AsGeojson(" + (isForce2D ? "ST_Force2D" : "ST_Force3D") + "(geo), " + SQLQueryBuilder.GEOMETRY_DECIMAL_DIGITS + "), 'nan', '0')";
+    boolean isForce2D = event instanceof SelectiveEvent ? ((SelectiveEvent) event).isForce2D() : false;
+    return "replace(ST_AsGeojson(" + (isForce2D ? "ST_Force2D" : "ST_Force3D") + "(geo), "
+        + SQLQueryBuilder.GEOMETRY_DECIMAL_DIGITS + "), 'nan', '0')";
   }
 }

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeaturesByGeometry.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeaturesByGeometry.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2017-2022 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.xyz.psql.query;
+
+import com.here.xyz.connectors.ErrorResponseException;
+import com.here.xyz.events.GetFeaturesByGeometryEvent;
+import com.here.xyz.psql.DatabaseHandler;
+import com.here.xyz.psql.SQLQuery;
+import java.sql.SQLException;
+
+public class GetFeaturesByGeometry extends SearchForFeatures<GetFeaturesByGeometryEvent> {
+
+  public GetFeaturesByGeometry(GetFeaturesByGeometryEvent event, DatabaseHandler dbHandler) throws SQLException, ErrorResponseException {
+    super(event, dbHandler);
+  }
+
+  @Override
+  protected SQLQuery buildQuery(GetFeaturesByGeometryEvent event) throws SQLException {
+    return super.buildQuery(event);
+  }
+}

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeaturesByGeometry.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeaturesByGeometry.java
@@ -19,10 +19,20 @@
 
 package com.here.xyz.psql.query;
 
+import static com.here.xyz.events.ContextAwareEvent.SpaceContext.DEFAULT;
+import static com.here.xyz.events.GetFeaturesByTileEvent.ResponseType.GEO_JSON;
+
 import com.here.xyz.connectors.ErrorResponseException;
+import com.here.xyz.events.GetFeaturesByBBoxEvent;
 import com.here.xyz.events.GetFeaturesByGeometryEvent;
+import com.here.xyz.events.SpatialQueryEvent;
+import com.here.xyz.models.geojson.coordinates.BBox;
+import com.here.xyz.models.geojson.coordinates.WKTHelper;
+import com.here.xyz.models.geojson.implementation.Geometry;
 import com.here.xyz.psql.DatabaseHandler;
 import com.here.xyz.psql.SQLQuery;
+import com.here.xyz.psql.SQLQueryBuilder;
+import com.here.xyz.psql.tools.DhString;
 import java.sql.SQLException;
 
 public class GetFeaturesByGeometry extends SearchForFeatures<GetFeaturesByGeometryEvent> {
@@ -33,6 +43,108 @@ public class GetFeaturesByGeometry extends SearchForFeatures<GetFeaturesByGeomet
 
   @Override
   protected SQLQuery buildQuery(GetFeaturesByGeometryEvent event) throws SQLException {
-    return super.buildQuery(event);
+    //if (isExtendedSpace(event) && event.getContext() == DEFAULT)
+
+    final int radius = event.getRadius();
+    final Geometry geometry = event.getGeometry();
+
+    final SQLQuery geoQuery;
+
+    if(event.getH3Index() != null){
+      if(radius != 0)
+        geoQuery = new SQLQuery("ST_Intersects( geo, ST_Buffer(hexbin::geography,? )::geometry)", radius);
+      else
+        geoQuery = new SQLQuery("ST_Intersects( geo, hexbin)");
+    }else{
+      geoQuery = radius != 0 ? new SQLQuery("ST_Intersects(geo, ST_Buffer(ST_GeomFromText('"
+          + WKTHelper.geometryToWKB(geometry) + "')::geography, ? )::geometry)", radius) : new SQLQuery("ST_Intersects(geo, ST_GeomFromText('"
+          + WKTHelper.geometryToWKB(geometry) + "',4326))");
+    }
+    return generateCombinedQuery(event, geoQuery);
+  }
+
+  //TODO: Can be removed after completion of refactoring
+  @Deprecated
+  public static SQLQuery generateCombinedQueryBWC(SpatialQueryEvent event, SQLQuery indexedQuery) {
+    SQLQuery query = generateCombinedQuery(event, indexedQuery);
+    if (query != null)
+      query.replaceNamedParameters();
+    return query;
+  }
+
+  private static SQLQuery generateCombinedQuery(SpatialQueryEvent event, SQLQuery indexedQuery) {
+    SQLQuery searchQuery = generateSearchQueryBWC(event);
+    boolean bConvertGeo2Geojson = event instanceof GetFeaturesByGeometryEvent || SQLQueryBuilder.getResponseType((GetFeaturesByBBoxEvent) event) == GEO_JSON;
+    String h3Index = event instanceof GetFeaturesByGeometryEvent ? ((GetFeaturesByGeometryEvent) event).getH3Index() : null;
+
+      final SQLQuery query = new SQLQuery();
+
+      if(h3Index != null)
+          query.append("WITH h AS (SELECT h3ToGeoBoundaryDeg( ('x' || '"+h3Index+"' )::bit(60)::bigint ) as hexbin )");
+
+      query.append("SELECT ");
+
+      query.append(SQLQuery.selectJson(event));
+      query.append(",");
+      query.append(" ${{geo}} ");
+      query.setQueryFragment("geo", geometrySelectorForEvent(event, bConvertGeo2Geojson));
+
+      if(h3Index != null)
+          query.append("FROM ${schema}.${table} ${{tableSample}}, h WHERE");
+      else
+          query.append("FROM ${schema}.${table} ${{tableSample}} WHERE");
+      query.setQueryFragment("tableSample", ""); //Can be overridden by caller
+
+      query.append(indexedQuery);
+
+      if( searchQuery != null )
+      { query.append(" and ");
+          query.append(searchQuery);
+      }
+
+      query.append(" ${{orderBy}} ");
+      query.setQueryFragment("orderBy", ""); //Can be overridden by caller
+
+      query.append("LIMIT ?", event.getLimit());
+      return query;
+  }
+
+  /**
+   * Returns the query, which will contains the geometry object.
+   */
+  private static SQLQuery geometrySelectorForEvent(final SpatialQueryEvent event, boolean bGeoJson) {
+      String forceMode = SQLQueryBuilder.getForceMode(event.isForce2D());
+
+      if(!event.getClip()){
+          return (bGeoJson ?
+                  new SQLQuery("replace(ST_AsGeojson("+forceMode+"(geo),?::INTEGER),'nan','0') as geo", SQLQueryBuilder.GEOMETRY_DECIMAL_DIGITS)
+                  : new SQLQuery(forceMode+"(geo) as geo"));
+      }else{
+          if(event instanceof GetFeaturesByBBoxEvent){
+              final BBox bbox = ((GetFeaturesByBBoxEvent)event).getBbox();
+              String geoSqlAttrib = (bGeoJson ? DhString.format("replace(ST_AsGeoJson(ST_Intersection(ST_MakeValid(geo),ST_MakeEnvelope(?,?,?,?,4326)),%d),'nan','0') as geo", SQLQueryBuilder.GEOMETRY_DECIMAL_DIGITS)
+                      : "ST_Intersection( ST_MakeValid(geo),ST_MakeEnvelope(?,?,?,?,4326) ) as geo");
+
+              return new SQLQuery(geoSqlAttrib, bbox.minLon(), bbox.minLat(), bbox.maxLon(), bbox.maxLat());
+          }else if(event instanceof GetFeaturesByGeometryEvent){
+              //Clip=true =>  Use input Geometry for clipping
+              final Geometry geometry = ((GetFeaturesByGeometryEvent)event).getGeometry();
+              //If h3Index is given - use it as input geometry
+              final String h3Index =  ((GetFeaturesByGeometryEvent)event).getH3Index();
+
+              String wktGeom = h3Index == null ? "ST_GeomFromText('" + WKTHelper.geometryToWKB(geometry) + "',4326)" : "hexbin" ;
+
+              //If radius is not null
+              if(((GetFeaturesByGeometryEvent)event).getRadius() != 0){
+                  //Enlarge input geometry with ST_Buffer
+                  wktGeom = (h3Index == null ?
+                          DhString.format("ST_Buffer(ST_GeomFromText('" + WKTHelper.geometryToWKB(geometry) + "')::geography, %d )::geometry", ((GetFeaturesByGeometryEvent)event).getRadius())
+                          : DhString.format("ST_Buffer(hexbin::geography,%d)::geometry", ((GetFeaturesByGeometryEvent)event).getRadius()));
+              }
+              return new SQLQuery("replace(ST_AsGeoJson(ST_Intersection(ST_MakeValid(geo),"+wktGeom+"),?::INTEGER),'nan','0') as geo", SQLQueryBuilder.GEOMETRY_DECIMAL_DIGITS);
+          }
+      }
+      //Should not happen (currently only used with GetFeaturesByBBoxEvent / GetFeaturesByGeometryEvent)
+      return new SQLQuery("ST_AsGeojson(geo) as geo");
   }
 }

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/IterateFeatures.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/IterateFeatures.java
@@ -101,6 +101,7 @@ public class IterateFeatures extends SearchForFeatures<IterateFeaturesEvent> {
       return buildQueryForOrderBy(event);
 
     SQLQuery query = super.buildQuery(event);
+    query.setQueryFragment("iColumn", ", i");
 
     boolean hasHandle = event.getHandle() != null;
     start = hasHandle ? Long.parseLong(event.getHandle()) : 0L;

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/SearchForFeatures.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/SearchForFeatures.java
@@ -69,7 +69,7 @@ public class SearchForFeatures<E extends SearchForFeaturesEvent> extends GetFeat
     return searchQuery;
   }
 
-  protected SQLQuery buildLimitFragment(long limit) {
+  protected static SQLQuery buildLimitFragment(long limit) {
     return new SQLQuery("LIMIT #{limit}", Collections.singletonMap("limit", limit));
   }
 

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/SearchForFeatures.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/SearchForFeatures.java
@@ -52,7 +52,6 @@ public class SearchForFeatures<E extends SearchForFeaturesEvent> extends GetFeat
     SQLQuery searchQuery = buildSearchFragment(event);
 
     SQLQuery query = super.buildQuery(event, "TRUE");
-    query.setQueryFragment("iColumn", ", i");
 
     if (hasSearch)
       query.setQueryFragment("filterWhereClause", searchQuery);
@@ -165,9 +164,8 @@ public class SearchForFeatures<E extends SearchForFeaturesEvent> extends GetFeat
     return query;
   }
 
-  /**
-   * This method is kept for backwards compatibility until refactoring is complete.
-   */
+  //TODO: Can be removed after completion of refactoring
+  @Deprecated
   public static SQLQuery generateSearchQueryBWC(QueryEvent event) {
     SQLQuery query = generateSearchQuery(event);
     if (query != null)

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/SearchForFeatures.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/SearchForFeatures.java
@@ -73,9 +73,9 @@ public class SearchForFeatures<E extends SearchForFeaturesEvent> extends GetFeat
     return new SQLQuery("LIMIT #{limit}", Collections.singletonMap("limit", limit));
   }
 
-  /**
-   * This method is kept for backwards compatibility until refactoring is complete.
-   */
+
+  //TODO: Can be removed after completion of refactoring
+  @Deprecated
   public static SQLQuery generatePropertiesQueryBWC(PropertiesQuery properties) {
     SQLQuery query = generatePropertiesQuery(properties);
     if (query != null)

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/Spatial.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/Spatial.java
@@ -19,14 +19,10 @@
 
 package com.here.xyz.psql.query;
 
-import static com.here.xyz.events.GetFeaturesByTileEvent.ResponseType.GEO_JSON;
-
 import com.here.xyz.connectors.ErrorResponseException;
-import com.here.xyz.events.GetFeaturesByTileEvent;
 import com.here.xyz.events.SpatialQueryEvent;
 import com.here.xyz.psql.DatabaseHandler;
 import com.here.xyz.psql.SQLQuery;
-import com.here.xyz.psql.SQLQueryBuilder;
 import java.sql.SQLException;
 
 public abstract class Spatial<E extends SpatialQueryEvent> extends SearchForFeatures<E> {
@@ -35,15 +31,9 @@ public abstract class Spatial<E extends SpatialQueryEvent> extends SearchForFeat
     super(event, dbHandler);
   }
 
-  protected static SQLQuery buildClippedGeoFragment(final SpatialQueryEvent event) {
-    boolean convertToGeoJson = !(event instanceof GetFeaturesByTileEvent && ((GetFeaturesByTileEvent) event).getResponseType() != GEO_JSON);
-    String forceMode = SQLQueryBuilder.getForceMode(event.isForce2D());
-
-    if (!event.getClip())
-      return new SQLQuery(convertToGeoJson
-          ? "replace(ST_AsGeojson(" + forceMode + "(geo), " + SQLQueryBuilder.GEOMETRY_DECIMAL_DIGITS + "),'nan','0') as geo"
-          : forceMode + "(geo) as geo");
-
-    return null; //Should never happen
-  }
+  /**
+   * Returns a geo-fragment, which will return the geometry objects clipped by the provided geoFilter
+   * depending on whether clipping is active or not.
+   */
+  protected abstract SQLQuery buildClippedGeoFragment(final E event, SQLQuery geoFilter);
 }

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/Spatial.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/Spatial.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2017-2022 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.xyz.psql.query;
+
+import static com.here.xyz.events.GetFeaturesByTileEvent.ResponseType.GEO_JSON;
+
+import com.here.xyz.connectors.ErrorResponseException;
+import com.here.xyz.events.GetFeaturesByTileEvent;
+import com.here.xyz.events.SpatialQueryEvent;
+import com.here.xyz.psql.DatabaseHandler;
+import com.here.xyz.psql.SQLQuery;
+import com.here.xyz.psql.SQLQueryBuilder;
+import java.sql.SQLException;
+
+public abstract class Spatial<E extends SpatialQueryEvent> extends SearchForFeatures<E> {
+
+  public Spatial(E event, DatabaseHandler dbHandler) throws SQLException, ErrorResponseException {
+    super(event, dbHandler);
+  }
+
+  protected static SQLQuery buildClippedGeoFragment(final SpatialQueryEvent event) {
+    boolean convertToGeoJson = !(event instanceof GetFeaturesByTileEvent && ((GetFeaturesByTileEvent) event).getResponseType() != GEO_JSON);
+    String forceMode = SQLQueryBuilder.getForceMode(event.isForce2D());
+
+    if (!event.getClip())
+      return new SQLQuery(convertToGeoJson
+          ? "replace(ST_AsGeojson(" + forceMode + "(geo), " + SQLQueryBuilder.GEOMETRY_DECIMAL_DIGITS + "),'nan','0') as geo"
+          : forceMode + "(geo) as geo");
+
+    return null; //Should never happen
+  }
+}


### PR DESCRIPTION
- Basic preparations for support of spatial search on composite spaces
- pull up force2D to SelectiveEvent and simplify GetFeatures#buildGeoFragment()
- move some functionality related to GetFeaturesByGeometryEvent handling into GetFeaturesByGeometry QR
- Prepare consolidation of GetFeaturesByGeometry QR by refactoring queries to use named parameters
- Add tmp backwards compatibility workarounds where necessary
- Remove usage of datasource where obsolete
- Consolidation of queries for GetFeaturesByGeometryEvent
- Preparations to consolidate clipping implementation for GetFeaturesByGeometryEvent & GetFeaturesByBBox
- Add common parts into new abstract "Spatial" QR
- Consolidate buildGeoFragment() use-cases into a single method in GetFeatures QR
- Further consolidate GetFeaturesByGeometry QR by re-using buildQuery implementation from super classes