### PR TITLE
Preparations for versioning in PSQL Connector

### DIFF
--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseMaintainer.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseMaintainer.java
@@ -47,7 +47,7 @@ public class DatabaseMaintainer {
     private static final Logger logger = LogManager.getLogger();
 
     /** Is used to check against xyz_ext_version() */
-    public static final int XYZ_EXT_VERSION = 150;
+    public static final int XYZ_EXT_VERSION = 151;
 
     public static final int H3_CORE_VERSION = 107;
 

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseWriter.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseWriter.java
@@ -84,8 +84,7 @@ public class DatabaseWriter {
 
         try {
             //NOTE: The following is a temporary implementation for backwards compatibility for old table structures
-            boolean oldTableStyle = DatabaseHandler.readVersionsToKeep(event) < 1;
-            if ((oldTableStyle || event.isEnableGlobalVersioning()) && version != -1)
+            if (event.isEnableGlobalVersioning() && version != -1)
                 feature.getProperties().getXyzNamespace().setVersion(version);
             json = feature.serialize();
         } finally {

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/SQLQueryBuilder.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/SQLQueryBuilder.java
@@ -738,11 +738,11 @@ public class SQLQueryBuilder {
     //NOTE: The following is a temporary implementation for backwards compatibility for old table structures
     boolean oldTableStyle = DatabaseHandler.readVersionsToKeep(event) < 1;
     boolean withDeletedColumn = oldTableStyle && DatabaseHandler.isForExtendingSpace(event);
-    return setWriteQueryComponents(new SQLQuery("${{geoWith}} INSERT INTO ${schema}.${table} (" + (oldTableStyle ? "" : "id, version, operation, ") + "jsondata, geo" + (withDeletedColumn ? ", deleted" : "") + ") "
+    return setWriteQueryComponents(new SQLQuery("${{geoWith}} INSERT INTO ${schema}.${table} (id, version, operation, jsondata, geo" + (withDeletedColumn ? ", deleted" : "") + ") "
         + "VALUES("
-        + (oldTableStyle ? "" : "#{id}, "
+        + "#{id}, "
         + "#{version}, "
-        + "#{operation}, ")
+        + "#{operation}, "
         + "#{jsondata}::jsonb, "
         + "${{geo}}"
         //NOTE: The following is a temporary implementation for backwards compatibility for old table structures
@@ -755,8 +755,8 @@ public class SQLQueryBuilder {
     boolean oldTableStyle = DatabaseHandler.readVersionsToKeep(event) < 1;
     boolean withDeletedColumn = oldTableStyle && DatabaseHandler.isForExtendingSpace(event);
       return setWriteQueryComponents(new SQLQuery("${{geoWith}} UPDATE ${schema}.${table} SET "
-          + (oldTableStyle ? "" : "version = #{version}, "
-          + "operation = #{operation}, ")
+          + "version = #{version}, "
+          + "operation = #{operation}, "
           + "jsondata = #{jsondata}::jsonb, "
           + "geo = (${{geo}}) "
           //NOTE: The following is a temporary implementation for backwards compatibility for old table structures

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/helpers/GetTablesWithComment.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/helpers/GetTablesWithComment.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2017-2022 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.xyz.psql.query.helpers;
+
+import com.here.xyz.connectors.ErrorResponseException;
+import com.here.xyz.psql.DatabaseHandler;
+import com.here.xyz.psql.QueryRunner;
+import com.here.xyz.psql.SQLQuery;
+import com.here.xyz.psql.query.helpers.GetTablesWithComment.GetTablesWithCommentInput;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class GetTablesWithComment extends QueryRunner<GetTablesWithCommentInput, List<String>> {
+
+  public GetTablesWithComment(GetTablesWithCommentInput input, DatabaseHandler dbHandler)
+      throws SQLException, ErrorResponseException {
+    super(input, dbHandler);
+  }
+
+  @Override
+  protected SQLQuery buildQuery(GetTablesWithCommentInput input) throws SQLException, ErrorResponseException {
+    return new SQLQuery("SELECT t.table_name "
+        + "FROM information_schema.tables t "
+        + "         INNER JOIN pg_catalog.pg_class pgc "
+        + "         ON t.table_name = pgc.relname "
+        + "WHERE "
+        + "  t.table_name != 'spatial_ref_sys' "
+        + "  AND t.table_name NOT LIKE '%_hst' "
+        + "  AND t.table_type = 'BASE TABLE' "
+        + "  AND t.table_schema = 'public' "
+        + "  AND reltuples < #{tableSizeLimit} "
+        + "  AND (${{comment}} ${{commentComparison}}) "
+        + "LIMIT #{limit}")
+        .withQueryFragment("comment", "pg_catalog.obj_description(pgc.oid, 'pg_class')")
+        .withQueryFragment("commentComparison",
+            input.comment == null ? "IS " + (input.exists ? "" : "NOT ") + "NULL" : (input.exists ? "= " : "IS NULL OR ${{comment}} != #{comment}"))
+        .withNamedParameter("limit", input.limit)
+        .withNamedParameter("comment", input.comment)
+        .withNamedParameter("tableSizeLimit", input.tableSizeLimit);
+  }
+
+  @Override
+  public List<String> handle(ResultSet rs) throws SQLException {
+    final ArrayList<String> result = new ArrayList<>();
+    while (rs.next())
+      result.add(rs.getString("table_name"));
+    return result;
+  }
+
+  public static class GetTablesWithCommentInput {
+
+    private String comment;
+    private boolean exists;
+
+    private int tableSizeLimit;
+    private int limit;
+
+    public GetTablesWithCommentInput(String comment, boolean exists, int tableSizeLimit, int limit) {
+      this.comment = comment;
+      this.exists = exists;
+      this.tableSizeLimit = tableSizeLimit;
+      this.limit = limit;
+    }
+  }
+}

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/helpers/SetVersion.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/helpers/SetVersion.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2017-2022 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.xyz.psql.query.helpers;
+
+import static com.here.xyz.psql.query.helpers.GetNextVersion.VERSION_SEQUENCE_SUFFIX;
+
+import com.here.xyz.connectors.ErrorResponseException;
+import com.here.xyz.events.ModifyFeaturesEvent;
+import com.here.xyz.psql.DatabaseHandler;
+import com.here.xyz.psql.QueryRunner;
+import com.here.xyz.psql.SQLQuery;
+import com.here.xyz.psql.query.helpers.SetVersion.SetVersionInput;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class SetVersion extends QueryRunner<SetVersionInput, Void> {
+
+  public SetVersion(SetVersionInput input, DatabaseHandler dbHandler) throws SQLException, ErrorResponseException {
+    super(input, dbHandler);
+  }
+
+  @Override
+  protected SQLQuery buildQuery(SetVersionInput input) throws SQLException, ErrorResponseException {
+    return new SQLQuery("SELECT setval('${schema}.${sequence}', #{version}, true)")
+        .withVariable(SCHEMA, getSchema())
+        .withVariable("sequence", dbHandler.getConfig().readTableFromEvent(input.event) + VERSION_SEQUENCE_SUFFIX)
+        .withNamedParameter("version", input.version);
+  }
+
+  @Override
+  public Void handle(ResultSet rs) throws SQLException {
+    return null;
+  }
+
+  public static class SetVersionInput {
+    private ModifyFeaturesEvent event;
+    private long version;
+
+    public SetVersionInput(ModifyFeaturesEvent event, long version) {
+      this.event = event;
+      this.version = version;
+    }
+  }
+}


### PR DESCRIPTION
Preparations for intermediate deployment phase1:
- Add implementation for one time action which fills the new empty columns which have been created on old tables during phase0
- Add new QueryRunner helper "GetTablesWithComment" which allows fetching all tables which (do not) have a specified comment
- Add new temporary QueryRunner helper "SetVersion" which allows (re-)setting the version sequence of a space table in order to enable synchronizing it with the legacy history sequence
- Write to old tables (versionsToKeep < 1) in the new way (including new columns), but without increasing version
- For all spaces which have enabled the obsolete global versioning (enableGlobalVersioning=true) synchronize the value of the new version sequence with the old history sequence in order to enable next phase of migration
- Update legacy history trigger (xyz_trigger_historywriter_versioned) to ignore updates which are performed by the migration or by changing only the next_version field of a row. Update xyz_ext version to 151

Signed-off-by: Benjamin Rögner <benjamin.roegner@here.com>