### PR TITLE
Preparations for versioning in PSQL Connector

### DIFF
--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/httpconnector/HCMaintenanceTestIT.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/httpconnector/HCMaintenanceTestIT.java
@@ -281,7 +281,7 @@ public class HCMaintenanceTestIT {
                 .then()
                 .statusCode(OK.code())
                 .body("idxCreationFinished", equalTo(true))
-                .body("idxAvailable.size", equalTo(13))
+                .body("idxAvailable.size", equalTo(15))
                 .body("idxManual.searchableProperties.foo", equalTo(true))
                 .body("idxManual.sortableProperties", nullValue());
     }

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseHandler.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseHandler.java
@@ -1177,6 +1177,8 @@ public abstract class DatabaseHandler extends StorageConnector {
 
             //Add index for new author column
             stmt.addBatch(buildCreateIndexQuery(schema, tableName, "author", "BTREE").substitute().text());
+            //Add insex for next_version column
+            stmt.addBatch(buildCreateIndexQuery(schema, tableName, "next_version", "BTREE").substitute().text());
 
             //Add comment "phaseX_complete"
             SQLQuery setPhaseXCOmment = new SQLQuery("COMMENT ON TABLE ${schema}.${table} IS '" + OTA_PHASE_X_COMPLETE + "'")
@@ -1263,9 +1265,11 @@ public abstract class DatabaseHandler extends StorageConnector {
     private static void createVersioningIndices(Statement stmt, String schema, String table) throws SQLException {
         stmt.addBatch(buildCreateIndexQuery(schema, table, "id", "BTREE", "idx_" + table + "_idnew").substitute().text());
         stmt.addBatch(buildCreateIndexQuery(schema, table, "version", "BTREE").substitute().text());
+        stmt.addBatch(buildCreateIndexQuery(schema, table, "next_version", "BTREE").substitute().text());
         stmt.addBatch(buildCreateIndexQuery(schema, table, Arrays.asList("id", "version"), "BTREE").substitute().text());
         stmt.addBatch(buildCreateIndexQuery(schema, table, Arrays.asList("id", "version", "next_version"), "BTREE").substitute().text());
         stmt.addBatch(buildCreateIndexQuery(schema, table, "operation", "BTREE").substitute().text());
+        stmt.addBatch(buildCreateIndexQuery(schema, table, "author", "BTREE").substitute().text());
     }
 
     static SQLQuery buildCreateIndexQuery(String schema, String table, String columnName, String method) {

--- a/xyz-psql-connector/src/test/java/com/here/xyz/psql/PSQLIndexIT.java
+++ b/xyz-psql-connector/src/test/java/com/here/xyz/psql/PSQLIndexIT.java
@@ -184,9 +184,11 @@ public class PSQLIndexIT extends PSQLAbstractIT {
                 add("viz");
                 add("idnew");
                 add("version");
+                add("nextversion");
                 add("idversion");
                 add("idversionnextversion");
                 add("operation");
+                add("author");
             }};
 
             String sqlSpaceSchema = "(select schema_name::text from information_schema.schemata where schema_name in ('xyz','public') order by 1 desc limit 1)";


### PR DESCRIPTION
- Add index creation for author & next_version columns on space creation

Preparations for intermediate deployment phaseX:
- Add index creation for next_version columns to OTA phaseX

Signed-off-by: Benjamin Rögner <benjamin.roegner@here.com>