### PR TITLE
Preparations for versioning in PSQL Connector

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/config/DynamoSpaceConfigClient.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/config/DynamoSpaceConfigClient.java
@@ -168,6 +168,9 @@ public class DynamoSpaceConfigClient extends SpaceConfigClient {
   private void storeSpaceSync(Space space, Promise p) {
     final Map<String, Object> itemData = XyzSerializable.STATIC_MAPPER.get().convertValue(space, new TypeReference<Map<String, Object>>() {});
     itemData.put("shared", space.isShared() ? 1 : 0); //Shared value must be a number because it's also used as index
+    //NOTE: The following is a temporary implementation to keep backwards compatibility for non-versioned spaces
+    if (itemData.get("versionsToKeep") != null && itemData.get("versionsToKeep") instanceof Integer && ((int) itemData.get("versionsToKeep")) == 0)
+      itemData.remove("versionsToKeep");
     sanitize(itemData);
     spaces.putItem(Item.fromMap(itemData));
     p.complete();


### PR DESCRIPTION
Preparations for intermediate deployment phase0:
- Add backwards compatibility also on store() of space config, so that for versionsToKeep == 0 the attribute won't be written

Signed-off-by: Benjamin Rögner <benjamin.roegner@here.com>