### PR TITLE
Fix load features and conflict detection for spaces v2k>1:

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/task/ModifyFeatureOp.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/task/ModifyFeatureOp.java
@@ -100,12 +100,8 @@ public class ModifyFeatureOp extends ModifyOp<Feature, FeatureEntry> {
   }
 
   public static class FeatureEntry extends ModifyOp.Entry<Feature> {
-
-    public int inputVersion;
-
     public FeatureEntry(Map<String, Object> input, IfNotExists ifNotExists, IfExists ifExists, ConflictResolution cr) {
       super(input, ifNotExists, ifExists, cr);
-      inputVersion = getVersion(input);
     }
 
     @Override
@@ -141,6 +137,16 @@ public class ModifyFeatureOp extends ModifyOp<Feature, FeatureEntry> {
     }
 
     @Override
+    protected long getVersion(Map<String, Object> feature) {
+      try {
+        return new JsonObject(feature).getJsonObject(PROPERTIES).getJsonObject(XyzNamespace.XYZ_NAMESPACE).getLong(VERSION, -1L);
+      }
+      catch (Exception e) {
+        return -1;
+      }
+    }
+
+    @Override
     protected String getUuid(Feature input) {
       try {
         return input.getProperties().getXyzNamespace().getUuid();
@@ -172,15 +178,6 @@ public class ModifyFeatureOp extends ModifyOp<Feature, FeatureEntry> {
                     .put(VERSION, true)
                     .put(AUTHOR, true))
         ).mapTo(Map.class);
-
-    private int getVersion(Map<String, Object> input) {
-      try {
-        return new JsonObject(input).getJsonObject(PROPERTIES).getJsonObject(XyzNamespace.XYZ_NAMESPACE).getInteger(VERSION, 0);
-      }
-      catch (Exception e) {
-        return -1;
-      }
-    }
   }
 
   /**

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/task/ModifyOp.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/task/ModifyOp.java
@@ -230,10 +230,12 @@ public abstract class ModifyOp<T, K extends Entry<T>> {
     public boolean isModified;
     public Exception exception;
     public String inputUUID;
+    public long inputVersion;
     private Map<String, Object> resultMap;
 
     public Entry(Map<String, Object> input, IfNotExists ifNotExists, IfExists ifExists, ConflictResolution cr) {
       this.inputUUID = getUuid(input);
+      this.inputVersion = getVersion(input);
       this.input = filterMetadata(input);
       this.cr = cr;
       this.ifExists = ifExists;
@@ -259,6 +261,8 @@ public abstract class ModifyOp<T, K extends Entry<T>> {
     protected abstract String getUuid(T record);
 
     protected abstract String getUuid(Map<String, Object> record);
+
+    protected abstract long getVersion(Map<String, Object> record);
 
     public T patch() throws ModifyOpError, HttpException {
       final Map<String, Object> computedInput = toMap(base);

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/task/ModifySpaceOp.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/task/ModifySpaceOp.java
@@ -64,6 +64,11 @@ public class ModifySpaceOp extends ModifyOp<Space, SpaceEntry> {
     }
 
     @Override
+    protected long getVersion(Map<String, Object> record) {
+      return -1;
+    }
+
+    @Override
     public Map<String, Object> filterMetadata(Map<String, Object> map) {
       return filter(map, metadataFilter);
     }

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/LoadFeatures.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/LoadFeatures.java
@@ -51,9 +51,8 @@ public class LoadFeatures extends GetFeatures<LoadFeaturesEvent> {
       Map<String, String> idsWithVersions = new HashMap<>();
 
       idMap.forEach((k,v) -> {
-        if (v == null)
-          idsOnly.add(k);
-        else
+        idsOnly.add(k);
+        if (v != null)
           idsWithVersions.put(k, v);
       });
 


### PR DESCRIPTION
 - ignore empty arrays when transforming the load features input in the database
 - extract version from input to be used later in the conditional processing
 - always return at least HEAD version during LFE to keep equals semantic when comparing to old spaces
 - enable conflict detection by loading HEAD and base when enableUUID is true

Signed-off-by: Lucas Ceni <lucas.ceni@here.com>