### PR TITLE
Introduce new space-context "super" pointing to the extended space …

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/FeatureQueryApi.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/FeatureQueryApi.java
@@ -39,7 +39,6 @@ import com.here.xyz.events.GetStatisticsEvent;
 import com.here.xyz.events.IterateFeaturesEvent;
 import com.here.xyz.events.PropertiesQuery;
 import com.here.xyz.events.SearchForFeaturesEvent;
-import com.here.xyz.events.SelectiveEvent;
 import com.here.xyz.hub.Service;
 import com.here.xyz.hub.rest.ApiParam.Path;
 import com.here.xyz.hub.rest.ApiParam.Query;
@@ -162,10 +161,6 @@ public class FeatureQueryApi extends SpaceBasedApi {
     } catch (HttpException e) {
       sendErrorResponse(context, e);
     }
-  }
-
-  private static SpaceContext getSpaceContext(RoutingContext context) {
-    return SpaceContext.of(Query.getString(context, Query.CONTEXT, SpaceContext.DEFAULT.toString()).toUpperCase());
   }
 
   /**

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/SpaceBasedApi.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/SpaceBasedApi.java
@@ -3,6 +3,8 @@ package com.here.xyz.hub.rest;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 
+import com.here.xyz.events.ContextAwareEvent.SpaceContext;
+import com.here.xyz.hub.rest.ApiParam.Query;
 import com.here.xyz.hub.task.FeatureTaskHandler.InvalidStorageException;
 import com.here.xyz.hub.task.Task;
 import com.here.xyz.responses.ErrorResponse;
@@ -15,6 +17,10 @@ public abstract class SpaceBasedApi extends Api {
   protected final static int DEFAULT_FEATURE_LIMIT = 30_000;
   protected final static int MIN_LIMIT = 1;
   protected final static int HARD_LIMIT = 100_000;
+
+  protected static SpaceContext getSpaceContext(RoutingContext context) {
+    return SpaceContext.of(Query.getString(context, Query.CONTEXT, SpaceContext.DEFAULT.toString()).toUpperCase());
+  }
 
   /**
    * Send an error response to the client when an exception occurred while processing a task.

--- a/xyz-hub-service/src/main/resources/openapi.yaml
+++ b/xyz-hub-service/src/main/resources/openapi.yaml
@@ -1193,18 +1193,23 @@ components:
       name: context
       in: query
       description: |
-        The context where the operation will be performed when the space extends
-        another space. If not specified, the operation occurs based on the extension
-        rules. For additional information, see Space.extends.
+        The context where the operation will be performed on a composite space.
+        If not specified, the operation occurs based on the extension rules.
+        For additional information, see Space.extends.
 
         Available context are:
         |Context|Description|
         |-------|-----------|
-        |extension|The operation will be executed only in the space which extends another and no operation will be performed in the extended space.
+        |default|The default value if none is given. For composite spaces the operation occurs based on the extension rules. For normal spaces this is the only valid context.|
+        |extension|The operation will be executed only in the extension and no operation will be performed in the extended space.|
+        |super|Only applicable for read-operations. The operation will be executed only in the space being extended (super space).|
       schema:
         type: string
         enum:
+          - default
           - extension
+          - super
+        default: default
 
     East:
       name: east

--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/ModifyFeatureCompositeSpaceIT.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/ModifyFeatureCompositeSpaceIT.java
@@ -20,8 +20,8 @@
 package com.here.xyz.hub.rest;
 
 import static com.here.xyz.hub.rest.Api.HeaderValues.APPLICATION_GEO_JSON;
-import static com.here.xyz.hub.rest.Api.HeaderValues.APPLICATION_JSON;
 import static com.jayway.restassured.RestAssured.given;
+import static io.netty.handler.codec.http.HttpResponseStatus.FORBIDDEN;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 import static io.netty.handler.codec.http.HttpResponseStatus.NO_CONTENT;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
@@ -102,26 +102,80 @@ public class ModifyFeatureCompositeSpaceIT extends TestCompositeSpace {
 
   @Test
   public void getOnlyOnDelta() {
-    Feature f1 = newFeature();
-    Feature f2 = newFeature();
-    // FIXME in order to get the extending space to be created, a read or write operation must be executed, otherwise a 504 is returned
-    postFeature("x-psql-test", f1);
-    postFeature("x-psql-test-ext", f2);
+    Feature feature = newFeature();
+    postFeature("x-psql-test-ext", feature);
 
     given()
         .headers(getAuthHeaders(AuthProfile.ACCESS_OWNER_1_ADMIN))
         .when()
-        .get("/spaces/x-psql-test/features/" + f2.getId())
+        .get("/spaces/x-psql-test/features/" + feature.getId())
         .then()
         .statusCode(NOT_FOUND.code());
 
     given()
         .headers(getAuthHeaders(AuthProfile.ACCESS_OWNER_1_ADMIN))
         .when()
-        .get("/spaces/x-psql-test-ext/features/" + f2.getId())
+        .get("/spaces/x-psql-test-ext/features/" + feature.getId())
         .then()
         .statusCode(OK.code())
-        .body("id", equalTo(f2.getId()));
+        .body("id", equalTo(feature.getId()));
+  }
+
+  @Test
+  public void getOnlyFromSuper() {
+    Feature feature = newFeature();
+    postFeature("x-psql-test", feature.withProperties(new Properties().with("name", "abc")));
+    postFeature("x-psql-test-ext", feature.withProperties(new Properties().with("name", "xyz")));
+
+    given()
+        .headers(getAuthHeaders(AuthProfile.ACCESS_OWNER_1_ADMIN))
+        .when()
+        .get("/spaces/x-psql-test-ext/features/" + feature.getId() + "?context=super")
+        .then()
+        .statusCode(OK.code())
+        .body("id", equalTo(feature.getId()))
+        .body("properties.name", equalTo("abc"));
+  }
+
+  @Test
+  public void createSuperNegative() {
+    Feature feature = newFeature();
+
+    given()
+        .headers(getAuthHeaders(AuthProfile.ACCESS_OWNER_1_ADMIN))
+        .body(feature.serialize())
+        .when()
+        .post("/spaces/x-psql-test-ext/features?context=super")
+        .then()
+        .statusCode(FORBIDDEN.code());
+  }
+
+  @Test
+  public void updateSuperNegative() {
+    Feature feature = newFeature();
+    postFeature("x-psql-test", feature);
+
+    given()
+        .headers(getAuthHeaders(AuthProfile.ACCESS_OWNER_1_ADMIN))
+        .contentType("application/geo+json")
+        .body(feature.withProperties(new Properties().with("name", "abc")).serialize())
+        .when()
+        .patch("/spaces/x-psql-test-ext/features/" + feature.getId() + "?context=super")
+        .then()
+        .statusCode(FORBIDDEN.code());
+  }
+
+  @Test
+  public void deleteSuperNegative() {
+    Feature feature = newFeature();
+    postFeature("x-psql-test", feature);
+
+    given()
+        .headers(getAuthHeaders(AuthProfile.ACCESS_OWNER_1_ADMIN))
+        .when()
+        .delete("/spaces/x-psql-test-ext/features/" + feature.getId() + "?context=super")
+        .then()
+        .statusCode(FORBIDDEN.code());
   }
 
   @Test

--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/TestCompositeSpace.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/TestCompositeSpace.java
@@ -21,15 +21,11 @@ package com.here.xyz.hub.rest;
 
 import static com.here.xyz.hub.rest.Api.HeaderValues.APPLICATION_JSON;
 import static com.jayway.restassured.RestAssured.given;
-import static io.netty.handler.codec.http.HttpResponseStatus.NO_CONTENT;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static org.hamcrest.Matchers.equalTo;
 
-import com.jayway.restassured.response.ValidatableResponse;
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
 
 public class TestCompositeSpace extends TestSpaceWithFeature {
 
@@ -41,7 +37,7 @@ public class TestCompositeSpace extends TestSpaceWithFeature {
     createSpaceWithExtension("x-psql-test");
     createSpaceWithExtension("x-psql-test-ext");
 
-    // FIXME avoid 504
+    //FIXME: in order to get the extending space to be created, a read or write operation must be executed, otherwise a 504 is returned
     getFeature("x-psql-test", "F1");
     getFeature("x-psql-test-2", "F1");
     getFeature("x-psql-test-ext", "F1");

--- a/xyz-models/src/main/java/com/here/xyz/events/ContextAwareEvent.java
+++ b/xyz-models/src/main/java/com/here/xyz/events/ContextAwareEvent.java
@@ -11,6 +11,7 @@ public abstract class ContextAwareEvent<T extends Event> extends Event<T> {
 
   public enum SpaceContext {
     EXTENSION,
+    SUPER,
     DEFAULT;
 
     public static SpaceContext of(String value) {


### PR DESCRIPTION
… of a composite space

- Add a new value "super" for query param "context" to read from the space being extended through a composite space
- Writing / Deleting through that new context is not permitted through a composite space
- Add tests for new super context

Signed-off-by: Benjamin Rögner <benjamin.roegner@here.com>