### PR TITLE
Limit that only changesets lower than HEAD can be deleted

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/task/FeatureTaskHandler.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/task/FeatureTaskHandler.java
@@ -162,7 +162,7 @@ public class FeatureTaskHandler {
    * If the value exists for a space and it points to a value > 0, that is the version of the latest write to that space as it has been
    * performed by this service-node.
    */
-  private static ConcurrentHashMap<String, Integer> latestSeenContentVersions = new ConcurrentHashMap<>();
+  private static ConcurrentHashMap<String, Long> latestSeenContentVersions = new ConcurrentHashMap<>();
 
   /**
    * Contains the amount of all in-flight requests for each storage ID.
@@ -512,9 +512,9 @@ public class FeatureTaskHandler {
     }
   }
 
-  static void setLatestSeenContentVersion(Space space, int version) {
+  static void setLatestSeenContentVersion(Space space, long version) {
     if ((space.isEnableHistory() || space.isEnableGlobalVersioning()) && version > 0)
-      latestSeenContentVersions.compute(space.getId(), (spaceId, currentVersion) -> Math.max(currentVersion != null ? currentVersion : 0,
+      latestSeenContentVersions.compute(space.getId(), (spaceId, currentVersion) -> Math.max(currentVersion != null ? currentVersion : 0L,
           version));
   }
 
@@ -538,7 +538,7 @@ public class FeatureTaskHandler {
       long timerId = Service.vertx.setTimer(interval, tId -> {
         timerMap.remove(nc.space.getId());
         ContentModifiedNotification cmn = new ContentModifiedNotification().withSpace(nc.space.getId());
-        Integer spaceVersion = latestSeenContentVersions.get(nc.space.getId());
+        Long spaceVersion = latestSeenContentVersions.get(nc.space.getId());
         if (spaceVersion != null) cmn.setSpaceVersion(spaceVersion);
         if (adminNotification) {
           //Send it to the modification SNS topic

--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/auth/AuthTestsIT.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/auth/AuthTestsIT.java
@@ -35,7 +35,11 @@ import static org.hamcrest.core.CombinableMatcher.either;
 
 import com.here.xyz.hub.rest.RestAssuredTest;
 import com.here.xyz.hub.util.Compression;
+import com.here.xyz.models.geojson.implementation.Feature;
+import com.here.xyz.models.geojson.implementation.FeatureCollection;
+import com.here.xyz.models.geojson.implementation.Properties;
 import com.jayway.restassured.response.ValidatableResponse;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.zip.DataFormatException;
 import org.junit.After;
@@ -1018,10 +1022,25 @@ public class AuthTestsIT extends RestAssuredTest {
         .statusCode(OK.code())
         .body("features.size()", equalTo(252));
 
+    //Write version 1
+    FeatureCollection changeset1 = new FeatureCollection().withFeatures(
+        Arrays.asList(
+            new Feature().withId("F1").withProperties(new Properties().with("name", "1b")),
+            new Feature().withId("F3").withProperties(new Properties().with("name", "3a"))
+        )
+    );
+    given()
+        .contentType(APPLICATION_JSON)
+        .headers(getAuthHeaders(AuthProfile.ACCESS_ALL))
+        .body(changeset1.toString())
+        .post("/spaces/x-auth-test-space/features")
+        .then()
+        .statusCode(OK.code());
+
     given()
         .headers(getAuthHeaders(AuthProfile.ACCESS_OWNER_1_ADMIN))
         .when()
-        .delete("/spaces/" + cleanUpId + "/changesets?version<10")
+        .delete("/spaces/" + cleanUpId + "/changesets?version<1")
         .then()
         .statusCode(NO_CONTENT.code());
   }

--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/ChangesetApiIT.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/ChangesetApiIT.java
@@ -193,7 +193,7 @@ public class ChangesetApiIT extends TestSpaceWithFeature {
   public void deleteChangesetsMaxValue() {
     given()
         .headers(getAuthHeaders(AuthProfile.ACCESS_ALL))
-        .delete("/spaces/" + cleanUpSpaceId + "/changesets?version<" + Long.MAX_VALUE)
+        .delete("/spaces/" + cleanUpSpaceId + "/changesets?version<4")
         .then()
         .statusCode(NO_CONTENT.code());
 
@@ -218,6 +218,21 @@ public class ChangesetApiIT extends TestSpaceWithFeature {
         .delete("/spaces/" + cleanUpSpaceId + "/changesets?version<-1")
         .then()
         .statusCode(BAD_REQUEST.code());
+  }
+
+  @Test
+  public void deleteChangesetsLargerThanHeadValue() {
+    given()
+        .headers(getAuthHeaders(AuthProfile.ACCESS_ALL))
+        .delete("/spaces/" + cleanUpSpaceId + "/changesets?version<5")
+        .then()
+        .statusCode(BAD_REQUEST.code());
+
+    given()
+        .headers(getAuthHeaders(AuthProfile.ACCESS_ALL))
+        .delete("/spaces/" + cleanUpSpaceId + "/changesets?version<4")
+        .then()
+        .statusCode(NO_CONTENT.code());
   }
 
   @Test

--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/ReadHistoryApiIT.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/ReadHistoryApiIT.java
@@ -650,7 +650,7 @@ public class ReadHistoryApiIT extends TestSpaceWithFeature {
 
   private void checkCompactChangesetVersionIntegrity(List<Feature> fList) {
     for (Feature f : fList) {
-      int v = f.getProperties().getXyzNamespace().getVersion();
+      long v = f.getProperties().getXyzNamespace().getVersion();
       if(v < 11) {
         assertEquals(true, f.getProperties().get("free"));
       }if(v == 11 || v == 12){

--- a/xyz-models/src/main/java/com/here/xyz/events/ContentModifiedNotification.java
+++ b/xyz-models/src/main/java/com/here/xyz/events/ContentModifiedNotification.java
@@ -35,20 +35,20 @@ public class ContentModifiedNotification extends Event<ContentModifiedNotificati
    * If the value exists and it points to a value > 0, that is the version of the latest write to that space as it has been performed by
    * the triggering service-node.
    */
-  private int spaceVersion;
+  private long spaceVersion;
 
   /**
    * @return The latest space-version as it has been seen on the service-node which sent this {@link ContentModifiedNotification}.
    */
-  public int getSpaceVersion() {
+  public long getSpaceVersion() {
     return spaceVersion;
   }
 
-  public void setSpaceVersion(int spaceVersion) {
+  public void setSpaceVersion(long spaceVersion) {
     this.spaceVersion = spaceVersion;
   }
 
-  public ContentModifiedNotification withSpaceVersion(int spaceVersion) {
+  public ContentModifiedNotification withSpaceVersion(long spaceVersion) {
     setSpaceVersion(spaceVersion);
     return this;
   }

--- a/xyz-models/src/main/java/com/here/xyz/models/geojson/implementation/FeatureCollection.java
+++ b/xyz-models/src/main/java/com/here/xyz/models/geojson/implementation/FeatureCollection.java
@@ -53,7 +53,7 @@ public class FeatureCollection extends XyzResponse<FeatureCollection> {
   private List<Feature> oldFeatures;
   private List<ModificationFailure> failed;
   @JsonInclude(Include.NON_EMPTY)
-  private Integer version;
+  private Long version;
 
   public FeatureCollection() {
     setFeatures(new ArrayList<>());
@@ -352,15 +352,15 @@ public class FeatureCollection extends XyzResponse<FeatureCollection> {
    * modification of the space - contains the (new) space-version which has just been written.
    * @return The new space-version after some modification
    */
-  public Integer getVersion() {
+  public Long getVersion() {
     return version;
   }
 
-  public void setVersion(int version) {
+  public void setVersion(long version) {
     this.version = version;
   }
 
-  public FeatureCollection withVersion(int version) {
+  public FeatureCollection withVersion(long version) {
     setVersion(version);
     return this;
   }

--- a/xyz-models/src/main/java/com/here/xyz/models/geojson/implementation/XyzNamespace.java
+++ b/xyz-models/src/main/java/com/here/xyz/models/geojson/implementation/XyzNamespace.java
@@ -81,7 +81,7 @@ public class XyzNamespace implements XyzSerializable {
    * The space-version of the feature within the space's versions.
    * Multiple features share the same space-version if they have been edited in one transaction.
    */
-  private int version = -1;
+  private long version = -1;
 
   /**
    * The author that changed the feature in the current version.
@@ -366,16 +366,16 @@ public class XyzNamespace implements XyzSerializable {
     return this;
   }
 
-  public int getVersion() {
+  public long getVersion() {
     return version;
   }
 
-  public void setVersion(int version) {
+  public void setVersion(long version) {
     this.version = version;
   }
 
   @SuppressWarnings("unused")
-  public XyzNamespace withVersion(int version) {
+  public XyzNamespace withVersion(long version) {
     setVersion(version);
     return this;
   }

--- a/xyz-models/src/main/java/com/here/xyz/responses/changesets/Changeset.java
+++ b/xyz-models/src/main/java/com/here/xyz/responses/changesets/Changeset.java
@@ -31,22 +31,22 @@ import com.here.xyz.responses.XyzResponse;
 @JsonInclude(Include.NON_DEFAULT)
 public class Changeset extends XyzResponse<Changeset> {
 
-    int version = -1;
+    long version = -1;
     String author;
     long createdAt;
     private FeatureCollection inserted;
     private FeatureCollection updated;
     private FeatureCollection deleted;
 
-    public int getVersion() {
+    public long getVersion() {
         return version;
     }
 
-    public void setVersion(int version) {
+    public void setVersion(long version) {
         this.version = version;
     }
 
-    public Changeset withVersion(int version) {
+    public Changeset withVersion(long version) {
         setVersion(version);
         return this;
     }

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseHandler.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseHandler.java
@@ -601,7 +601,7 @@ public abstract class DatabaseHandler extends StorageConnector {
             }
         }
 
-        int version = -1;
+        long version = -1;
         try {
           /** Include Old states */
           if (includeOldStates) {
@@ -626,9 +626,9 @@ public abstract class DatabaseHandler extends StorageConnector {
               SQLQuery query = SQLQueryBuilder.buildGetNextVersionQuery(table);
               version = executeQueryWithRetry(query, rs -> {
                     if (rs.next()) {
-                        return rs.getInt(1);
+                        return rs.getLong(1);
                     }
-                    return -1;
+                    return -1L;
                 }, false);   // false -> not use readreplica due to sequence 'update' statement: SELECT nextval("...._hst_seq"') and to make sure the read sequence value is the correct (most recent) one
               collection.setVersion(version);
               //NOTE: The following is a temporary implementation for backwards compatibility for old spaces with globalVersioning

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseMaintainer.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseMaintainer.java
@@ -276,7 +276,7 @@ public class DatabaseMaintainer {
         }
     }
 
-    public SQLQuery maintainHistory(TraceItem traceItem, String schema, String table, int currentVersion, int maxVersionCount){
+    public SQLQuery maintainHistory(TraceItem traceItem, String schema, String table, long currentVersion, int maxVersionCount){
         long maxAllowedVersion = currentVersion - maxVersionCount;
 
         if(maxAllowedVersion <= 0)

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseWriter.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseWriter.java
@@ -83,7 +83,7 @@ public class DatabaseWriter {
 
     protected static final String TRANSACTION_ERROR_GENERAL = "Transaction has failed";
 
-    private static PGobject featureToPGobject(ModifyFeaturesEvent event, final Feature feature, int version) throws SQLException {
+    private static PGobject featureToPGobject(ModifyFeaturesEvent event, final Feature feature, long version) throws SQLException {
         final Geometry geometry = feature.getGeometry();
         feature.setGeometry(null); // Do not serialize the geometry in the JSON object
 
@@ -104,7 +104,7 @@ public class DatabaseWriter {
         return jsonbObject;
     }
 
-    private static void fillDeleteQueryFromDeletion(SQLQuery query, Entry<String, String> deletion, ModifyFeaturesEvent event, int version)
+    private static void fillDeleteQueryFromDeletion(SQLQuery query, Entry<String, String> deletion, ModifyFeaturesEvent event, long version)
         throws SQLException {
         /*
         NOTE: If versioning is activated for the space, always only inserts are performed,
@@ -129,7 +129,7 @@ public class DatabaseWriter {
         }
     }
 
-    private static void fillUpdateQueryFromFeature(SQLQuery query, Feature feature, ModifyFeaturesEvent event, int version) throws SQLException {
+    private static void fillUpdateQueryFromFeature(SQLQuery query, Feature feature, ModifyFeaturesEvent event, long version) throws SQLException {
         if (feature.getId() == null)
             throw new WriteFeatureException(UPDATE_ERROR_ID_MISSING);
 
@@ -152,7 +152,7 @@ public class DatabaseWriter {
         fillInsertQueryFromFeature(query, UPDATE, feature, event, version);
     }
 
-    private static void fillInsertQueryFromFeature(SQLQuery query, ModificationType action, Feature feature, ModifyFeaturesEvent event, int version) throws SQLException {
+    private static void fillInsertQueryFromFeature(SQLQuery query, ModificationType action, Feature feature, ModifyFeaturesEvent event, long version) throws SQLException {
         query
             .withNamedParameter("id", feature.getId())
             .withNamedParameter("version", version)
@@ -178,7 +178,7 @@ public class DatabaseWriter {
 
     protected static void modifyFeatures(DatabaseHandler dbh, ModifyFeaturesEvent event, ModificationType action,
         FeatureCollection collection, List<FeatureCollection.ModificationFailure> fails, List inputData, Connection connection,
-        int version) throws SQLException, JsonProcessingException {
+        long version) throws SQLException, JsonProcessingException {
         boolean transactional = event.getTransaction();
         connection.setAutoCommit(!transactional);
         SQLQuery modificationQuery = buildModificationStmtQuery(dbh, event, action, version);
@@ -268,7 +268,7 @@ public class DatabaseWriter {
     }
 
     private static SQLQuery buildModificationStmtQuery(DatabaseHandler dbHandler, ModifyFeaturesEvent event, ModificationType action,
-        int version) {
+        long version) {
         //If versioning is activated for the space, always only perform inserts
         if (event.getVersionsToKeep() > 1)
             return SQLQueryBuilder.buildMultiModalInsertStmtQuery(dbHandler, event);
@@ -284,7 +284,7 @@ public class DatabaseWriter {
     }
 
     private static void fillModificationQueryFromInput(SQLQuery query, ModifyFeaturesEvent event, ModificationType action, Object inputDatum,
-        int version) throws SQLException {
+        long version) throws SQLException {
         switch (action) {
             case INSERT: {
                 fillInsertQueryFromFeature(query, action, (Feature) inputDatum, event, version);

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/QueryRunner.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/QueryRunner.java
@@ -46,12 +46,12 @@ public abstract class QueryRunner<E extends Object, R extends Object> implements
     query = buildQuery(input);
   }
 
-  public R run() throws SQLException {
+  public R run() throws SQLException, ErrorResponseException {
     prepareQuery();
     return dbHandler.executeQueryWithRetry(query, this, useReadReplica);
   }
 
-  public void write() throws SQLException {
+  public void write() throws SQLException, ErrorResponseException {
     prepareQuery();
     dbHandler.executeUpdateWithRetry(query);
   }

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/SQLQueryBuilder.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/SQLQueryBuilder.java
@@ -780,7 +780,7 @@ public class SQLQueryBuilder {
         .withVariable("table", dbHandler.config.readTableFromEvent(event));
   }
 
-  protected static SQLQuery buildDeleteStmtQuery(DatabaseHandler dbHandler, ModifyFeaturesEvent event, int version) {
+  protected static SQLQuery buildDeleteStmtQuery(DatabaseHandler dbHandler, ModifyFeaturesEvent event, long version) {
       //If versioning is enabled, perform an update instead of a deletion. The trigger will finally delete the row.
       //NOTE: The following is a temporary implementation for backwards compatibility for old table structures
       boolean oldTableStyle = DatabaseHandler.readVersionsToKeep(event) < 1;

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/helpers/GetHeadVersion.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/helpers/GetHeadVersion.java
@@ -27,25 +27,23 @@ import com.here.xyz.psql.query.XyzEventBasedQueryRunner;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
-public class GetNextVersion<E extends Event> extends XyzEventBasedQueryRunner<E, Long> {
+public class GetHeadVersion<E extends Event> extends XyzEventBasedQueryRunner<E, Long> {
 
-  public static final String VERSION_SEQUENCE_SUFFIX = "_version_seq";
-
-  public GetNextVersion(E input, DatabaseHandler dbHandler) throws SQLException, ErrorResponseException {
+  public GetHeadVersion(E input, DatabaseHandler dbHandler) throws SQLException, ErrorResponseException {
     super(input, dbHandler);
   }
 
   @Override
   protected SQLQuery buildQuery(E event) throws SQLException, ErrorResponseException {
-    return new SQLQuery("SELECT nextval('${schema}.${sequence}')")
+    return new SQLQuery("SELECT max(version) FROM ${schema}.${table}")
         .withVariable(SCHEMA, getSchema())
-        .withVariable("sequence", getDefaultTable(event) + VERSION_SEQUENCE_SUFFIX);
+        .withVariable(TABLE, getDefaultTable(event));
   }
 
   @Override
   public Long handle(ResultSet rs) throws SQLException {
     if (rs.next())
       return rs.getLong(1);
-    throw new SQLException("Unable to increase version sequence.");
+    throw new SQLException("Unable to retrieve HEAD version from space.");
   }
 }


### PR DESCRIPTION
- Add new GetHeadVersion QR which fetches the max version from the space table
- Change DeleteChangesets QR to throw an ILLEGAL_ARGUMENT error if the user tries to specify a value larger than HEAD (uses new GetHeadVersion QR)
- Add test deleteChangesetsLargerThanHeadValue() which tests that the above error is thrown
- Also refactor all occurrences of "version" to be long rather than int

Signed-off-by: Benjamin Rögner <benjamin.roegner@here.com>