### PR TITLE
Preparations for versioning in PSQL Connector

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/Service.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/Service.java
@@ -750,7 +750,7 @@ public class Service extends Core {
     /**
      * Global limit for the maximum amount of versions to keep per space.
      */
-    public long MAX_VERSIONS_TO_KEEP = 1_000_000;
+    public long MAX_VERSIONS_TO_KEEP = 1_000_000_000;
 
     /**
      * Flag indicating whether the author should be retrieved from the custom header Author.

--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/CreateSpaceApiIT.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/CreateSpaceApiIT.java
@@ -393,7 +393,7 @@ public class CreateSpaceApiIT extends TestSpaceWithFeature {
     final ValidatableResponse response = given()
         .contentType(APPLICATION_JSON)
         .headers(getAuthHeaders(AuthProfile.ACCESS_OWNER_1_NO_ADMIN))
-        .body("{\"title\":\"test\", \"versionsToKeep\":1000001}")
+        .body("{\"title\":\"test\", \"versionsToKeep\":1000000001}")
         .when()
         .post("/spaces")
         .then();

--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/TestSpaceWithFeature.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/TestSpaceWithFeature.java
@@ -277,7 +277,7 @@ public class TestSpaceWithFeature extends TestWithSpaceCleanup {
   }
 
   protected void validateXyzNs(JsonObject xyzNs) {
-    String[] allowedFieldNames = {"space", "createdAt", "updatedAt", "tags", "author"};
+    String[] allowedFieldNames = {"space", "createdAt", "updatedAt", "tags", "author", "version"};
     assertThat(xyzNs.fieldNames(), everyItem(isIn(allowedFieldNames)));
   }
 

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseMaintainer.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseMaintainer.java
@@ -47,7 +47,7 @@ public class DatabaseMaintainer {
     private static final Logger logger = LogManager.getLogger();
 
     /** Is used to check against xyz_ext_version() */
-    public static final int XYZ_EXT_VERSION = 151;
+    public static final int XYZ_EXT_VERSION = 152;
 
     public static final int H3_CORE_VERSION = 107;
 

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseWriter.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseWriter.java
@@ -254,7 +254,7 @@ public class DatabaseWriter {
         int version) {
         //If versioning is activated for the space, always only perform inserts
         if (event.getVersionsToKeep() > 1)
-            return SQLQueryBuilder.buildInsertStmtQuery(dbHandler, event);
+            return SQLQueryBuilder.buildMultiModalInsertStmtQuery(dbHandler, event);
         switch (action) {
             case INSERT:
                 return SQLQueryBuilder.buildInsertStmtQuery(dbHandler, event);

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/SQLQueryBuilder.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/SQLQueryBuilder.java
@@ -737,6 +737,14 @@ public class SQLQueryBuilder {
         return new SQLQuery("SELECT idx_available FROM "+ ModifySpace.IDX_STATUS_TABLE+" WHERE spaceid=? AND count >=?", space, BIG_SPACE_THRESHOLD);
     }
 
+  protected static SQLQuery buildMultiModalInsertStmtQuery(DatabaseHandler dbHandler, ModifyFeaturesEvent event) {
+      return new SQLQuery("SELECT xyz_write_versioned_modification_operation(#{id}, #{version}, #{operation}, #{jsondata}, #{geo}, "
+          + "#{schema}, #{table}, #{concurrencyCheck})")
+          .withNamedParameter("schema", dbHandler.config.getDatabaseSettings().getSchema())
+          .withNamedParameter("table", dbHandler.config.readTableFromEvent(event))
+          .withNamedParameter("concurrencyCheck", event.getEnableUUID());
+  }
+
   protected static SQLQuery buildInsertStmtQuery(DatabaseHandler dbHandler, ModifyFeaturesEvent event) {
     //NOTE: The following is a temporary implementation for backwards compatibility for old table structures
     boolean oldTableStyle = DatabaseHandler.readVersionsToKeep(event) < 1;

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeaturesById.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeaturesById.java
@@ -34,11 +34,11 @@ public class GetFeaturesById extends GetFeatures<GetFeaturesByIdEvent> {
   @Override
   protected SQLQuery buildQuery(GetFeaturesByIdEvent event) throws SQLException {
     String[] idArray = event.getIds().toArray(new String[0]);
-    String filterWhereClause = "jsondata->>'id' = ANY(#{ids})";
+    String filterWhereClause = "${{idColumn}} = ANY(#{ids})";
 
-    SQLQuery query = super.buildQuery(event);
-    query.setQueryFragment("filterWhereClause", filterWhereClause);
-    query.setNamedParameter("ids", idArray);
-    return query;
+    return super.buildQuery(event)
+        .withQueryFragment("filterWhereClause", filterWhereClause)
+        .withQueryFragment("idColumn", buildIdFragment(event))
+        .withNamedParameter("ids", idArray);
   }
 }

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/IterateFeatures.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/IterateFeatures.java
@@ -240,7 +240,7 @@ public class IterateFeatures extends SearchForFeatures<IterateFeaturesEvent> {
 
     String orderByClause = buildOrderByClause(event);
     List<String> continuationWhereClauses = event.getHandle() == null ? Collections.singletonList("")
-        : buildContinuationConditions(event.getHandle());
+        : buildContinuationConditions(event);
 
     SQLQuery partialQuery = new SQLQuery("");
 
@@ -326,13 +326,13 @@ public class IterateFeatures extends SearchForFeatures<IterateFeaturesEvent> {
     List<String> sortby = event.getHandle() != null ? convHandle2sortbyList(event.getHandle()) : event.getSort();
 
     if (sortby == null || sortby.size() == 0)
-     return isPartOverI(event) ? "ORDER BY i" : "ORDER BY (jsondata->>'id')"; // in case no sort is specified
+     return isPartOverI(event) ? "ORDER BY i" : "ORDER BY (" + buildIdFragment(event) + ")"; // in case no sort is specified
 
     if( sortby.size() == 1 && sortby.get(0).toLowerCase().startsWith("id") ) // usecase order by id
      if( sortby.get(0).equalsIgnoreCase( "id:desc" ) )
-      return "ORDER BY (jsondata->>'id') DESC";
+      return "ORDER BY (" + buildIdFragment(event) + ") DESC";
      else
-      return "ORDER BY (jsondata->>'id')";
+      return "ORDER BY (" + buildIdFragment(event) + ")";
 
     String orderByClause = "", direction = "";
 
@@ -343,7 +343,7 @@ public class IterateFeatures extends SearchForFeatures<IterateFeaturesEvent> {
      orderByClause += DhString.format("%s %s %s", (orderByClause.length() == 0 ? "" : ","), jpathFromSortProperty(s), direction);
     }
 
-    return DhString.format("ORDER BY %s, (jsondata->>'id') %s", orderByClause, direction); // id is always last sort crit with sort direction as last (most inner) index
+    return DhString.format("ORDER BY %s, (" + buildIdFragment(event) + ") %s", orderByClause, direction); // id is always last sort crit with sort direction as last (most inner) index
   }
 
   private static List<String> convHandle2sortbyList( String handle )
@@ -363,8 +363,9 @@ public class IterateFeatures extends SearchForFeatures<IterateFeaturesEvent> {
     return event.getPart() != null && event.getSort() == null && !hasSearch;
   }
 
-  private static List<String> buildContinuationConditions( String handle )
+  private static List<String> buildContinuationConditions(IterateFeaturesEvent event)
   {
+    String handle = event.getHandle();
    List<String> ret = new ArrayList<String>(),
                 sortby = convHandle2sortbyList( handle );
    JSONObject h = new JSONObject(handle);
@@ -378,7 +379,7 @@ public class IterateFeatures extends SearchForFeatures<IterateFeaturesEvent> {
    }
 
    if( h.has("h") ) // start handle partitioned by id
-   { ret.add(DhString.format(" and (jsondata->>'id') >= '%s'",h.get("h").toString()));
+   { ret.add(DhString.format(" and (" + buildIdFragment(event) + ") >= '%s'",h.get("h").toString()));
      return ret;
    }
 
@@ -400,7 +401,7 @@ public class IterateFeatures extends SearchForFeatures<IterateFeaturesEvent> {
       sqlWhereContinuation += DhString.format(" and %s is null", jpathFromSortProperty(s) );
     }
 
-   sqlWhereContinuation += DhString.format(" and (jsondata->>'id') %s '%s'", ( descendingLast ? "<" : ">" ) ,h.get("h0").toString());
+   sqlWhereContinuation += DhString.format(" and (" + buildIdFragment(event) + ") %s '%s'", ( descendingLast ? "<" : ">" ) ,h.get("h0").toString());
 
    ret.add( sqlWhereContinuation );
 

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/helpers/FetchExistingIds.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/helpers/FetchExistingIds.java
@@ -38,11 +38,11 @@ public class FetchExistingIds extends QueryRunner<FetchIdsInput, List<String>> {
 
   @Override
   protected SQLQuery buildQuery(FetchIdsInput input) throws SQLException, ErrorResponseException {
-    SQLQuery query = new SQLQuery("SELECT jsondata->>'id' id FROM ${schema}.${table} WHERE jsondata->>'id' = ANY(#{ids})");
-    query.setVariable(SCHEMA, getSchema());
-    query.setVariable(TABLE, input.targetTable);
-    query.setNamedParameter("ids", input.idsToFetch.toArray(new String[0]));
-    return query;
+    return new SQLQuery("SELECT ${{idColumn}} id FROM ${schema}.${table} WHERE ${{idColumn}} = ANY(#{ids})")
+        .withVariable(SCHEMA, getSchema())
+        .withVariable(TABLE, input.targetTable)
+        .withNamedParameter("ids", input.idsToFetch.toArray(new String[0]))
+        .withQueryFragment("idColumn", input.useLegacyIdColumn ? "jsondata->>'id'" : "id");
   }
 
   @Override
@@ -54,11 +54,14 @@ public class FetchExistingIds extends QueryRunner<FetchIdsInput, List<String>> {
   }
 
   public static class FetchIdsInput {
-    public FetchIdsInput(String targetTable, Collection<String> idsToFetch) {
+    public FetchIdsInput(String targetTable, Collection<String> idsToFetch, boolean useLegacyIdColumn) {
       this.targetTable = targetTable;
       this.idsToFetch = idsToFetch;
+      this.useLegacyIdColumn = useLegacyIdColumn;
     }
     String targetTable;
     Collection<String> idsToFetch;
+
+    boolean useLegacyIdColumn;
   }
 }

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/helpers/GetTablesWithComment.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/helpers/GetTablesWithComment.java
@@ -52,7 +52,7 @@ public class GetTablesWithComment extends QueryRunner<GetTablesWithCommentInput,
         + "LIMIT #{limit}")
         .withQueryFragment("comment", "pg_catalog.obj_description(pgc.oid, 'pg_class')")
         .withQueryFragment("commentComparison",
-            input.comment == null ? "IS " + (input.exists ? "" : "NOT ") + "NULL" : (input.exists ? "= " : "IS NULL OR ${{comment}} != #{comment}"))
+            input.comment == null ? "IS " + (input.exists ? "" : "NOT ") + "NULL" : (input.exists ? "= #{comment}" : "IS NULL OR ${{comment}} != #{comment}"))
         .withNamedParameter("limit", input.limit)
         .withNamedParameter("comment", input.comment)
         .withNamedParameter("tableSizeLimit", input.tableSizeLimit);

--- a/xyz-psql-connector/src/main/resources/xyz_ext.sql
+++ b/xyz-psql-connector/src/main/resources/xyz_ext.sql
@@ -153,7 +153,7 @@ DROP FUNCTION IF EXISTS xyz_statistic_history(text, text);
 CREATE OR REPLACE FUNCTION xyz_ext_version()
   RETURNS integer AS
 $BODY$
- select 151
+ select 152
 $BODY$
   LANGUAGE sql IMMUTABLE;
 ----------
@@ -3123,5 +3123,68 @@ begin
   return 0.0;
 end;
 $body$;
+------------------------------------------------
+------------------------------------------------
+CREATE OR REPLACE FUNCTION max_bigint() RETURNS BIGINT AS
+$BODY$
+BEGIN
+    RETURN 9223372036854775807::BIGINT;
+END
+$BODY$
+LANGUAGE plpgsql VOLATILE;
+------------------------------------------------
+------------------------------------------------
+CREATE OR REPLACE FUNCTION operation_2_human_readable(operation CHAR) RETURNS TEXT AS
+$BODY$
+BEGIN
+    RETURN CASE WHEN operation = 'I' THEN 'insert' ELSE (CASE WHEN operation = 'U' THEN 'update' ELSE 'delete' END) END;
+END
+$BODY$
+    LANGUAGE plpgsql VOLATILE;
+------------------------------------------------
+------------------------------------------------
+CREATE OR REPLACE FUNCTION xyz_write_versioned_modification_operation(id TEXT, version BIGINT, operation CHAR, jsondata JSONB, geo GEOMETRY, schema TEXT, tableName TEXT, concurrencyCheck BOOLEAN)
+    RETURNS VOID AS
+$BODY$
+    DECLARE
+        base_version BIGINT := (jsondata->'properties'->'@ns:com:here:xyz'->>'version')::BIGINT;
+        updated_rows INTEGER;
+    BEGIN
+        EXECUTE
+           format('INSERT INTO %s.%s (id, version, operation, jsondata, geo) VALUES (%L, %L, %L, %L, %L)',
+               schema, tableName, id, version, operation, jsondata, CASE WHEN geo::geometry IS NULL THEN NULL ELSE ST_Force3D(ST_GeomFromWKB(geo::BYTEA, 4326)) END);
+
+        IF operation != 'I' THEN
+            IF concurrencyCheck THEN
+                IF base_version IS NULL THEN
+                    RAISE EXCEPTION 'Error while trying to % feature with ID % in version %.', operation_2_human_readable(operation), id, version
+                        USING HINT = 'Base version is missing. Concurrency check can not be performed.';
+                END IF;
+
+                EXECUTE
+                    format('UPDATE %s.%s SET next_version = %L WHERE id = %L AND next_version = %L AND version = %L',
+                           schema, tableName, version, id, max_bigint(), base_version);
+
+                GET DIAGNOSTICS updated_rows = ROW_COUNT;
+                IF updated_rows != 1 THEN
+                    RAISE EXCEPTION 'Conflict while trying to % feature with ID % in version %.', operation_2_human_readable(operation), id, version
+                        USING HINT = 'Base version ' || base_version::TEXT || ' is not matching the current HEAD version.';
+                END IF;
+            ELSE
+                EXECUTE
+                    format('UPDATE %s.%s SET next_version = %L WHERE id = %L AND next_version = %L AND version < %L',
+                           schema, tableName, version, id, max_bigint(), version);
+
+                GET DIAGNOSTICS updated_rows = ROW_COUNT;
+                IF updated_rows != 1 THEN
+                    -- This can only happen if the HEAD version of the feature was deleted in the table for some reason
+                    RAISE EXCEPTION 'Unexpected error while trying to % feature with ID % in version %.', operation_2_human_readable(operation), id, version
+                        USING HINT = 'Previous (HEAD) version of the feature is missing.';
+                END IF;
+            END IF;
+        END IF;
+    END
+$BODY$
+LANGUAGE plpgsql VOLATILE;
 ------------------------------------------------
 ------------------------------------------------

--- a/xyz-psql-connector/src/test/java/com/here/xyz/psql/PSQLIndexIT.java
+++ b/xyz-psql-connector/src/test/java/com/here/xyz/psql/PSQLIndexIT.java
@@ -287,7 +287,7 @@ public class PSQLIndexIT extends PSQLAbstractIT {
                         assertEquals("CREATE INDEX "+idx_name+" ON public.foo USING btree (geometrytype(geo))",indexdef);
                         break;
                     case "id" :
-                        assertEquals("CREATE UNIQUE INDEX idx_foo_id ON public.foo USING btree (((jsondata ->> 'id'::text)))",indexdef);
+                        assertEquals("CREATE INDEX idx_foo_id ON public.foo USING btree (((jsondata ->> 'id'::text)))",indexdef);
                         break;
                     case "geo" :
                         assertEquals("CREATE INDEX idx_foo_geo ON public.foo USING gist (geo)",indexdef);

--- a/xyz-psql-connector/src/test/java/com/here/xyz/psql/PSQLUuidIT.java
+++ b/xyz-psql-connector/src/test/java/com/here/xyz/psql/PSQLUuidIT.java
@@ -372,32 +372,31 @@ public class PSQLUuidIT extends PSQLAbstractIT {
         else
             assertEquals(DatabaseWriter.DELETE_ERROR_NOT_EXISTS, failure1.get("message"));
 
-        // =========== INSERT EXISTING FEATURE ==========
-        //Stream
         Feature existing = insertRequestCollection.getFeatures().get(0);
         existing.getProperties().getXyzNamespace().setPuuid(existing.getProperties().getXyzNamespace().getUuid());
-
-        mfevent.setInsertFeatures(new ArrayList<Feature>(){{add(existing);}});
         mfevent.setDeleteFeatures(new HashMap<>());
-        mfevent.setTransaction(false);
-        response = invokeLambda(mfevent.serialize());
-        responseCollection = XyzSerializable.deserialize(response);
-        assertEquals(existing.getId(), responseCollection.getFailed().get(0).getId());
-        assertEquals(DatabaseWriter.INSERT_ERROR_GENERAL, responseCollection.getFailed().get(0).getMessage());
-        assertEquals(0,responseCollection.getFeatures().size());
-        assertNull(responseCollection.getUpdated());
-        assertNull(responseCollection.getInserted());
-        assertNull(responseCollection.getDeleted());
-
-        //Transactional
-        mfevent.setTransaction(true);
-        response = invokeLambda(mfevent.serialize());
-
-        errorResponse = XyzSerializable.deserialize(response);
-        assertEquals(XyzError.CONFLICT, errorResponse.getError());
-        failedList = ((ArrayList)errorResponse.getErrorDetails().get("FailedList"));
-        assertEquals(0, failedList.size());
-        assertEquals(DatabaseWriter.TRANSACTION_ERROR_GENERAL, errorResponse.getErrorMessage());
+//        // =========== INSERT EXISTING FEATURE ==========
+//        //Stream
+//        mfevent.setInsertFeatures(new ArrayList<Feature>(){{add(existing);}});
+//        mfevent.setTransaction(false);
+//        response = invokeLambda(mfevent.serialize());
+//        responseCollection = XyzSerializable.deserialize(response);
+//        assertEquals(existing.getId(), responseCollection.getFailed().get(0).getId());
+//        assertEquals(DatabaseWriter.INSERT_ERROR_GENERAL, responseCollection.getFailed().get(0).getMessage());
+//        assertEquals(0,responseCollection.getFeatures().size());
+//        assertNull(responseCollection.getUpdated());
+//        assertNull(responseCollection.getInserted());
+//        assertNull(responseCollection.getDeleted());
+//
+//        //Transactional
+//        mfevent.setTransaction(true);
+//        response = invokeLambda(mfevent.serialize());
+//
+//        errorResponse = XyzSerializable.deserialize(response);
+//        assertEquals(XyzError.CONFLICT, errorResponse.getError());
+//        failedList = ((ArrayList)errorResponse.getErrorDetails().get("FailedList"));
+//        assertEquals(0, failedList.size());
+//        assertEquals(DatabaseWriter.TRANSACTION_ERROR_GENERAL, errorResponse.getErrorMessage());
 
         // =========== UPDATE NOT EXISTING FEATURE ==========
         //Stream

--- a/xyz-psql-connector/src/test/java/com/here/xyz/psql/PsqlOtaIT.java
+++ b/xyz-psql-connector/src/test/java/com/here/xyz/psql/PsqlOtaIT.java
@@ -8,18 +8,21 @@ import com.here.xyz.XyzSerializable;
 import com.here.xyz.events.OneTimeActionEvent;
 import com.here.xyz.responses.SuccessResponse;
 import com.here.xyz.responses.XyzResponse;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import org.json.JSONObject;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class PsqlOtaIT extends PSQLAbstractIT {
 
-  /*@BeforeClass
+  //@BeforeClass
   public static void init() throws Exception {
     initEnv(null);
   }
 
-  @Test
+  //@Test
   public void testOtaEvent() throws Exception {
     OneTimeActionEvent ota = new OneTimeActionEvent()
         .withPhase("test")
@@ -28,6 +31,6 @@ public class PsqlOtaIT extends PSQLAbstractIT {
     assertNotNull(response);
     assertNoErrorInResponse(response);
     assertTrue(response instanceof SuccessResponse);
-  }*/
+  }
 
 }


### PR DESCRIPTION
- Adjust validateXyzNs test to allow new "version" field
- Change createSpaceStatement() to create all space tables in the new format including new versioning constraints
- Change PSQLIndexIT#testOnDemandIndexContent() to not expect legacy id index to be UNIQUE anymore
- Change PSQLUuidIT#testModifyFeatureFailures() to not test for failing concurrent INSERTs with same id anymore
- Increase MAX_VERSIONS_TO_KEEP to 1_000_000_000 and adapt according test
- Implement new versioned INSERT function which is used to execute operations by writing them as inserts into the table and update the next_version field of the predecessor features; Use that function for INSERTs into spaces which have versioning enabled
- Increase xyz_ext version to 152

Preparations for intermediate deployment phaseX:
- Fix bug in GetTablesWithComment
- Change GetFeatures, GetFeaturesById, IterateFeatures, LoadFeatures, FetchExistingIds QRs & SQLQueryBuilder to distinguish between migrated / non-migrated spaces with regards to legacy id column
- Change GetFeatures QR to support injecting versions for composite spaces and inject version into NS for spaces where versionsToKeep > 0 (was only for >1 before)
- Change implementation of fetchOldStates() to distinguish between migrated / non-migrated spaces with regards to legacy id column
- Add implementation for OTA phaseX in DatabaseHandler
- Also add author column and according index
- Add backwards compatibility for old spaces to create legacy id-index uniquely
- Add test for OTA event
