### PR TITLE
Preparations for versioning in PSQL Connector

### DIFF
--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseHandler.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseHandler.java
@@ -1127,7 +1127,7 @@ public abstract class DatabaseHandler extends StorageConnector {
         stmt.addBatch(buildCreateIndexQuery(schema, table, "version", "BTREE").substitute().text());
         stmt.addBatch(buildCreateIndexQuery(schema, table, Arrays.asList("id", "version"), "BTREE").substitute().text());
         stmt.addBatch(buildCreateIndexQuery(schema, table, Arrays.asList("id", "version", "next_version"), "BTREE").substitute().text());
-        stmt.addBatch(buildCreateIndexQuery(schema, table, "operation", "HASH").substitute().text());
+        stmt.addBatch(buildCreateIndexQuery(schema, table, "operation", "BTREE").substitute().text());
     }
 
     private static SQLQuery buildCreateIndexQuery(String schema, String table, String columnName, String method) {


### PR DESCRIPTION
- Use type BTREE for index on "operation" instead of HASH

Signed-off-by: Benjamin Rögner <benjamin.roegner@here.com>