### PR TITLE
Implement support for spatial search on composite spaces

### DIFF
--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseHandler.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseHandler.java
@@ -23,6 +23,8 @@ import static com.here.xyz.events.ContextAwareEvent.SpaceContext.DEFAULT;
 import static com.here.xyz.events.ModifySpaceEvent.Operation.CREATE;
 import static com.here.xyz.events.ModifySpaceEvent.Operation.DELETE;
 import static com.here.xyz.events.ModifySpaceEvent.Operation.UPDATE;
+import static com.here.xyz.psql.QueryRunner.SCHEMA;
+import static com.here.xyz.psql.QueryRunner.TABLE;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -415,7 +417,7 @@ public abstract class DatabaseHandler extends StorageConnector {
         try {
             final QueryRunner run = new QueryRunner(dataSource, new StatementConfiguration(null,null,null,null,calculateTimeout()));
 
-            query.setText(SQLQuery.replaceVars(query.text(),config.getDatabaseSettings().getSchema(), config.readTableFromEvent(event)));
+            query.setText(SQLQuery.replaceVars(query.text(), config.getDatabaseSettings().getSchema(), config.readTableFromEvent(event)));
             final String queryText = query.text();
             final List<Object> queryParameters = query.parameters();
             logger.debug("{} executeUpdate: {} - Parameter: {}", traceItem, queryText, queryParameters);

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/QueryRunner.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/QueryRunner.java
@@ -34,8 +34,9 @@ import org.apache.commons.dbutils.ResultSetHandler;
  */
 public abstract class QueryRunner<E extends Object, R extends Object> implements ResultSetHandler<R> {
 
-  protected static final String SCHEMA = "schema";
-  protected static final String TABLE = "table";
+  //TODO: Make protected again after refactoring is complete
+  public static final String SCHEMA = "schema";
+  public static final String TABLE = "table";
 
   private final SQLQuery query;
   private boolean useReadReplica;

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/SQLQueryBuilder.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/SQLQueryBuilder.java
@@ -690,9 +690,7 @@ public class SQLQueryBuilder {
       SQLQuery searchQuery = generateSearchQuery(event);
      String tSample = ( sampleRatio <= 0.0 ? "" : DhString.format("tablesample system(%.6f) repeatable(499)", 100.0 * sampleRatio) );
 
-     final SQLQuery query = new SQLQuery();
-
-     query.append("select * from ( SELECT");
+     final SQLQuery query = new SQLQuery("select * from ( SELECT");
 
      query.append(SQLQuery.selectJson(event));
 

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeaturesById.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeaturesById.java
@@ -19,8 +19,6 @@
 
 package com.here.xyz.psql.query;
 
-import static com.here.xyz.events.ContextAwareEvent.SpaceContext.DEFAULT;
-
 import com.here.xyz.connectors.ErrorResponseException;
 import com.here.xyz.events.GetFeaturesByIdEvent;
 import com.here.xyz.psql.DatabaseHandler;
@@ -34,13 +32,12 @@ public class GetFeaturesById extends GetFeatures<GetFeaturesByIdEvent> {
   }
 
   @Override
-  protected SQLQuery buildQuery(GetFeaturesByIdEvent event) {
+  protected SQLQuery buildQuery(GetFeaturesByIdEvent event) throws SQLException {
     String[] idArray = event.getIds().toArray(new String[0]);
     String filterWhereClause = "jsondata->>'id' = ANY(#{ids})";
 
-    SQLQuery query = buildQuery(event, filterWhereClause);
-
-    //query.setQueryFragment("filterWhereClause", filterWhereClause);
+    SQLQuery query = super.buildQuery(event);
+    query.setQueryFragment("filterWhereClause", filterWhereClause);
     query.setNamedParameter("ids", idArray);
     return query;
   }

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/IterateFeatures.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/IterateFeatures.java
@@ -75,7 +75,8 @@ public class IterateFeatures extends SearchForFeatures<IterateFeaturesEvent> {
   protected SQLQuery buildQuery(IterateFeaturesEvent event) throws SQLException {
     if (isExtendedSpace(event) && event.getContext() == SpaceContext.DEFAULT) {
 
-      SQLQuery extensionQuery = buildQuery(event, "TRUE"); //TODO: Do not support search on iterate for now
+      SQLQuery extensionQuery = super.buildQuery(event);
+      extensionQuery.setQueryFragment("filterWhereClause", "TRUE"); //TODO: Do not support search on iterate for now
       extensionQuery.setQueryFragment("iColumn", ", CONCAT('', i) AS i");
 
       if (is2LevelExtendedSpace(event)) {
@@ -85,7 +86,8 @@ public class IterateFeatures extends SearchForFeatures<IterateFeaturesEvent> {
       else
         extensionQuery.setQueryFragment("iColumnExtension", ", CONCAT('e', i) AS i");
 
-      SQLQuery offsetQuery = new SQLQuery(event.getHandle() == null? "TRUE" : "i::text > #{startOffset}", Collections.singletonMap("startOffset", event.getHandle()));
+      SQLQuery offsetQuery = new SQLQuery(event.getHandle() == null? "TRUE" : "i::text > #{startOffset}")
+          .withNamedParameter("startOffset", event.getHandle());
 
       SQLQuery query = new SQLQuery(
           "SELECT * FROM (${{extensionQuery}}) orderQuery WHERE ${{offsetQuery}} ORDER BY i ${{limit}}");
@@ -112,7 +114,7 @@ public class IterateFeatures extends SearchForFeatures<IterateFeaturesEvent> {
     }
     else {
       if (hasHandle)
-        query.setQueryFragment("filterWhereClause", query.getQueryFragment("filterWhereClause") + " AND i > #{startOffset}");
+        query.setQueryFragment("filterWhereClause", "i > #{startOffset}");
 
       query.setQueryFragment("orderBy", "ORDER BY i");
     }

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/SearchForFeatures.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/SearchForFeatures.java
@@ -49,10 +49,9 @@ public class SearchForFeatures<E extends SearchForFeaturesEvent> extends GetFeat
 
   @Override
   protected SQLQuery buildQuery(E event) throws SQLException {
+    SQLQuery query = super.buildQuery(event);
+
     SQLQuery searchQuery = buildSearchFragment(event);
-
-    SQLQuery query = super.buildQuery(event, "TRUE");
-
     if (hasSearch)
       query.setQueryFragment("filterWhereClause", searchQuery);
     else
@@ -69,7 +68,7 @@ public class SearchForFeatures<E extends SearchForFeaturesEvent> extends GetFeat
   }
 
   protected static SQLQuery buildLimitFragment(long limit) {
-    return new SQLQuery("LIMIT #{limit}", Collections.singletonMap("limit", limit));
+    return new SQLQuery("LIMIT #{limit}").withNamedParameter("limit", limit);
   }
 
 
@@ -214,7 +213,7 @@ public class SearchForFeatures<E extends SearchForFeaturesEvent> extends GetFeat
       segmentNames.put(segmentParamName, keySegment);
     }
 
-    return new SQLQuery(keyPath, segmentNames);
+    return new SQLQuery(keyPath).withNamedParameters(segmentNames);
   }
 
   private static String getValue(Object value, PropertyQuery.QueryOperation op, String key, String paramName) {

--- a/xyz-psql-connector/src/test/java/com/here/xyz/psql/SQLQueryTests.java
+++ b/xyz-psql-connector/src/test/java/com/here/xyz/psql/SQLQueryTests.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2017-2022 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.xyz.psql;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class SQLQueryTests {
+
+  @Test
+  public void testVariableInheritance() {
+    SQLQuery q = new SQLQuery("${{someFragment}} ${someVariable}");
+    q.setVariable("someVariable", "someValue");
+    q.setQueryFragment("someFragment", "${someVariable} ==");
+    q.substitute();
+    assertEquals("\"someValue\" == \"someValue\"", q.text());
+  }
+
+  @Test
+  public void testParameterInheritance() {
+    SQLQuery q = new SQLQuery("${{someFragment}} #{someParameter}");
+    q.setNamedParameter("someParameter", "someValue");
+    q.setQueryFragment("someFragment", "#{someParameter} ==");
+    q.substitute();
+    assertEquals("? == ?", q.text());
+    assertEquals(2, q.parameters().size());
+    assertEquals("someValue", q.parameters().get(0));
+    assertEquals("someValue", q.parameters().get(1));
+  }
+
+  @Test
+  public void testFragmentInheritance() {
+    SQLQuery q = new SQLQuery("${{someInnerFragment}} ${{abc}}");
+    q.setQueryFragment("abc", "someValue");
+    q.setQueryFragment("someInnerFragment", new SQLQuery("${{abc}} =="));
+    q.substitute();
+    assertEquals("someValue == someValue", q.text());
+  }
+
+}


### PR DESCRIPTION
- Improve SQLQuery to properly replace fragments, variables & parameters recursively
- Add tests for checking recursive desubstitution of fragments, variables & parameters in SQLQuery
- Some further minor refactoring and deprecations in SQLQuery
- Improve GetFeatures QR to not have a special 2-args implementation of #buildQuery() anymore, but override the standard one
- Use new 1-arg implementation of #buildQuery() in all QRs and consolidate different execution paths (e.g. remove duplications)
- Complete consolidation of execution paths for GetFeaturesByGeometry QR - now re-using implementation of GetFeatures properly
- Add chainable methods withNamedParameter(), withQueryFragment(), withVariable() to SQLQuery for convenience

Signed-off-by: Benjamin Rögner <benjamin.roegner@here.com>