### PR TITLE
Refactor processing of GetFeaturesByBBoxEvent in PSQL connector

### DIFF
--- a/xyz-connectors/src/main/java/com/here/xyz/connectors/ErrorResponseException.java
+++ b/xyz-connectors/src/main/java/com/here/xyz/connectors/ErrorResponseException.java
@@ -33,16 +33,33 @@ public class ErrorResponseException extends Exception {
     this(null, xyzError, errorMessage);
   }
 
+  /**
+   * @deprecated Please use constructor without stream ID (see above).
+   *  The stream ID will be attached just before the ErrorResponse is being sent.
+   * @param streamId
+   * @param xyzError
+   * @param errorMessage
+   */
+  @Deprecated
   public ErrorResponseException(String streamId, XyzError xyzError, String errorMessage) {
     super(errorMessage);
     createErrorResponse(streamId, xyzError, errorMessage);
   }
 
+  /**
+   * @deprecated Please use constructor without stream ID (see above).
+   *  The stream ID will be attached just before the ErrorResponse is being sent.
+   * @param streamId
+   * @param xyzError
+   * @param e
+   */
+  @Deprecated
   public ErrorResponseException(String streamId, XyzError xyzError, Exception e) {
     super(e);
     createErrorResponse(streamId, xyzError, e.getMessage());
   }
 
+  @Deprecated
   private void createErrorResponse(String streamId, XyzError xyzError, String errorMessage) {
     this.errorResponse = new ErrorResponse()
         .withStreamId(streamId)

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/Capabilities.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/Capabilities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2017-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ public class Capabilities {
     return skeys;
   }
 
-  public static boolean canSearchFor(String space, PropertiesQuery query, PSQLXyzConnector connector) {
+  public static boolean canSearchFor(String tableName, PropertiesQuery query, DatabaseHandler dbHandler) {
     if (query == null) {
       return true;
     }
@@ -75,7 +75,7 @@ public class Capabilities {
          return true;
 
         /** Check if custom Indices are available. Eg.: properties.foo1&f.foo2*/
-        List<String> indices = IndexList.getIndexList(space, connector);
+        List<String> indices = IndexList.getIndexList(tableName, dbHandler);
 
         /** The table has not many records - Indices are not required */
         if (indices == null) {
@@ -96,7 +96,7 @@ public class Capabilities {
       if(idx_check == keys.size())
         return true;
 
-      return IndexList.getIndexList(space, connector) == null;
+      return IndexList.getIndexList(tableName, dbHandler) == null;
     } catch (Exception e) {
       // In all cases, when something with the check went wrong, allow the search
       return true;

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseHandler.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseHandler.java
@@ -1517,10 +1517,10 @@ public abstract class DatabaseHandler extends StorageConnector {
     public FeatureCollection defaultFeatureResultSetHandler(ResultSet rs) throws SQLException
     { return _defaultFeatureResultSetHandler(rs,false); }
 
-    protected FeatureCollection defaultFeatureResultSetHandlerSkipIfGeomIsNull(ResultSet rs) throws SQLException
+    public FeatureCollection defaultFeatureResultSetHandlerSkipIfGeomIsNull(ResultSet rs) throws SQLException
     { return _defaultFeatureResultSetHandler(rs,true); }
 
-    protected BinaryResponse defaultBinaryResultSetHandler(ResultSet rs) throws SQLException {
+    public BinaryResponse defaultBinaryResultSetHandler(ResultSet rs) throws SQLException {
         BinaryResponse br = new BinaryResponse()
             .withMimeType(APPLICATION_VND_MAPBOX_VECTOR_TILE);
 

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseHandler.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseHandler.java
@@ -53,6 +53,7 @@ import com.here.xyz.psql.config.ConnectorParameters;
 import com.here.xyz.psql.config.DatabaseSettings;
 import com.here.xyz.psql.config.PSQLConfig;
 import com.here.xyz.psql.query.ExtendedSpace;
+import com.here.xyz.psql.query.GetFeaturesByBBox;
 import com.here.xyz.psql.query.ModifySpace;
 import com.here.xyz.psql.query.helpers.FetchExistingIds;
 import com.here.xyz.psql.query.helpers.FetchExistingIds.FetchIdsInput;
@@ -788,7 +789,7 @@ public abstract class DatabaseHandler extends StorageConnector {
         boolean includeOldStates = event.getParams() != null
                 && event.getParams().get(INCLUDE_OLD_STATES) == Boolean.TRUE;
 
-        final SQLQuery searchQuery = SQLQueryBuilder.generateSearchQuery(event);
+        final SQLQuery searchQuery = GetFeaturesByBBox.generateSearchQueryBWC(event);
         final SQLQuery query = SQLQueryBuilder.buildDeleteFeaturesByTagQuery(includeOldStates, searchQuery);
 
         //TODO: check in detail what we want to return

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/PSQLXyzConnector.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/PSQLXyzConnector.java
@@ -19,7 +19,6 @@
 
 package com.here.xyz.psql;
 
-import static com.here.xyz.events.ContextAwareEvent.SpaceContext.DEFAULT;
 import static com.here.xyz.events.GetFeaturesByTileEvent.ResponseType.MVT;
 import static com.here.xyz.events.GetFeaturesByTileEvent.ResponseType.MVT_FLATTENED;
 import static com.here.xyz.responses.XyzError.EXCEPTION;
@@ -32,7 +31,6 @@ import com.here.xyz.events.GetFeaturesByBBoxEvent;
 import com.here.xyz.events.GetFeaturesByGeometryEvent;
 import com.here.xyz.events.GetFeaturesByIdEvent;
 import com.here.xyz.events.GetFeaturesByTileEvent;
-import com.here.xyz.events.GetFeaturesByTileEvent.ResponseType;
 import com.here.xyz.events.GetHistoryStatisticsEvent;
 import com.here.xyz.events.GetStatisticsEvent;
 import com.here.xyz.events.GetStorageStatisticsEvent;
@@ -44,16 +42,12 @@ import com.here.xyz.events.ModifyFeaturesEvent;
 import com.here.xyz.events.ModifySpaceEvent;
 import com.here.xyz.events.ModifySubscriptionEvent;
 import com.here.xyz.events.SearchForFeaturesEvent;
-import com.here.xyz.models.geojson.HQuad;
-import com.here.xyz.models.geojson.WebMercatorTile;
-import com.here.xyz.models.geojson.coordinates.BBox;
 import com.here.xyz.models.geojson.implementation.Feature;
 import com.here.xyz.models.geojson.implementation.FeatureCollection;
-import com.here.xyz.psql.factory.H3SQL;
-import com.here.xyz.psql.factory.QuadbinSQL;
-import com.here.xyz.psql.factory.TweaksSQL;
 import com.here.xyz.psql.query.DeleteChangesets;
 import com.here.xyz.psql.query.GetFeaturesByBBox;
+import com.here.xyz.psql.query.GetFeaturesByBBoxClustered;
+import com.here.xyz.psql.query.GetFeaturesByBBoxTweaked;
 import com.here.xyz.psql.query.GetFeaturesByGeometry;
 import com.here.xyz.psql.query.GetFeaturesById;
 import com.here.xyz.psql.query.GetStorageStatistics;
@@ -66,15 +60,10 @@ import com.here.xyz.responses.SuccessResponse;
 import com.here.xyz.responses.XyzError;
 import com.here.xyz.responses.XyzResponse;
 import java.sql.SQLException;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
@@ -83,11 +72,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 public class PSQLXyzConnector extends DatabaseHandler {
-
-  public static final String COUNTMODE_REAL      = "real";  // Real live counts via count(*)
-  public static final String COUNTMODE_ESTIMATED = "estimated"; // Estimated counts, determined with _postgis_selectivity() or EXPLAIN Plan analyze
-  public static final String COUNTMODE_MIXED     = "mixed"; // Combination of real and estimated.
-  public static final String COUNTMODE_BOOL      = "bool"; // no counts but test [0|1] if data exists int tile.
 
   private static final Logger logger = LogManager.getLogger();
   /**
@@ -164,250 +148,34 @@ public class PSQLXyzConnector extends DatabaseHandler {
     }
   }
 
-  static private class TupleTime
-  { static private Map<String,String> rTuplesMap = new ConcurrentHashMap<String,String>();
-    long outTs;
-    TupleTime() { outTs = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(15); rTuplesMap.clear(); }
-    boolean expired() { return  System.currentTimeMillis() > outTs; }
-  }
-
-  static private TupleTime ttime = new TupleTime();
-
-  static private boolean isVeryLargeSpace( String rTuples )
-  { long tresholdVeryLargeSpace = 350000000L; // 350M Objects
-
-    if( rTuples == null ) return false;
-
-    String[] a = rTuples.split("~");
-    if( a == null || a[0] == null ) return false;
-
-    try{ return tresholdVeryLargeSpace <= Long.parseLong(a[0]); } catch( NumberFormatException e ){}
-
-    return false;
-  }
-
   @Override
   protected XyzResponse processGetFeaturesByBBoxEvent(GetFeaturesByBBoxEvent event) throws Exception {
-    try{
+    try {
       logger.info("{} Received "+event.getClass().getSimpleName(), traceItem);
 
-      final BBox bbox = event.getBbox();
-
-      boolean bTweaks = ( event.getTweakType() != null ),
-              bOptViz = "viz".equals( event.getOptimizationMode() ),
-              bSelectionStar = false,
-              bClustering = (event.getClusteringType() != null);
-
-      ResponseType responseType = GetFeaturesByBBox.getResponseType(event);
-      int mvtMargin = 0;
-      boolean bMvtRequested = responseType == MVT || responseType == MVT_FLATTENED,
-              bMvtFlattend  = responseType == MVT_FLATTENED;
-
-      WebMercatorTile mercatorTile = null;
-      HQuad hereTile = null;
-      GetFeaturesByTileEvent tileEv = ( event instanceof GetFeaturesByTileEvent ? (GetFeaturesByTileEvent) event : null );
-
-      if( tileEv != null && tileEv.getHereTileFlag() ){
-        if(bClustering)
-          throw new ErrorResponseException(streamId, XyzError.ILLEGAL_ARGUMENT, "clustering=[hexbin,quadbin] is not supported for 'here' tile type. Use Web Mercator projection (quadkey, web, tms).");
-      }
-
-      if( bMvtRequested && tileEv == null )
-       throw new ErrorResponseException(streamId, XyzError.ILLEGAL_ARGUMENT, "mvt format needs tile request");
-
-      if( bMvtRequested )
-      {
-        if( event.getConnectorParams() == null || event.getConnectorParams().get("mvtSupport") != Boolean.TRUE )
-         throw new ErrorResponseException(streamId, XyzError.ILLEGAL_ARGUMENT, "mvt format is not supported");
-
-        if(!tileEv.getHereTileFlag())
-         mercatorTile = WebMercatorTile.forWeb(tileEv.getLevel(), tileEv.getX(), tileEv.getY());
-        else
-         hereTile = new HQuad(tileEv.getX(), tileEv.getY(),tileEv.getLevel());
-
-        mvtMargin = tileEv.getMargin();
-      }
-
-      if( event.getSelection() != null && "*".equals( event.getSelection().get(0) ))
-      { event.setSelection(null);
-        bSelectionStar = true; // differentiation needed, due to different semantic of "event.getSelection() == null" tweaks vs. nonTweaks
-      }
-
-      if( !bClustering && ( bTweaks || bOptViz ) )
-      {
-        Map<String, Object> tweakParams;
-        boolean bVizSamplingOff = false;
-
-        if( bTweaks )
-         tweakParams = event.getTweakParams();
-        else if ( !bOptViz )
-        { event.setTweakType( TweaksSQL.SIMPLIFICATION );
-          tweakParams = new HashMap<String, Object>();
-          tweakParams.put("algorithm", new String("gridbytilelevel"));
-        }
-        else
-        { event.setTweakType( TweaksSQL.ENSURE );
-          tweakParams = new HashMap<String, Object>();
-          switch( event.getVizSampling().toLowerCase() )
-          { case "high" : tweakParams.put(TweaksSQL.ENSURE_SAMPLINGTHRESHOLD, new Integer( 15 ) ); break;
-            case "low"  : tweakParams.put(TweaksSQL.ENSURE_SAMPLINGTHRESHOLD, new Integer( 70 ) ); break;
-            case "off"  : tweakParams.put(TweaksSQL.ENSURE_SAMPLINGTHRESHOLD, new Integer( 100 ));
-                          bVizSamplingOff = true;
-                          break;
-            case "med"  :
-            default     : tweakParams.put(TweaksSQL.ENSURE_SAMPLINGTHRESHOLD, new Integer( 30 ) ); break;
-          }
-        }
-
-        int distStrength = 1;
-        boolean bSortByHashedValue = false;
-
-        switch ( event.getTweakType().toLowerCase() )  {
-
-          case TweaksSQL.ENSURE: {
-
-            if(ttime.expired())
-             ttime = new TupleTime();
-
-            String rTuples = TupleTime.rTuplesMap.get(event.getSpace());
-            Feature estimateFtr = executeQueryWithRetry(GetFeaturesByBBox.buildEstimateSamplingStrengthQuery(event, bbox, rTuples )).getFeatures().get(0);
-            int rCount = estimateFtr.get("rcount");
-
-            if( rTuples == null )
-            { rTuples = estimateFtr.get("rtuples");
-              TupleTime.rTuplesMap.put(event.getSpace(), rTuples );
-            }
-
-            bSortByHashedValue = isVeryLargeSpace( rTuples );
-
-            boolean bDefaultSelectionHandling = (tweakParams.get(TweaksSQL.ENSURE_DEFAULT_SELECTION) == Boolean.TRUE );
-
-            if( event.getSelection() == null && !bDefaultSelectionHandling && !bSelectionStar )
-             event.setSelection(Arrays.asList("id","type"));
-
-            distStrength = TweaksSQL.calculateDistributionStrength( rCount, Math.max(Math.min((int) tweakParams.getOrDefault(TweaksSQL.ENSURE_SAMPLINGTHRESHOLD,10),100),10) * 1000 );
-
-            HashMap<String, Object> hmap = new HashMap<>();
-            hmap.put("algorithm", new String("distribution"));
-            hmap.put("strength", new Integer( distStrength ));
-            tweakParams = hmap;
-            // fall thru tweaks=sampling
-          }
-
-          case TweaksSQL.SAMPLING: {
-            if( bTweaks || !bVizSamplingOff )
-            {
-              if( !bMvtRequested )
-              { FeatureCollection collection = executeQueryWithRetrySkipIfGeomIsNull(
-                  GetFeaturesByBBox.buildSamplingTweaksQuery(event, bbox, tweakParams, bSortByHashedValue));
-                if( distStrength > 0 ) collection.setPartial(true); // either ensure mode or explicit tweaks:sampling request where strenght in [1..100]
-                return collection;
-              }
-              else
-               return executeBinQueryWithRetry(
-                         SQLQueryBuilder.buildMvtEncapsuledQuery(event.getSpace(), GetFeaturesByBBox.buildSamplingTweaksQuery(event, bbox, tweakParams, bSortByHashedValue) , mercatorTile, hereTile, bbox, mvtMargin, bMvtFlattend ) );
-            }
-            else
-            { // fall thru tweaks=simplification e.g. mode=viz and vizSampling=off
-              tweakParams.put("algorithm", "gridbytilelevel");
-            }
-          }
-
-          case TweaksSQL.SIMPLIFICATION: {
-            if( !bMvtRequested )
-            { FeatureCollection collection = executeQueryWithRetrySkipIfGeomIsNull(
-                GetFeaturesByBBox.buildSimplificationTweaksQuery(event, bbox, tweakParams));
-              return collection;
-            }
-            else
-             return executeBinQueryWithRetry(
-               SQLQueryBuilder.buildMvtEncapsuledQuery(event.getSpace(), GetFeaturesByBBox.buildSimplificationTweaksQuery(event, bbox, tweakParams) , mercatorTile, hereTile, bbox, mvtMargin, bMvtFlattend ) );
-          }
-
-          default: break; // fall back to non-tweaks usage.
-        }
-      }
-
-      if( bClustering )
-      { final Map<String, Object> clusteringParams = event.getClusteringParams();
-
-        switch(event.getClusteringType().toLowerCase())
-        {
-          case H3SQL.HEXBIN :
-           if( !bMvtRequested )
-            return executeQueryWithRetry(GetFeaturesByBBox.buildHexbinClusteringQuery(event, bbox, clusteringParams),false);
-           else
-            return executeBinQueryWithRetry(
-             SQLQueryBuilder.buildMvtEncapsuledQuery(event.getSpace(), GetFeaturesByBBox.buildHexbinClusteringQuery(event, bbox, clusteringParams), mercatorTile, hereTile, bbox, mvtMargin, bMvtFlattend ),false );
-
-          case QuadbinSQL.QUAD :
-           final int relResolution = ( clusteringParams.get(QuadbinSQL.QUADBIN_RESOLUTION) != null ? (int) clusteringParams.get(QuadbinSQL.QUADBIN_RESOLUTION) :
-                                     ( clusteringParams.get(QuadbinSQL.QUADBIN_RESOLUTION_RELATIVE) != null ? (int) clusteringParams.get(QuadbinSQL.QUADBIN_RESOLUTION_RELATIVE) : 0)),
-                     absResolution = clusteringParams.get(QuadbinSQL.QUADBIN_RESOLUTION_ABSOLUTE) != null ? (int) clusteringParams.get(QuadbinSQL.QUADBIN_RESOLUTION_ABSOLUTE) : 0;
-           final String countMode = (String) clusteringParams.get(QuadbinSQL.QUADBIN_COUNTMODE);
-           final boolean noBuffer = (boolean) clusteringParams.getOrDefault(QuadbinSQL.QUADBIN_NOBOFFER,false);
-
-           checkQuadbinInput(countMode, relResolution, event, streamId);
-
-            if( !bMvtRequested )
-              return executeQueryWithRetry(
-                  GetFeaturesByBBox.buildQuadbinClusteringQuery(event, bbox, relResolution, absResolution, countMode, config, noBuffer));
-            else
-              return executeBinQueryWithRetry(
-                      SQLQueryBuilder.buildMvtEncapsuledQuery(config.readTableFromEvent(event), GetFeaturesByBBox.buildQuadbinClusteringQuery(event, bbox, relResolution, absResolution, countMode, config, noBuffer), mercatorTile, hereTile, bbox, mvtMargin, bMvtFlattend ) );
-
-          default: break; // fall back to non-tweaks usage.
-       }
-      }
-
-      final boolean isBigQuery = (bbox.widthInDegree(false) >= (360d / 4d) || (bbox.heightInDegree() >= (180d / 4d)));
-
-      if (isBigQuery)
-        //Check if Properties are indexed
-        checkCanSearchFor(event);
-
-      if (isForExtendingSpace(event) && event.getContext() == DEFAULT)
-        return new GetFeaturesByBBox<>(event, this).run();
-
-      if( !bMvtRequested )
-       return executeQueryWithRetry(GetFeaturesByBBox.buildGetFeaturesByBBoxQuery(event));
-      else
-       return executeBinQueryWithRetry( SQLQueryBuilder.buildMvtEncapsuledQuery(event.getSpace(), GetFeaturesByBBox.buildGetFeaturesByBBoxQuery(event), mercatorTile, hereTile, bbox, mvtMargin, bMvtFlattend ) );
-
-    }catch (SQLException e){
+      if (event.getClusteringType() != null)
+        return new GetFeaturesByBBoxClustered<>(event, this).run();
+      if (event.getTweakType() != null || "viz".equals(event.getOptimizationMode()))
+        return new GetFeaturesByBBoxTweaked<>(event, this).run();
+      return new GetFeaturesByBBox<>(event, this).run();
+    }
+    catch (SQLException e) {
       return checkSQLException(e, config.readTableFromEvent(event));
-    }finally {
+    }
+    finally {
       logger.info("{} Finished "+event.getClass().getSimpleName(), traceItem);
     }
   }
 
-  /**
-   * Check if request parameters are valid. In case of invalidity throw an Exception
-   */
-  private void checkQuadbinInput(String countMode, int relResolution, GetFeaturesByBBoxEvent event, String streamId) throws ErrorResponseException
-  {
-    if( countMode != null )
-     switch( countMode.toLowerCase() )
-     { case COUNTMODE_REAL : case COUNTMODE_ESTIMATED: case COUNTMODE_MIXED: case COUNTMODE_BOOL : break;
-       default:
-        throw new ErrorResponseException(streamId, XyzError.ILLEGAL_ARGUMENT,
-             "Invalid request parameters. Unknown clustering.countmode="+countMode+". Available are: ["+ COUNTMODE_REAL
-            +","+ COUNTMODE_ESTIMATED +","+ COUNTMODE_MIXED +","+ COUNTMODE_BOOL +"]!");
-     }
-
-    if(relResolution > 5)
-      throw new ErrorResponseException(streamId, XyzError.ILLEGAL_ARGUMENT,
-          "Invalid request parameters. clustering.relativeResolution="+relResolution+" to high. 5 is maximum!");
-
-    if(event.getPropertiesQuery() != null && event.getPropertiesQuery().get(0).size() != 1)
-      throw new ErrorResponseException(streamId, XyzError.ILLEGAL_ARGUMENT,
-          "Invalid request parameters. Only one Property is allowed");
-
-    checkCanSearchFor(event);
-  }
-
   @Override
   protected XyzResponse processGetFeaturesByTileEvent(GetFeaturesByTileEvent event) throws Exception {
+    if (event.getHereTileFlag() && event.getClusteringType() != null)
+      throw new ErrorResponseException(XyzError.ILLEGAL_ARGUMENT, "clustering=[hexbin,quadbin] is not supported for 'here' tile type. Use Web Mercator projection (quadkey, web, tms).");
+
+    if ((event.getResponseType() == MVT || event.getResponseType() == MVT_FLATTENED)
+        && (event.getConnectorParams() == null || event.getConnectorParams().get("mvtSupport") != Boolean.TRUE))
+      throw new ErrorResponseException(XyzError.ILLEGAL_ARGUMENT, "mvt format is not supported");
+
     return processGetFeaturesByBBoxEvent(event);
   }
 
@@ -415,7 +183,7 @@ public class PSQLXyzConnector extends DatabaseHandler {
   protected XyzResponse processIterateFeaturesEvent(IterateFeaturesEvent event) throws Exception {
     try {
       logger.info("{} Received "+event.getClass().getSimpleName(), traceItem);
-      checkCanSearchFor(event);
+      SearchForFeatures.checkCanSearchFor(event, this);
 
       if (isOrderByEvent(event))
         return IterateFeatures.findFeaturesSort(event, this);
@@ -445,7 +213,7 @@ public class PSQLXyzConnector extends DatabaseHandler {
   protected XyzResponse processSearchForFeaturesEvent(SearchForFeaturesEvent event) throws Exception {
     try {
       logger.info("{} Received "+event.getClass().getSimpleName(), traceItem);
-      checkCanSearchFor(event);
+      SearchForFeatures.checkCanSearchFor(event, this);
 
       // For testing purposes.
       if (event.getSpace().contains("illegal_argument")) //TODO: Remove testing code from the actual connector implementation
@@ -460,12 +228,6 @@ public class PSQLXyzConnector extends DatabaseHandler {
     finally {
       logger.info("{} Finished " + event.getClass().getSimpleName(), traceItem);
     }
-  }
-
-  private void checkCanSearchFor(SearchForFeaturesEvent event) throws ErrorResponseException {
-    if (!Capabilities.canSearchFor(config.readTableFromEvent(event), event.getPropertiesQuery(), this))
-      throw new ErrorResponseException(streamId, XyzError.ILLEGAL_ARGUMENT,
-          "Invalid request parameters. Search for the provided properties is not supported for this space.");
   }
 
   @Override

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/SQLQueryBuilder.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/SQLQueryBuilder.java
@@ -18,37 +18,23 @@
  */
 package com.here.xyz.psql;
 
-import static com.here.xyz.events.GetFeaturesByTileEvent.ResponseType.GEO_JSON;
-
 import com.here.xyz.events.ContextAwareEvent;
 import com.here.xyz.events.Event;
-import com.here.xyz.events.GetFeaturesByBBoxEvent;
-import com.here.xyz.events.GetFeaturesByTileEvent;
-import com.here.xyz.events.GetFeaturesByTileEvent.ResponseType;
 import com.here.xyz.events.GetHistoryStatisticsEvent;
 import com.here.xyz.events.IterateFeaturesEvent;
 import com.here.xyz.events.IterateHistoryEvent;
 import com.here.xyz.events.ModifyFeaturesEvent;
-import com.here.xyz.events.PropertiesQuery;
-import com.here.xyz.events.QueryEvent;
 import com.here.xyz.models.geojson.HQuad;
 import com.here.xyz.models.geojson.WebMercatorTile;
 import com.here.xyz.models.geojson.coordinates.BBox;
 import com.here.xyz.psql.config.PSQLConfig;
-import com.here.xyz.psql.factory.H3SQL;
-import com.here.xyz.psql.factory.QuadbinSQL;
 import com.here.xyz.psql.factory.TweaksSQL;
 import com.here.xyz.psql.query.GetFeaturesByBBox;
 import com.here.xyz.psql.query.ModifySpace;
-import com.here.xyz.psql.query.SearchForFeatures;
 import com.here.xyz.psql.tools.DhString;
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Map;
 
 public class SQLQueryBuilder {
-    public static final long GEOMETRY_DECIMAL_DIGITS = 8;
+
   private static final Integer BIG_SPACE_THRESHOLD = 10000;
 
     public static SQLQuery buildGetStatisticsQuery(Event event, PSQLConfig config, boolean historyMode) {
@@ -67,462 +53,10 @@ public class SQLQueryBuilder {
         return new SQLQuery("SELECT nextval('${schema}.\"" + table.replaceAll("-","_") + "_hst_seq\"')");
     }
 
-  public static SQLQuery buildGetFeaturesByBBoxQuery(final GetFeaturesByBBoxEvent event)
-        throws SQLException{
-        final BBox bbox = event.getBbox();
+  /***************************************** CLUSTERING END **************************************************/
 
-        final SQLQuery geoQuery = new SQLQuery("ST_Intersects(geo, ST_MakeEnvelope(?, ?, ?, ?, 4326))",
-                bbox.minLon(), bbox.minLat(), bbox.maxLon(), bbox.maxLat());
 
-        return generateCombinedQuery(event, geoQuery);
-    }
-
-    /***************************************** CLUSTERING ******************************************************/
-
-    private static int evalH3Resolution( Map<String, Object> clusteringParams, int defaultResForLevel )
-    {
-     int h3res = defaultResForLevel, overzoomingRes = 2; // restrict to "defaultResForLevel + 2" as maximum resolution per level
-
-     if( clusteringParams == null ) return h3res;
-/** deprecated */
-     if( clusteringParams.get(H3SQL.HEXBIN_RESOLUTION) != null )
-      h3res = Math.min((Integer) clusteringParams.get(H3SQL.HEXBIN_RESOLUTION), defaultResForLevel + overzoomingRes);
-/***/
-     if( clusteringParams.get(H3SQL.HEXBIN_RESOLUTION_ABSOLUTE) != null )
-      h3res = Math.min((Integer) clusteringParams.get(H3SQL.HEXBIN_RESOLUTION_ABSOLUTE), defaultResForLevel + overzoomingRes);
-
-     if( clusteringParams.get(H3SQL.HEXBIN_RESOLUTION_RELATIVE) != null )
-      h3res += Math.max(-2, Math.min( 2, (Integer) clusteringParams.get(H3SQL.HEXBIN_RESOLUTION_RELATIVE)));
-
-     return Math.min( Math.min( h3res, defaultResForLevel + overzoomingRes ) , 13 ); // cut to maximum res
-    }
-
-    public static SQLQuery buildHexbinClusteringQuery(
-            GetFeaturesByBBoxEvent event, BBox bbox,
-            Map<String, Object> clusteringParams) {
-
-        int zLevel = (event instanceof GetFeaturesByTileEvent ? ((GetFeaturesByTileEvent) event).getLevel() : H3SQL.bbox2zoom(bbox)),
-            defaultResForLevel = H3SQL.zoom2resolution(zLevel),
-            h3res = evalH3Resolution( clusteringParams, defaultResForLevel );
-
-        if( zLevel == 1)  // prevent ERROR:  Antipodal (180 degrees long) edge detected!
-         if( bbox.minLon() == 0.0 )
-          bbox.setEast( bbox.maxLon() - 0.0001 );
-         else
-          bbox.setWest( bbox.minLon() + 0.0001);
-
-        String statisticalProperty = (String) clusteringParams.get(H3SQL.HEXBIN_PROPERTY);
-        boolean statisticalPropertyProvided = (statisticalProperty != null && statisticalProperty.length() > 0),
-                h3cflip = (clusteringParams.get(H3SQL.HEXBIN_POINTMODE) == Boolean.TRUE);
-               /** todo: replace format %.14f with parameterized version*/
-        final String expBboxSql = String
-                .format("st_envelope( st_buffer( ST_MakeEnvelope(%.14f,%.14f,%.14f,%.14f, 4326)::geography, ( 2.5 * edgeLengthM( %d )) )::geometry )",
-                        bbox.minLon(), bbox.minLat(), bbox.maxLon(), bbox.maxLat(), h3res);
-
-        /*clippedGeo - passed bbox is extended by "margin" on service level */
-        String clippedGeo = (!event.getClip() ? "geo" : String
-                .format("ST_Intersection(st_makevalid(geo),ST_MakeEnvelope(%.14f,%.14f,%.14f,%.14f,4326) )", bbox.minLon(), bbox.minLat(), bbox.maxLon(), bbox.maxLat())),
-                fid = (!event.getClip() ? "h3" : DhString.format("h3 || %f || %f", bbox.minLon(), bbox.minLat())),
-                filterEmptyGeo = (!event.getClip() ? "" : DhString.format(" and not st_isempty( %s ) ", clippedGeo));
-
-        final SQLQuery searchQuery = generateSearchQuery(event);
-
-        String aggField = (statisticalPropertyProvided ? "jsonb_set('{}'::jsonb, ? , agg::jsonb)::json" : "agg");
-
-        final SQLQuery query = new SQLQuery(DhString.format(H3SQL.h3sqlBegin, h3res,
-                !h3cflip ? "st_centroid(geo)" : "geo",
-                DhString.format( (getResponseType(event) == GEO_JSON ? "st_asgeojson( %1$s, 7 )::json" : "(%1$s)" ), (h3cflip ? "st_centroid(geo)" : clippedGeo) ),
-                statisticalPropertyProvided ? ", min, max, sum, avg, median" : "",
-                zLevel,
-                !h3cflip ? "centroid" : "hexagon",
-                aggField,
-                fid,
-                expBboxSql));
-
-        if (statisticalPropertyProvided) {
-            ArrayList<String> jpath = new ArrayList<>();
-            jpath.add(statisticalProperty);
-            query.addParameter(jpath.toArray(new String[]{}));
-        }
-
-        int pxSize = H3SQL.adjPixelSize( h3res, defaultResForLevel );
-
-        String h3sqlMid = H3SQL.h3sqlMid( clusteringParams.get(H3SQL.HEXBIN_SINGLECOORD) == Boolean.TRUE );
-
-        int samplingStrength = samplingStrengthFromText((String) clusteringParams.getOrDefault(H3SQL.HEXBIN_SAMPLING, "off"),false);
-        String samplingCondition =  ( samplingStrength <= 0 ? "1 = 1" : TweaksSQL.strengthSql( samplingStrength, true) );
-
-        if (!statisticalPropertyProvided) {
-            query.append(new SQLQuery(DhString.format(h3sqlMid, h3res, "(0.0)::numeric", zLevel, pxSize,expBboxSql,samplingCondition)));
-        } else {
-            ArrayList<String> jpath = new ArrayList<>();
-            jpath.add("properties");
-            jpath.addAll(Arrays.asList(statisticalProperty.split("\\.")));
-
-            query.append(new SQLQuery(DhString.format(h3sqlMid, h3res, "(jsondata#>> ?)::numeric", zLevel, pxSize,expBboxSql,samplingCondition)));
-            query.addParameter(jpath.toArray(new String[]{}));
-        }
-
-        if (searchQuery != null) {
-            query.append(" and ");
-            query.append(searchQuery);
-        }
-
-        query.append(DhString.format(H3SQL.h3sqlEnd, filterEmptyGeo));
-        query.append("LIMIT ?", event.getLimit());
-
-        return query;
-    }
-
-    private static WebMercatorTile getTileFromBbox(BBox bbox)
-    {
-     /* Quadkey calc */
-     final int lev = WebMercatorTile.getZoomFromBBOX(bbox);
-     double lon2 = bbox.minLon() + ((bbox.maxLon() - bbox.minLon()) / 2);
-     double lat2 = bbox.minLat() + ((bbox.maxLat() - bbox.minLat()) / 2);
-
-     return WebMercatorTile.getTileFromLatLonLev(lat2, lon2, lev);
-    }
-
-    public static SQLQuery buildQuadbinClusteringQuery(GetFeaturesByBBoxEvent event,
-                                                          BBox bbox, int relResolution, int absResolution, String countMode,
-                                                          PSQLConfig config, boolean noBuffer) {
-        boolean isTileRequest = (event instanceof GetFeaturesByTileEvent) && ((GetFeaturesByTileEvent) event).getMargin() == 0,
-                clippedOnBbox = (!isTileRequest && event.getClip());
-
-        final WebMercatorTile tile = getTileFromBbox(bbox);
-
-        if( (absResolution - tile.level) >= 0 )  // case of valid absResolution convert it to a relative resolution and add both resolutions
-         relResolution = Math.min( relResolution + (absResolution - tile.level), 5);
-
-        SQLQuery propQuery;
-        String propQuerySQL = null;
-
-        if (event.getPropertiesQuery() != null) {
-            propQuery = generatePropertiesQuery(event);
-
-            if (propQuery != null) {
-                propQuerySQL = propQuery.text();
-                for (Object param : propQuery.parameters()) {
-                    propQuerySQL = propQuerySQL.replaceFirst("\\?", "'" + param + "'");
-                }
-            }
-        }
-        return QuadbinSQL.generateQuadbinClusteringSQL(config.getDatabaseSettings().getSchema(), config.readTableFromEvent(event), relResolution, countMode, propQuerySQL, tile, bbox, isTileRequest, clippedOnBbox, noBuffer, getResponseType(event) == GEO_JSON);
-    }
-
-    /***************************************** CLUSTERING END **************************************************/
-
-    /***************************************** TWEAKS **************************************************/
-
-    public static ResponseType getResponseType(GetFeaturesByBBoxEvent event) {
-      if (event instanceof GetFeaturesByTileEvent)
-        return ((GetFeaturesByTileEvent) event).getResponseType();
-      return GEO_JSON;
-    }
-
-    private static String map2MvtGeom( GetFeaturesByBBoxEvent event, BBox bbox, String tweaksGeoSql )
-    {
-     boolean bExtendTweaks = // -> 2048 only if tweaks or viz been specified explicit
-      ( "viz".equals(event.getOptimizationMode()) || (event.getTweakParams() != null && event.getTweakParams().size() > 0 ) );
-
-     int extend = ( bExtendTweaks ? 2048 : 4096 ), extendPerMargin = extend / WebMercatorTile.TileSizeInPixel, extendWithMargin = extend, level = -1, tileX = -1, tileY = -1, margin = 0;
-     boolean hereTile = false;
-
-     if( event instanceof GetFeaturesByTileEvent )
-     { GetFeaturesByTileEvent tevnt = (GetFeaturesByTileEvent) event;
-       level = tevnt.getLevel();
-       tileX = tevnt.getX();
-       tileY = tevnt.getY();
-       margin = tevnt.getMargin();
-       extendWithMargin = extend + (margin * extendPerMargin);
-       hereTile = tevnt.getHereTileFlag();
-     }
-     else
-     { final WebMercatorTile tile = getTileFromBbox(bbox);
-       level = tile.level;
-       tileX = tile.x;
-       tileY = tile.y;
-     }
-
-     double wgs3857width = 20037508.342789244d, wgs4326width = 180d,
-            wgsWidth = 2 * ( !hereTile ? wgs3857width : wgs4326width ),
-            xwidth = wgsWidth,
-            ywidth = wgsWidth,
-            gridsize = (1L << level),
-            stretchFactor = 1.0 + ( margin / ((double) WebMercatorTile.TileSizeInPixel)), // xyz-hub uses margin for tilesize of 256 pixel.
-            xProjShift = (!hereTile ? (tileX - gridsize/2 + 0.5) * (xwidth / gridsize)      : -180d + (tileX + 0.5) * (xwidth / gridsize) ) ,
-            yProjShift = (!hereTile ? (tileY - gridsize/2 + 0.5) * (ywidth / gridsize) * -1 :  -90d + (tileY + 0.5) * (ywidth / gridsize) ) ;
-
-     String
-      box2d   = DhString.format( DhString.format("ST_MakeEnvelope(%%.%1$df,%%.%1$df,%%.%1$df,%%.%1$df, 4326)", 14 /*GEOMETRY_DECIMAL_DIGITS*/), bbox.minLon(), bbox.minLat(), bbox.maxLon(), bbox.maxLat() ),
-        // 1. build mvt
-      mvtgeom = DhString.format( (!hereTile ? "st_asmvtgeom(st_force2d(st_transform(%1$s,3857)), st_transform(%2$s,3857),%3$d,0,true)"
-                                            : "st_asmvtgeom(st_force2d(%1$s), %2$s,%3$d,0,true)")
-                                 , tweaksGeoSql, box2d, extendWithMargin);
-        // 2. project the mvt to tile
-      mvtgeom = DhString.format( (!hereTile ? "st_setsrid(st_translate(st_scale(st_translate(%1$s, %2$d , %2$d, 0.0), st_makepoint(%3$f,%4$f,1.0) ), %5$f , %6$f, 0.0 ), 3857)"
-                                            : "st_setsrid(st_translate(st_scale(st_translate(%1$s, %2$d , %2$d, 0.0), st_makepoint(%3$f,%4$f,1.0) ), %5$f , %6$f, 0.0 ), 4326)")
-                                 ,mvtgeom
-                                 ,-extendWithMargin/2 // => shift to stretch from tilecenter
-                                 ,stretchFactor*(xwidth / (gridsize*extend)), stretchFactor * (ywidth / (gridsize*extend)) * -1 // stretch tile to proj. size
-                                 ,xProjShift, yProjShift // shift to proj. position
-                               );
-        // 3 project tile to wgs84 and map invalid geom to null
-
-      mvtgeom = DhString.format( (!hereTile ? "(select case st_isvalid(g) when true then g else null end from st_transform(%1$s,4326) g)"
-                                            : "(select case st_isvalid(g) when true then g else null end from %1$s g)")
-                                 , mvtgeom );
-
-        // 4. assure intersect with origin bbox in case of mapping errors
-      mvtgeom  = DhString.format("ST_Intersection(%1$s,st_setsrid(%2$s,4326))", mvtgeom, box2d);
-        // 5. map non-null but empty polygons to null - e.g. avoid -> "geometry": { "type": "Polygon", "coordinates": [] }
-      mvtgeom = DhString.format("(select case st_isempty(g) when false then g else null end from %1$s g)", mvtgeom );
-
-      // if geom = point | multipoint then no mvt <-> geo conversion should be done
-      mvtgeom = DhString.format("case strpos(ST_GeometryType( geo ), 'Point') > 0 when true then geo else %1$s end", mvtgeom );
-
-      return mvtgeom;
-    }
-
-    private static String clipProjGeom(BBox bbox, String tweaksGeoSql )
-    {
-     String fmt =  DhString.format(  " case st_within( %%1$s, ST_MakeEnvelope(%%2$.%1$df,%%3$.%1$df,%%4$.%1$df,%%5$.%1$df, 4326) ) "
-                                 + "  when true then %%1$s "
-                                 + "  else ST_Intersection(ST_MakeValid(%%1$s),ST_MakeEnvelope(%%2$.%1$df,%%3$.%1$df,%%4$.%1$df,%%5$.%1$df, 4326))"
-                                 + " end " , 14 /*GEOMETRY_DECIMAL_DIGITS*/ );
-     return DhString.format( fmt, tweaksGeoSql, bbox.minLon(), bbox.minLat(), bbox.maxLon(), bbox.maxLat());
-    }
-
-    private static int samplingStrengthFromText( String sampling, boolean fiftyOnUnset )
-    {
-     int strength = 0;
-     switch( sampling.toLowerCase() )
-     { case "low"     : strength =  10;  break;
-       case "lowmed"  : strength =  30;  break;
-       case "med"     : strength =  50;  break;
-       case "medhigh" : strength =  75;  break;
-       case "high"    : strength = 100;  break;
-       default: if( fiftyOnUnset ) strength = 50;  break;
-     }
-
-     return strength;
-
-    }
-
-    public static SQLQuery buildSamplingTweaksQuery(GetFeaturesByBBoxEvent event, BBox bbox, Map tweakParams, boolean bSortByHashedValue) throws SQLException
-    {
-     int strength = 0;
-     boolean bDistribution  = true,
-             bDistribution2 = false,
-             bConvertGeo2Geojson = getResponseType(event) == GEO_JSON;
-
-     if( tweakParams != null )
-     {
-      if( tweakParams.get(TweaksSQL.SAMPLING_STRENGTH) instanceof Integer )
-       strength = (int) tweakParams.get(TweaksSQL.SAMPLING_STRENGTH);
-      else
-       strength = samplingStrengthFromText( (String) tweakParams.getOrDefault(TweaksSQL.SAMPLING_STRENGTH,"default"), true );
-
-       switch(((String) tweakParams.getOrDefault(TweaksSQL.SAMPLING_ALGORITHM, TweaksSQL.SAMPLING_ALGORITHM_DST)).toLowerCase() )
-       {
-         case TweaksSQL.SAMPLING_ALGORITHM_SZE  : bDistribution = false; break;
-         case TweaksSQL.SAMPLING_ALGORITHM_DST2 : bDistribution2 = true;
-         case TweaksSQL.SAMPLING_ALGORITHM_DST  :
-         default                                : bDistribution = true; break;
-       }
-     }
-
-     boolean bEnsureMode = TweaksSQL.ENSURE.equalsIgnoreCase(event.getTweakType());
-
-     float tblSampleRatio = ( (strength > 0 && bDistribution2) ? TweaksSQL.tableSampleRatio(strength) : -1f);
-
-     final String sCondition = ( ((bEnsureMode && strength == 0) || (tblSampleRatio >= 0.0)) ? "1 = 1" : TweaksSQL.strengthSql(strength,bDistribution)  ),
-                  twqry = DhString.format(DhString.format("ST_Intersects(geo, ST_MakeEnvelope(%%.%1$df,%%.%1$df,%%.%1$df,%%.%1$df, 4326) ) and %%s", 14 /*GEOMETRY_DECIMAL_DIGITS*/), bbox.minLon(), bbox.minLat(), bbox.maxLon(), bbox.maxLat(), sCondition );
-
-     final SQLQuery tweakQuery = new SQLQuery(twqry);
-
-     if( !bEnsureMode || !bConvertGeo2Geojson ) {
-       SQLQuery combinedQuery = generateCombinedQuery(event, tweakQuery);
-       if (tblSampleRatio > 0.0)
-         combinedQuery.setQueryFragment("tableSample", DhString.format("tablesample system(%.6f) repeatable(499)", 100.0 * tblSampleRatio));
-       if (bSortByHashedValue)
-         combinedQuery.setQueryFragment("orderBy", "ORDER BY " + TweaksSQL.distributionFunctionIndexExpression());
-       return combinedQuery;
-     }
-
-
-     /* TweaksSQL.ENSURE and geojson requested (no mvt) */
-     boolean bTestTweaksGeoIfNull = false;
-     String tweaksGeoSql = clipProjGeom(bbox,"geo");
-     tweaksGeoSql = map2MvtGeom( event, bbox, tweaksGeoSql );
-     //convert to geojson
-     tweaksGeoSql = ( bConvertGeo2Geojson ? DhString.format("replace(ST_AsGeojson(" + getForceMode(event.isForce2D()) + "( %s ),%d),'nan','0')",tweaksGeoSql,GEOMETRY_DECIMAL_DIGITS)
-                                          : DhString.format( getForceMode(event.isForce2D()) + "( %s )",tweaksGeoSql ) );
-
-     return generateCombinedQueryTweaks(event, tweakQuery , tweaksGeoSql, bTestTweaksGeoIfNull, tblSampleRatio, bSortByHashedValue );
-	}
-
-
-    private static double cToleranceFromStrength(int strength )
-    {
-     double tolerance = 0.0001;
-     if(  strength > 0  && strength <= 25 )      tolerance = 0.0001 + ((0.001-0.0001)/25.0) * (strength -  1);
-     else if(  strength > 25 && strength <= 50 ) tolerance = 0.001  + ((0.01 -0.001) /25.0) * (strength - 26);
-     else if(  strength > 50 && strength <= 75 ) tolerance = 0.01   + ((0.1  -0.01)  /25.0) * (strength - 51);
-     else /* [76 - 100 ] */                      tolerance = 0.1    + ((1.0  -0.1)   /25.0) * (strength - 76);
-
-     return tolerance;
-    }
-
-    public static SQLQuery buildSimplificationTweaksQuery(GetFeaturesByBBoxEvent event, BBox bbox, Map tweakParams) throws SQLException
-    {
-     int strength = 0,
-         iMerge = 0;
-     String tweaksGeoSql = "geo";
-     boolean bStrength = true, bTestTweaksGeoIfNull = true, bConvertGeo2Geojson = getResponseType(event) == GEO_JSON, bMvtRequested = !bConvertGeo2Geojson;
-
-     if( tweakParams != null )
-     {
-      if( tweakParams.get(TweaksSQL.SIMPLIFICATION_STRENGTH) instanceof Integer )
-       strength = (int) tweakParams.get(TweaksSQL.SIMPLIFICATION_STRENGTH);
-      else
-       switch(((String) tweakParams.getOrDefault(TweaksSQL.SIMPLIFICATION_STRENGTH,"default")).toLowerCase() )
-       { case "low"     : strength =  20;  break;
-         case "lowmed"  : strength =  40;  break;
-         case "med"     : strength =  60;  break;
-         case "medhigh" : strength =  80;  break;
-         case "high"    : strength = 100; break;
-         case "default" : bStrength = false;
-         default: strength  = 50; break;
-       }
-
-       String tweaksAlgorithm = ((String) tweakParams.getOrDefault(TweaksSQL.SIMPLIFICATION_ALGORITHM,"default")).toLowerCase();
-
-       // do clip before simplification -- preventing extrem large polygon for further working steps (except for mvt with gridbytilelevel, redundancy)
-       if (event.getClip() && !( TweaksSQL.SIMPLIFICATION_ALGORITHM_A05.equals( tweaksAlgorithm ) && bMvtRequested ) )
-        tweaksGeoSql = clipProjGeom( bbox,tweaksGeoSql );
-
-       //SIMPLIFICATION_ALGORITHM
-       int hint = 0;
-       String[] pgisAlgorithm = { "ST_SnapToGrid", "ftm_SimplifyPreserveTopology", "ftm_Simplify" };
-
-       switch( tweaksAlgorithm )
-       {
-         case TweaksSQL.SIMPLIFICATION_ALGORITHM_A03 : hint++;
-         case TweaksSQL.SIMPLIFICATION_ALGORITHM_A02 : hint++;
-         case TweaksSQL.SIMPLIFICATION_ALGORITHM_A01 :
-         {
-          double tolerance = ( bStrength ? cToleranceFromStrength( strength ) : Math.abs( bbox.maxLon() - bbox.minLon() ) / 4096 );
-          tweaksGeoSql = DhString.format("%s(%s, %f)", pgisAlgorithm[hint], tweaksGeoSql, tolerance );
-         }
-         break;
-
-         case TweaksSQL.SIMPLIFICATION_ALGORITHM_A05 : // gridbytilelevel - convert to/from mvt
-         {
-          if(!bMvtRequested)
-           tweaksGeoSql = map2MvtGeom( event, bbox, tweaksGeoSql );
-          bTestTweaksGeoIfNull = false;
-         }
-         break;
-
-         case TweaksSQL.SIMPLIFICATION_ALGORITHM_A06 : iMerge++;
-         case TweaksSQL.SIMPLIFICATION_ALGORITHM_A04 : iMerge++; break;
-
-         default: break;
-       }
-
-       //convert to geojson
-       tweaksGeoSql = ( bConvertGeo2Geojson ? DhString.format("replace(ST_AsGeojson(" + getForceMode(event.isForce2D()) + "( %s ),%d),'nan','0')",tweaksGeoSql,GEOMETRY_DECIMAL_DIGITS)
-                                            : DhString.format( getForceMode(event.isForce2D()) + "( %s )",tweaksGeoSql) );
-     }
-
-       final String bboxqry = DhString.format( DhString.format("ST_Intersects(geo, ST_MakeEnvelope(%%.%1$df,%%.%1$df,%%.%1$df,%%.%1$df, 4326) )", 14 /*GEOMETRY_DECIMAL_DIGITS*/), bbox.minLon(), bbox.minLat(), bbox.maxLon(), bbox.maxLat() );
-
-       if( iMerge == 0 )
-        return generateCombinedQueryTweaks(event, new SQLQuery(bboxqry), tweaksGeoSql, bTestTweaksGeoIfNull);
-
-       // Merge Algorithm - only using low, med, high
-
-       int minGeoHashLenToMerge = 0,
-           minGeoHashLenForLineMerge = 3;
-
-       if      ( strength <= 20 ) { minGeoHashLenToMerge = 7; minGeoHashLenForLineMerge = 7; } //low
-       else if ( strength <= 40 ) { minGeoHashLenToMerge = 6; minGeoHashLenForLineMerge = 6; } //lowmed
-       else if ( strength <= 60 ) { minGeoHashLenToMerge = 6; minGeoHashLenForLineMerge = 5; } //med
-       else if ( strength <= 80 ) {                           minGeoHashLenForLineMerge = 4; } //medhigh
-
-       if( "geo".equals(tweaksGeoSql) ) // formal, just in case
-        tweaksGeoSql = ( bConvertGeo2Geojson ? DhString.format("replace(ST_AsGeojson(" + getForceMode(event.isForce2D()) + "( %s ),%d),'nan','0')",tweaksGeoSql,GEOMETRY_DECIMAL_DIGITS)
-                                             : DhString.format(getForceMode(event.isForce2D()) + "( %s )",tweaksGeoSql) );
-
-       if( bConvertGeo2Geojson )
-        tweaksGeoSql = DhString.format("(%s)::jsonb", tweaksGeoSql);
-
-        SQLQuery query =
-         ( iMerge == 1 ? new SQLQuery( DhString.format( TweaksSQL.mergeBeginSql, tweaksGeoSql, minGeoHashLenToMerge, bboxqry ) )
-                       : new SQLQuery( DhString.format( TweaksSQL.linemergeBeginSql, /*(event.getClip() ? clipProjGeom(bbox,"geo") : "geo")*/ "geo" , bboxqry ) ));  // use clipped geom as input (?)
-
-      final SQLQuery searchQuery = generateSearchQuery(event);
-       if (searchQuery != null)
-       { query.append(" and ");
-         query.append(searchQuery);
-       }
-
-       if( iMerge == 1 )
-        query.append( TweaksSQL.mergeEndSql(bConvertGeo2Geojson) );
-       else
-       { query.append( DhString.format( TweaksSQL.linemergeEndSql1, minGeoHashLenForLineMerge ) );
-         query.append(SQLQuery.selectJson(event));
-         query.append( DhString.format( TweaksSQL.linemergeEndSql2, tweaksGeoSql ) );
-       }
-
-       query.append("LIMIT ?", event.getLimit());
-
-       return query;
-	}
-
-
-
-
-    public static SQLQuery buildEstimateSamplingStrengthQuery( GetFeaturesByBBoxEvent event, BBox bbox, String relTuples )
-    {
-     int level, tileX, tileY, margin = 0;
-
-     if( event instanceof GetFeaturesByTileEvent )
-     { GetFeaturesByTileEvent tevnt = (GetFeaturesByTileEvent) event;
-       level = tevnt.getLevel();
-       tileX = tevnt.getX();
-       tileY = tevnt.getY();
-       margin = tevnt.getMargin();
-     }
-     else
-     { final WebMercatorTile tile = getTileFromBbox(bbox);
-       level = tile.level;
-       tileX = tile.x;
-       tileY = tile.y;
-     }
-
-     ArrayList<BBox> listOfBBoxes = new ArrayList<BBox>();
-     int nrTilesXY = 1 << level;
-
-     for( int dy = -1; dy < 2; dy++ )
-      for( int dx = -1; dx < 2; dx++ )
-       if( (dy == 0) && (dx == 0) ) listOfBBoxes.add(bbox);  // centerbox, this is already extended by margin
-       else if( ((tileY + dy) > 0) && ((tileY + dy) < nrTilesXY) )
-        listOfBBoxes.add( WebMercatorTile.forWeb(level, ((nrTilesXY +(tileX + dx)) % nrTilesXY) , (tileY + dy)).getExtendedBBox(margin) );
-
-     int flag = 0;
-     StringBuilder sb = new StringBuilder();
-     for (BBox b : listOfBBoxes)
-      sb.append(DhString.format("%s%s",( flag++ > 0 ? "," : ""),DhString.format( TweaksSQL.requestedTileBoundsSql , b.minLon(), b.minLat(), b.maxLon(), b.maxLat() )));
-
-     String estimateSubSql = ( relTuples == null ? TweaksSQL.estWithPgClass : DhString.format( TweaksSQL.estWithoutPgClass, relTuples ) );
-
-     return new SQLQuery( DhString.format( TweaksSQL.estimateCountByBboxesSql, sb.toString(), estimateSubSql ) );
-    }
-
-    public static SQLQuery buildMvtEncapsuledQuery( String spaceId, SQLQuery dataQry, WebMercatorTile mvtTile, HQuad hereTile, BBox eventBbox, int mvtMargin, boolean bFlattend )
+  public static SQLQuery buildMvtEncapsuledQuery( String spaceId, SQLQuery dataQry, WebMercatorTile mvtTile, HQuad hereTile, BBox eventBbox, int mvtMargin, boolean bFlattend )
     {
       //TODO: The following is a workaround for backwards-compatibility and can be removed after completion of refactoring
       dataQry.replaceUnnamedParameters();
@@ -556,7 +90,7 @@ public class SQLQueryBuilder {
         }
 
         if (searchQuery != null && includeOldStates)
-            query.append(" RETURNING jsondata->'id' as id, replace(ST_AsGeojson(ST_Force3D(geo),"+GEOMETRY_DECIMAL_DIGITS+"),'nan','0') as geometry");
+            query.append(" RETURNING jsondata->'id' as id, replace(ST_AsGeojson(ST_Force3D(geo),"+ GetFeaturesByBBox.GEOMETRY_DECIMAL_DIGITS+"),'nan','0') as geometry");
 
         return query;
     }
@@ -646,7 +180,7 @@ public class SQLQueryBuilder {
                 "   select distinct ON (jsondata->>'id') jsondata->>'id' as id," +
                 "   jsondata->'properties'->'@ns:com:here:xyz'->'deleted' as deleted," +
                 "   jsondata," +
-                "   replace(ST_AsGeojson(ST_Force3D(geo),"+GEOMETRY_DECIMAL_DIGITS+"),'nan','0') as geo"+
+                "   replace(ST_AsGeojson(ST_Force3D(geo),"+ GetFeaturesByBBox.GEOMETRY_DECIMAL_DIGITS+"),'nan','0') as geo"+
                 "       FROM ${schema}.${hsttable}" +
                 "   WHERE 1=1" );
 
@@ -679,54 +213,9 @@ public class SQLQueryBuilder {
         return query;
     }
 
-  /** ###################################################################################### */
 
-    private static SQLQuery generatePropertiesQuery(QueryEvent event) {
-      return SearchForFeatures.generatePropertiesQueryBWC(event);
-    }
-
-    private static SQLQuery generateCombinedQueryTweaks(GetFeaturesByBBoxEvent event, SQLQuery indexedQuery, String tweaksgeo, boolean bTestTweaksGeoIfNull, float sampleRatio, boolean bSortByHashedValue)
-    {
-      SQLQuery searchQuery = generateSearchQuery(event);
-     String tSample = ( sampleRatio <= 0.0 ? "" : DhString.format("tablesample system(%.6f) repeatable(499)", 100.0 * sampleRatio) );
-
-     final SQLQuery query = new SQLQuery("select * from ( SELECT");
-
-     query.append(SQLQuery.selectJson(event));
-
-     query.append(DhString.format(",%s as geo",tweaksgeo));
-
-     query.append( DhString.format("FROM ${schema}.${table} %s WHERE",tSample) );
-     query.append(indexedQuery);
-
-     if( searchQuery != null )
-     { query.append(" and ");
-       query.append(searchQuery);
-     }
-
-     if( bSortByHashedValue )
-      query.append( DhString.format( " order by %s ", TweaksSQL.distributionFunctionIndexExpression() ) );
-
-     query.append(DhString.format(" ) tw where %s ", bTestTweaksGeoIfNull ? "geo is not null" : "1 = 1" ) );
-
-     query.append("LIMIT ?", event.getLimit());
-     return query;
-    }
-
-    private static SQLQuery generateCombinedQueryTweaks(GetFeaturesByBBoxEvent event, SQLQuery indexedQuery, String tweaksgeo, boolean bTestTweaksGeoIfNull)
-    { return generateCombinedQueryTweaks(event, indexedQuery, tweaksgeo, bTestTweaksGeoIfNull, -1.0f, false );  }
-
-  private static SQLQuery generateCombinedQuery(GetFeaturesByBBoxEvent event, SQLQuery indexedQuery) {
-      return GetFeaturesByBBox.generateCombinedQueryBWC(event, indexedQuery);
-  }
-
-
-  protected static SQLQuery generateSearchQuery(final QueryEvent event) {
-      return SearchForFeatures.generateSearchQueryBWC(event);
-  }
-
-    protected static SQLQuery generateLoadOldFeaturesQuery(ModifyFeaturesEvent event, final String[] idsToFetch) {
-        return new SQLQuery("SELECT jsondata, replace(ST_AsGeojson(ST_Force3D(geo),"+GEOMETRY_DECIMAL_DIGITS+"),'nan','0') FROM ${schema}.${table} WHERE " + buildIdFragment(event) + " = ANY(?)", (Object) idsToFetch);
+  protected static SQLQuery generateLoadOldFeaturesQuery(ModifyFeaturesEvent event, final String[] idsToFetch) {
+        return new SQLQuery("SELECT jsondata, replace(ST_AsGeojson(ST_Force3D(geo),"+ GetFeaturesByBBox.GEOMETRY_DECIMAL_DIGITS+"),'nan','0') FROM ${schema}.${table} WHERE " + buildIdFragment(event) + " = ANY(?)", (Object) idsToFetch);
     }
 
     private static String buildIdFragment(ContextAwareEvent event) {
@@ -905,11 +394,7 @@ public class SQLQueryBuilder {
         return SQLQuery.replaceVars(triggerSQL, schema, table);
     }
 
-    public static String getForceMode(boolean isForce2D) {
-      return isForce2D ? "ST_Force2D" : "ST_Force3D";
-    }
-
-	protected static SQLQuery buildAddSubscriptionQuery(String space, String schemaName, String tableName) {
+  protected static SQLQuery buildAddSubscriptionQuery(String space, String schemaName, String tableName) {
         String theSql =
           "insert into xyz_config.space_meta  ( id, schem, h_id, meta ) values(?,?,?,'{\"subscriptions\":true}' )"
          +" on conflict (id,schem) do "

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/factory/QuadbinSQL.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/factory/QuadbinSQL.java
@@ -19,10 +19,10 @@
 
 package com.here.xyz.psql.factory;
 
-import static com.here.xyz.psql.PSQLXyzConnector.COUNTMODE_ESTIMATED;
-import static com.here.xyz.psql.PSQLXyzConnector.COUNTMODE_MIXED;
-import static com.here.xyz.psql.PSQLXyzConnector.COUNTMODE_REAL;
-import static com.here.xyz.psql.PSQLXyzConnector.COUNTMODE_BOOL;
+import static com.here.xyz.psql.query.GetFeaturesByBBoxClustered.COUNTMODE_ESTIMATED;
+import static com.here.xyz.psql.query.GetFeaturesByBBoxClustered.COUNTMODE_MIXED;
+import static com.here.xyz.psql.query.GetFeaturesByBBoxClustered.COUNTMODE_REAL;
+import static com.here.xyz.psql.query.GetFeaturesByBBoxClustered.COUNTMODE_BOOL;
 
 import com.here.xyz.models.geojson.WebMercatorTile;
 import com.here.xyz.models.geojson.coordinates.BBox;

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeatures.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeatures.java
@@ -32,7 +32,6 @@ import com.here.xyz.models.geojson.implementation.FeatureCollection;
 import com.here.xyz.psql.DatabaseHandler;
 import com.here.xyz.psql.DatabaseWriter.ModificationType;
 import com.here.xyz.psql.SQLQuery;
-import com.here.xyz.psql.SQLQueryBuilder;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -256,7 +255,7 @@ public abstract class GetFeatures<E extends ContextAwareEvent> extends ExtendedS
     String geo = geoOverride != null ? "${{geoOverride}}" : ((isForce2D ? "ST_Force2D" : "ST_Force3D") + "(geo)");
 
     if (convertToGeoJson)
-      geo = "replace(ST_AsGeojson(" + geo + ", " + SQLQueryBuilder.GEOMETRY_DECIMAL_DIGITS + "), 'nan', '0')";
+      geo = "replace(ST_AsGeojson(" + geo + ", " + GetFeaturesByBBox.GEOMETRY_DECIMAL_DIGITS + "), 'nan', '0')";
 
     SQLQuery geoFragment = new SQLQuery(geo + " as geo");
     if (geoOverride != null)

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeatures.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeatures.java
@@ -66,7 +66,7 @@ public abstract class GetFeatures<E extends ContextAwareEvent, R extends XyzResp
     else {
       query = new SQLQuery(
           "SELECT ${{selection}}, ${{geo}}${{iColumn}}"
-              + "    FROM ${schema}.${table}"
+              + "    FROM ${schema}.${table} ${{tableSample}}"
               + "    WHERE ${{filterWhereClause}} ${{deletedCheck}} ${{versionCheck}} ${{authorCheck}} ${{orderBy}} ${{limit}} ${{offset}}");
     }
 
@@ -76,6 +76,7 @@ public abstract class GetFeatures<E extends ContextAwareEvent, R extends XyzResp
     query.setQueryFragment("selection", buildSelectionFragment(event));
     query.setQueryFragment("geo", buildGeoFragment(event));
     query.setQueryFragment("iColumn", ""); //NOTE: This can be overridden by implementing subclasses
+    query.setQueryFragment("tableSample", ""); //NOTE: This can be overridden by implementing subclasses
     query.setQueryFragment("limit", ""); //NOTE: This can be overridden by implementing subclasses
 
     query.setVariable(SCHEMA, getSchema());

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeatures.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeatures.java
@@ -28,17 +28,17 @@ import com.here.xyz.connectors.ErrorResponseException;
 import com.here.xyz.events.ContextAwareEvent;
 import com.here.xyz.events.QueryEvent;
 import com.here.xyz.events.SelectiveEvent;
-import com.here.xyz.models.geojson.implementation.FeatureCollection;
 import com.here.xyz.psql.DatabaseHandler;
 import com.here.xyz.psql.DatabaseWriter.ModificationType;
 import com.here.xyz.psql.SQLQuery;
+import com.here.xyz.responses.XyzResponse;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-public abstract class GetFeatures<E extends ContextAwareEvent> extends ExtendedSpace<E, FeatureCollection> {
+public abstract class GetFeatures<E extends ContextAwareEvent, R extends XyzResponse> extends ExtendedSpace<E, R> {
 
   public GetFeatures(E event, DatabaseHandler dbHandler) throws SQLException, ErrorResponseException {
     super(event, dbHandler);
@@ -46,7 +46,7 @@ public abstract class GetFeatures<E extends ContextAwareEvent> extends ExtendedS
   }
 
   @Override
-  protected SQLQuery buildQuery(E event) throws SQLException {
+  protected SQLQuery buildQuery(E event) throws SQLException, ErrorResponseException {
     boolean isExtended = isExtendedSpace(event) && event.getContext() == DEFAULT;
     SQLQuery query;
     if (isExtended) {
@@ -198,8 +198,8 @@ public abstract class GetFeatures<E extends ContextAwareEvent> extends ExtendedS
   }
 
   @Override
-  public FeatureCollection handle(ResultSet rs) throws SQLException {
-    return dbHandler.defaultFeatureResultSetHandler(rs);
+  public R handle(ResultSet rs) throws SQLException {
+    return (R) dbHandler.defaultFeatureResultSetHandler(rs);
   }
 
   protected static SQLQuery buildSelectionFragment(ContextAwareEvent event) {

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeaturesByBBox.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeaturesByBBox.java
@@ -24,36 +24,535 @@ import static com.here.xyz.events.GetFeaturesByTileEvent.ResponseType.GEO_JSON;
 
 import com.here.xyz.connectors.ErrorResponseException;
 import com.here.xyz.events.GetFeaturesByBBoxEvent;
+import com.here.xyz.events.GetFeaturesByTileEvent;
+import com.here.xyz.events.GetFeaturesByTileEvent.ResponseType;
+import com.here.xyz.events.QueryEvent;
+import com.here.xyz.models.geojson.WebMercatorTile;
 import com.here.xyz.models.geojson.coordinates.BBox;
 import com.here.xyz.psql.DatabaseHandler;
 import com.here.xyz.psql.SQLQuery;
-import com.here.xyz.psql.SQLQueryBuilder;
+import com.here.xyz.psql.config.PSQLConfig;
+import com.here.xyz.psql.factory.H3SQL;
+import com.here.xyz.psql.factory.QuadbinSQL;
+import com.here.xyz.psql.factory.TweaksSQL;
+import com.here.xyz.psql.tools.DhString;
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
 
 public class GetFeaturesByBBox<E extends GetFeaturesByBBoxEvent> extends Spatial<E> {
 
+  public static final long GEOMETRY_DECIMAL_DIGITS = 8;
+
   public GetFeaturesByBBox(E event, DatabaseHandler dbHandler) throws SQLException, ErrorResponseException {
     super(event, dbHandler);
+  }
+
+  public static SQLQuery buildGetFeaturesByBBoxQuery(final GetFeaturesByBBoxEvent event)
+        throws SQLException{
+        final BBox bbox = event.getBbox();
+
+        final SQLQuery geoQuery = new SQLQuery("ST_Intersects(geo, ST_MakeEnvelope(?, ?, ?, ?, 4326))",
+                bbox.minLon(), bbox.minLat(), bbox.maxLon(), bbox.maxLat());
+
+        return generateCombinedQueryBWC(event, geoQuery);
+    }
+
+  /***************************************** CLUSTERING ******************************************************/
+
+    private static int evalH3Resolution( Map<String, Object> clusteringParams, int defaultResForLevel )
+    {
+     int h3res = defaultResForLevel, overzoomingRes = 2; // restrict to "defaultResForLevel + 2" as maximum resolution per level
+
+     if( clusteringParams == null ) return h3res;
+/** deprecated */
+     if( clusteringParams.get(H3SQL.HEXBIN_RESOLUTION) != null )
+      h3res = Math.min((Integer) clusteringParams.get(H3SQL.HEXBIN_RESOLUTION), defaultResForLevel + overzoomingRes);
+/***/
+     if( clusteringParams.get(H3SQL.HEXBIN_RESOLUTION_ABSOLUTE) != null )
+      h3res = Math.min((Integer) clusteringParams.get(H3SQL.HEXBIN_RESOLUTION_ABSOLUTE), defaultResForLevel + overzoomingRes);
+
+     if( clusteringParams.get(H3SQL.HEXBIN_RESOLUTION_RELATIVE) != null )
+      h3res += Math.max(-2, Math.min( 2, (Integer) clusteringParams.get(H3SQL.HEXBIN_RESOLUTION_RELATIVE)));
+
+     return Math.min( Math.min( h3res, defaultResForLevel + overzoomingRes ) , 13 ); // cut to maximum res
+    }
+
+  public static SQLQuery buildHexbinClusteringQuery(
+            GetFeaturesByBBoxEvent event, BBox bbox,
+            Map<String, Object> clusteringParams) {
+
+        int zLevel = (event instanceof GetFeaturesByTileEvent ? ((GetFeaturesByTileEvent) event).getLevel() : H3SQL.bbox2zoom(bbox)),
+            defaultResForLevel = H3SQL.zoom2resolution(zLevel),
+            h3res = evalH3Resolution( clusteringParams, defaultResForLevel );
+
+        if( zLevel == 1)  // prevent ERROR:  Antipodal (180 degrees long) edge detected!
+         if( bbox.minLon() == 0.0 )
+          bbox.setEast( bbox.maxLon() - 0.0001 );
+         else
+          bbox.setWest( bbox.minLon() + 0.0001);
+
+        String statisticalProperty = (String) clusteringParams.get(H3SQL.HEXBIN_PROPERTY);
+        boolean statisticalPropertyProvided = (statisticalProperty != null && statisticalProperty.length() > 0),
+                h3cflip = (clusteringParams.get(H3SQL.HEXBIN_POINTMODE) == Boolean.TRUE);
+               /** todo: replace format %.14f with parameterized version*/
+        final String expBboxSql = String
+                .format("st_envelope( st_buffer( ST_MakeEnvelope(%.14f,%.14f,%.14f,%.14f, 4326)::geography, ( 2.5 * edgeLengthM( %d )) )::geometry )",
+                        bbox.minLon(), bbox.minLat(), bbox.maxLon(), bbox.maxLat(), h3res);
+
+        /*clippedGeo - passed bbox is extended by "margin" on service level */
+        String clippedGeo = (!event.getClip() ? "geo" : String
+                .format("ST_Intersection(st_makevalid(geo),ST_MakeEnvelope(%.14f,%.14f,%.14f,%.14f,4326) )", bbox.minLon(), bbox.minLat(), bbox.maxLon(), bbox.maxLat())),
+                fid = (!event.getClip() ? "h3" : DhString.format("h3 || %f || %f", bbox.minLon(), bbox.minLat())),
+                filterEmptyGeo = (!event.getClip() ? "" : DhString.format(" and not st_isempty( %s ) ", clippedGeo));
+
+        final SQLQuery searchQuery = generateSearchQueryBWC(event);
+
+        String aggField = (statisticalPropertyProvided ? "jsonb_set('{}'::jsonb, ? , agg::jsonb)::json" : "agg");
+
+        final SQLQuery query = new SQLQuery(DhString.format(H3SQL.h3sqlBegin, h3res,
+                !h3cflip ? "st_centroid(geo)" : "geo",
+                DhString.format( (getResponseType(event) == GEO_JSON ? "st_asgeojson( %1$s, 7 )::json" : "(%1$s)" ), (h3cflip ? "st_centroid(geo)" : clippedGeo) ),
+                statisticalPropertyProvided ? ", min, max, sum, avg, median" : "",
+                zLevel,
+                !h3cflip ? "centroid" : "hexagon",
+                aggField,
+                fid,
+                expBboxSql));
+
+        if (statisticalPropertyProvided) {
+            ArrayList<String> jpath = new ArrayList<>();
+            jpath.add(statisticalProperty);
+            query.addParameter(jpath.toArray(new String[]{}));
+        }
+
+        int pxSize = H3SQL.adjPixelSize( h3res, defaultResForLevel );
+
+        String h3sqlMid = H3SQL.h3sqlMid( clusteringParams.get(H3SQL.HEXBIN_SINGLECOORD) == Boolean.TRUE );
+
+        int samplingStrength = samplingStrengthFromText((String) clusteringParams.getOrDefault(H3SQL.HEXBIN_SAMPLING, "off"),false);
+        String samplingCondition =  ( samplingStrength <= 0 ? "1 = 1" : TweaksSQL.strengthSql( samplingStrength, true) );
+
+        if (!statisticalPropertyProvided) {
+            query.append(new SQLQuery(DhString.format(h3sqlMid, h3res, "(0.0)::numeric", zLevel, pxSize,expBboxSql,samplingCondition)));
+        } else {
+            ArrayList<String> jpath = new ArrayList<>();
+            jpath.add("properties");
+            jpath.addAll(Arrays.asList(statisticalProperty.split("\\.")));
+
+            query.append(new SQLQuery(DhString.format(h3sqlMid, h3res, "(jsondata#>> ?)::numeric", zLevel, pxSize,expBboxSql,samplingCondition)));
+            query.addParameter(jpath.toArray(new String[]{}));
+        }
+
+        if (searchQuery != null) {
+            query.append(" and ");
+            query.append(searchQuery);
+        }
+
+        query.append(DhString.format(H3SQL.h3sqlEnd, filterEmptyGeo));
+        query.append("LIMIT ?", event.getLimit());
+
+        return query;
+    }
+
+  private static WebMercatorTile getTileFromBbox(BBox bbox)
+    {
+     /* Quadkey calc */
+     final int lev = WebMercatorTile.getZoomFromBBOX(bbox);
+     double lon2 = bbox.minLon() + ((bbox.maxLon() - bbox.minLon()) / 2);
+     double lat2 = bbox.minLat() + ((bbox.maxLat() - bbox.minLat()) / 2);
+
+     return WebMercatorTile.getTileFromLatLonLev(lat2, lon2, lev);
+    }
+
+  public static SQLQuery buildQuadbinClusteringQuery(GetFeaturesByBBoxEvent event,
+                                                          BBox bbox, int relResolution, int absResolution, String countMode,
+                                                          PSQLConfig config, boolean noBuffer) {
+        boolean isTileRequest = (event instanceof GetFeaturesByTileEvent) && ((GetFeaturesByTileEvent) event).getMargin() == 0,
+                clippedOnBbox = (!isTileRequest && event.getClip());
+
+        final WebMercatorTile tile = getTileFromBbox(bbox);
+
+        if( (absResolution - tile.level) >= 0 )  // case of valid absResolution convert it to a relative resolution and add both resolutions
+         relResolution = Math.min( relResolution + (absResolution - tile.level), 5);
+
+        SQLQuery propQuery;
+        String propQuerySQL = null;
+
+        if (event.getPropertiesQuery() != null) {
+            propQuery = generatePropertiesQueryBWC(event);
+
+            if (propQuery != null) {
+                propQuerySQL = propQuery.text();
+                for (Object param : propQuery.parameters()) {
+                    propQuerySQL = propQuerySQL.replaceFirst("\\?", "'" + param + "'");
+                }
+            }
+        }
+        return QuadbinSQL.generateQuadbinClusteringSQL(config.getDatabaseSettings().getSchema(), config.readTableFromEvent(event), relResolution, countMode, propQuerySQL, tile, bbox, isTileRequest, clippedOnBbox, noBuffer, getResponseType(event) == GEO_JSON);
+    }
+
+  /***************************************** TWEAKS **************************************************/
+
+  public static ResponseType getResponseType(GetFeaturesByBBoxEvent event) {
+    if (event instanceof GetFeaturesByTileEvent)
+      return ((GetFeaturesByTileEvent) event).getResponseType();
+    return GEO_JSON;
+  }
+
+  private static String map2MvtGeom( GetFeaturesByBBoxEvent event, BBox bbox, String tweaksGeoSql )
+  {
+   boolean bExtendTweaks = // -> 2048 only if tweaks or viz been specified explicit
+    ( "viz".equals(event.getOptimizationMode()) || (event.getTweakParams() != null && event.getTweakParams().size() > 0 ) );
+
+   int extend = ( bExtendTweaks ? 2048 : 4096 ), extendPerMargin = extend / WebMercatorTile.TileSizeInPixel, extendWithMargin = extend, level = -1, tileX = -1, tileY = -1, margin = 0;
+   boolean hereTile = false;
+
+   if( event instanceof GetFeaturesByTileEvent )
+   { GetFeaturesByTileEvent tevnt = (GetFeaturesByTileEvent) event;
+     level = tevnt.getLevel();
+     tileX = tevnt.getX();
+     tileY = tevnt.getY();
+     margin = tevnt.getMargin();
+     extendWithMargin = extend + (margin * extendPerMargin);
+     hereTile = tevnt.getHereTileFlag();
+   }
+   else
+   { final WebMercatorTile tile = getTileFromBbox(bbox);
+     level = tile.level;
+     tileX = tile.x;
+     tileY = tile.y;
+   }
+
+   double wgs3857width = 20037508.342789244d, wgs4326width = 180d,
+          wgsWidth = 2 * ( !hereTile ? wgs3857width : wgs4326width ),
+          xwidth = wgsWidth,
+          ywidth = wgsWidth,
+          gridsize = (1L << level),
+          stretchFactor = 1.0 + ( margin / ((double) WebMercatorTile.TileSizeInPixel)), // xyz-hub uses margin for tilesize of 256 pixel.
+          xProjShift = (!hereTile ? (tileX - gridsize/2 + 0.5) * (xwidth / gridsize)      : -180d + (tileX + 0.5) * (xwidth / gridsize) ) ,
+          yProjShift = (!hereTile ? (tileY - gridsize/2 + 0.5) * (ywidth / gridsize) * -1 :  -90d + (tileY + 0.5) * (ywidth / gridsize) ) ;
+
+   String
+    box2d   = DhString.format( DhString.format("ST_MakeEnvelope(%%.%1$df,%%.%1$df,%%.%1$df,%%.%1$df, 4326)", 14 /*GEOMETRY_DECIMAL_DIGITS*/), bbox.minLon(), bbox.minLat(), bbox.maxLon(), bbox.maxLat() ),
+      // 1. build mvt
+    mvtgeom = DhString.format( (!hereTile ? "st_asmvtgeom(st_force2d(st_transform(%1$s,3857)), st_transform(%2$s,3857),%3$d,0,true)"
+                                          : "st_asmvtgeom(st_force2d(%1$s), %2$s,%3$d,0,true)")
+                               , tweaksGeoSql, box2d, extendWithMargin);
+      // 2. project the mvt to tile
+    mvtgeom = DhString.format( (!hereTile ? "st_setsrid(st_translate(st_scale(st_translate(%1$s, %2$d , %2$d, 0.0), st_makepoint(%3$f,%4$f,1.0) ), %5$f , %6$f, 0.0 ), 3857)"
+                                          : "st_setsrid(st_translate(st_scale(st_translate(%1$s, %2$d , %2$d, 0.0), st_makepoint(%3$f,%4$f,1.0) ), %5$f , %6$f, 0.0 ), 4326)")
+                               ,mvtgeom
+                               ,-extendWithMargin/2 // => shift to stretch from tilecenter
+                               ,stretchFactor*(xwidth / (gridsize*extend)), stretchFactor * (ywidth / (gridsize*extend)) * -1 // stretch tile to proj. size
+                               ,xProjShift, yProjShift // shift to proj. position
+                             );
+      // 3 project tile to wgs84 and map invalid geom to null
+
+    mvtgeom = DhString.format( (!hereTile ? "(select case st_isvalid(g) when true then g else null end from st_transform(%1$s,4326) g)"
+                                          : "(select case st_isvalid(g) when true then g else null end from %1$s g)")
+                               , mvtgeom );
+
+      // 4. assure intersect with origin bbox in case of mapping errors
+    mvtgeom  = DhString.format("ST_Intersection(%1$s,st_setsrid(%2$s,4326))", mvtgeom, box2d);
+      // 5. map non-null but empty polygons to null - e.g. avoid -> "geometry": { "type": "Polygon", "coordinates": [] }
+    mvtgeom = DhString.format("(select case st_isempty(g) when false then g else null end from %1$s g)", mvtgeom );
+
+    // if geom = point | multipoint then no mvt <-> geo conversion should be done
+    mvtgeom = DhString.format("case strpos(ST_GeometryType( geo ), 'Point') > 0 when true then geo else %1$s end", mvtgeom );
+
+    return mvtgeom;
+  }
+
+  private static String clipProjGeom(BBox bbox, String tweaksGeoSql )
+  {
+   String fmt =  DhString.format(  " case st_within( %%1$s, ST_MakeEnvelope(%%2$.%1$df,%%3$.%1$df,%%4$.%1$df,%%5$.%1$df, 4326) ) "
+                               + "  when true then %%1$s "
+                               + "  else ST_Intersection(ST_MakeValid(%%1$s),ST_MakeEnvelope(%%2$.%1$df,%%3$.%1$df,%%4$.%1$df,%%5$.%1$df, 4326))"
+                               + " end " , 14 /*GEOMETRY_DECIMAL_DIGITS*/ );
+   return DhString.format( fmt, tweaksGeoSql, bbox.minLon(), bbox.minLat(), bbox.maxLon(), bbox.maxLat());
+  }
+
+  private static int samplingStrengthFromText( String sampling, boolean fiftyOnUnset )
+  {
+   int strength = 0;
+   switch( sampling.toLowerCase() )
+   { case "low"     : strength =  10;  break;
+     case "lowmed"  : strength =  30;  break;
+     case "med"     : strength =  50;  break;
+     case "medhigh" : strength =  75;  break;
+     case "high"    : strength = 100;  break;
+     default: if( fiftyOnUnset ) strength = 50;  break;
+   }
+
+   return strength;
+
+  }
+
+  public static SQLQuery buildSamplingTweaksQuery(GetFeaturesByBBoxEvent event, BBox bbox, Map tweakParams, boolean bSortByHashedValue) throws SQLException
+  {
+   int strength = 0;
+   boolean bDistribution  = true,
+           bDistribution2 = false,
+           bConvertGeo2Geojson = getResponseType(event) == GEO_JSON;
+
+   if( tweakParams != null )
+   {
+    if( tweakParams.get(TweaksSQL.SAMPLING_STRENGTH) instanceof Integer )
+     strength = (int) tweakParams.get(TweaksSQL.SAMPLING_STRENGTH);
+    else
+     strength = samplingStrengthFromText( (String) tweakParams.getOrDefault(TweaksSQL.SAMPLING_STRENGTH,"default"), true );
+
+     switch(((String) tweakParams.getOrDefault(TweaksSQL.SAMPLING_ALGORITHM, TweaksSQL.SAMPLING_ALGORITHM_DST)).toLowerCase() )
+     {
+       case TweaksSQL.SAMPLING_ALGORITHM_SZE  : bDistribution = false; break;
+       case TweaksSQL.SAMPLING_ALGORITHM_DST2 : bDistribution2 = true;
+       case TweaksSQL.SAMPLING_ALGORITHM_DST  :
+       default                                : bDistribution = true; break;
+     }
+   }
+
+   boolean bEnsureMode = TweaksSQL.ENSURE.equalsIgnoreCase(event.getTweakType());
+
+   float tblSampleRatio = ( (strength > 0 && bDistribution2) ? TweaksSQL.tableSampleRatio(strength) : -1f);
+
+   final String sCondition = ( ((bEnsureMode && strength == 0) || (tblSampleRatio >= 0.0)) ? "1 = 1" : TweaksSQL.strengthSql(strength,bDistribution)  ),
+                twqry = DhString.format(DhString.format("ST_Intersects(geo, ST_MakeEnvelope(%%.%1$df,%%.%1$df,%%.%1$df,%%.%1$df, 4326) ) and %%s", 14 /*GEOMETRY_DECIMAL_DIGITS*/), bbox.minLon(), bbox.minLat(), bbox.maxLon(), bbox.maxLat(), sCondition );
+
+   final SQLQuery tweakQuery = new SQLQuery(twqry);
+
+   if( !bEnsureMode || !bConvertGeo2Geojson ) {
+     SQLQuery combinedQuery = generateCombinedQueryBWC(event, tweakQuery);
+     if (tblSampleRatio > 0.0)
+       combinedQuery.setQueryFragment("tableSample", DhString.format("tablesample system(%.6f) repeatable(499)", 100.0 * tblSampleRatio));
+     if (bSortByHashedValue)
+       combinedQuery.setQueryFragment("orderBy", "ORDER BY " + TweaksSQL.distributionFunctionIndexExpression());
+     return combinedQuery;
+   }
+
+
+   /* TweaksSQL.ENSURE and geojson requested (no mvt) */
+   boolean bTestTweaksGeoIfNull = false;
+   String tweaksGeoSql = clipProjGeom(bbox,"geo");
+   tweaksGeoSql = map2MvtGeom( event, bbox, tweaksGeoSql );
+   //convert to geojson
+   tweaksGeoSql = ( bConvertGeo2Geojson ? DhString.format("replace(ST_AsGeojson(" + getForceMode(event.isForce2D()) + "( %s ),%d),'nan','0')",tweaksGeoSql,GEOMETRY_DECIMAL_DIGITS)
+                                        : DhString.format( getForceMode(event.isForce2D()) + "( %s )",tweaksGeoSql ) );
+
+   return generateCombinedQueryTweaks(event, tweakQuery , tweaksGeoSql, bTestTweaksGeoIfNull, tblSampleRatio, bSortByHashedValue );
+}
+
+  private static double cToleranceFromStrength(int strength )
+  {
+   double tolerance = 0.0001;
+   if(  strength > 0  && strength <= 25 )      tolerance = 0.0001 + ((0.001-0.0001)/25.0) * (strength -  1);
+   else if(  strength > 25 && strength <= 50 ) tolerance = 0.001  + ((0.01 -0.001) /25.0) * (strength - 26);
+   else if(  strength > 50 && strength <= 75 ) tolerance = 0.01   + ((0.1  -0.01)  /25.0) * (strength - 51);
+   else /* [76 - 100 ] */                      tolerance = 0.1    + ((1.0  -0.1)   /25.0) * (strength - 76);
+
+   return tolerance;
+  }
+
+  public static SQLQuery buildSimplificationTweaksQuery(GetFeaturesByBBoxEvent event, BBox bbox, Map tweakParams) throws SQLException
+  {
+   int strength = 0,
+       iMerge = 0;
+   String tweaksGeoSql = "geo";
+   boolean bStrength = true, bTestTweaksGeoIfNull = true, bConvertGeo2Geojson = getResponseType(event) == GEO_JSON, bMvtRequested = !bConvertGeo2Geojson;
+
+   if( tweakParams != null )
+   {
+    if( tweakParams.get(TweaksSQL.SIMPLIFICATION_STRENGTH) instanceof Integer )
+     strength = (int) tweakParams.get(TweaksSQL.SIMPLIFICATION_STRENGTH);
+    else
+     switch(((String) tweakParams.getOrDefault(TweaksSQL.SIMPLIFICATION_STRENGTH,"default")).toLowerCase() )
+     { case "low"     : strength =  20;  break;
+       case "lowmed"  : strength =  40;  break;
+       case "med"     : strength =  60;  break;
+       case "medhigh" : strength =  80;  break;
+       case "high"    : strength = 100; break;
+       case "default" : bStrength = false;
+       default: strength  = 50; break;
+     }
+
+     String tweaksAlgorithm = ((String) tweakParams.getOrDefault(TweaksSQL.SIMPLIFICATION_ALGORITHM,"default")).toLowerCase();
+
+     // do clip before simplification -- preventing extrem large polygon for further working steps (except for mvt with gridbytilelevel, redundancy)
+     if (event.getClip() && !( TweaksSQL.SIMPLIFICATION_ALGORITHM_A05.equals( tweaksAlgorithm ) && bMvtRequested ) )
+      tweaksGeoSql = clipProjGeom( bbox,tweaksGeoSql );
+
+     //SIMPLIFICATION_ALGORITHM
+     int hint = 0;
+     String[] pgisAlgorithm = { "ST_SnapToGrid", "ftm_SimplifyPreserveTopology", "ftm_Simplify" };
+
+     switch( tweaksAlgorithm )
+     {
+       case TweaksSQL.SIMPLIFICATION_ALGORITHM_A03 : hint++;
+       case TweaksSQL.SIMPLIFICATION_ALGORITHM_A02 : hint++;
+       case TweaksSQL.SIMPLIFICATION_ALGORITHM_A01 :
+       {
+        double tolerance = ( bStrength ? cToleranceFromStrength( strength ) : Math.abs( bbox.maxLon() - bbox.minLon() ) / 4096 );
+        tweaksGeoSql = DhString.format("%s(%s, %f)", pgisAlgorithm[hint], tweaksGeoSql, tolerance );
+       }
+       break;
+
+       case TweaksSQL.SIMPLIFICATION_ALGORITHM_A05 : // gridbytilelevel - convert to/from mvt
+       {
+        if(!bMvtRequested)
+         tweaksGeoSql = map2MvtGeom( event, bbox, tweaksGeoSql );
+        bTestTweaksGeoIfNull = false;
+       }
+       break;
+
+       case TweaksSQL.SIMPLIFICATION_ALGORITHM_A06 : iMerge++;
+       case TweaksSQL.SIMPLIFICATION_ALGORITHM_A04 : iMerge++; break;
+
+       default: break;
+     }
+
+     //convert to geojson
+     tweaksGeoSql = ( bConvertGeo2Geojson ? DhString.format("replace(ST_AsGeojson(" + getForceMode(event.isForce2D()) + "( %s ),%d),'nan','0')",tweaksGeoSql,GEOMETRY_DECIMAL_DIGITS)
+                                          : DhString.format( getForceMode(event.isForce2D()) + "( %s )",tweaksGeoSql) );
+   }
+
+     final String bboxqry = DhString.format( DhString.format("ST_Intersects(geo, ST_MakeEnvelope(%%.%1$df,%%.%1$df,%%.%1$df,%%.%1$df, 4326) )", 14 /*GEOMETRY_DECIMAL_DIGITS*/), bbox.minLon(), bbox.minLat(), bbox.maxLon(), bbox.maxLat() );
+
+     if( iMerge == 0 )
+      return generateCombinedQueryTweaks(event, new SQLQuery(bboxqry), tweaksGeoSql, bTestTweaksGeoIfNull);
+
+     // Merge Algorithm - only using low, med, high
+
+     int minGeoHashLenToMerge = 0,
+         minGeoHashLenForLineMerge = 3;
+
+     if      ( strength <= 20 ) { minGeoHashLenToMerge = 7; minGeoHashLenForLineMerge = 7; } //low
+     else if ( strength <= 40 ) { minGeoHashLenToMerge = 6; minGeoHashLenForLineMerge = 6; } //lowmed
+     else if ( strength <= 60 ) { minGeoHashLenToMerge = 6; minGeoHashLenForLineMerge = 5; } //med
+     else if ( strength <= 80 ) {                           minGeoHashLenForLineMerge = 4; } //medhigh
+
+     if( "geo".equals(tweaksGeoSql) ) // formal, just in case
+      tweaksGeoSql = ( bConvertGeo2Geojson ? DhString.format("replace(ST_AsGeojson(" + getForceMode(event.isForce2D()) + "( %s ),%d),'nan','0')",tweaksGeoSql,GEOMETRY_DECIMAL_DIGITS)
+                                           : DhString.format(getForceMode(event.isForce2D()) + "( %s )",tweaksGeoSql) );
+
+     if( bConvertGeo2Geojson )
+      tweaksGeoSql = DhString.format("(%s)::jsonb", tweaksGeoSql);
+
+      SQLQuery query =
+       ( iMerge == 1 ? new SQLQuery( DhString.format( TweaksSQL.mergeBeginSql, tweaksGeoSql, minGeoHashLenToMerge, bboxqry ) )
+                     : new SQLQuery( DhString.format( TweaksSQL.linemergeBeginSql, /*(event.getClip() ? clipProjGeom(bbox,"geo") : "geo")*/ "geo" , bboxqry ) ));  // use clipped geom as input (?)
+
+    final SQLQuery searchQuery = generateSearchQueryBWC(event);
+     if (searchQuery != null)
+     { query.append(" and ");
+       query.append(searchQuery);
+     }
+
+     if( iMerge == 1 )
+      query.append( TweaksSQL.mergeEndSql(bConvertGeo2Geojson) );
+     else
+     { query.append( DhString.format( TweaksSQL.linemergeEndSql1, minGeoHashLenForLineMerge ) );
+       query.append(SQLQuery.selectJson(event));
+       query.append( DhString.format( TweaksSQL.linemergeEndSql2, tweaksGeoSql ) );
+     }
+
+     query.append("LIMIT ?", event.getLimit());
+
+     return query;
+}
+
+  public static SQLQuery buildEstimateSamplingStrengthQuery( GetFeaturesByBBoxEvent event, BBox bbox, String relTuples )
+  {
+   int level, tileX, tileY, margin = 0;
+
+   if( event instanceof GetFeaturesByTileEvent )
+   { GetFeaturesByTileEvent tevnt = (GetFeaturesByTileEvent) event;
+     level = tevnt.getLevel();
+     tileX = tevnt.getX();
+     tileY = tevnt.getY();
+     margin = tevnt.getMargin();
+   }
+   else
+   { final WebMercatorTile tile = getTileFromBbox(bbox);
+     level = tile.level;
+     tileX = tile.x;
+     tileY = tile.y;
+   }
+
+   ArrayList<BBox> listOfBBoxes = new ArrayList<BBox>();
+   int nrTilesXY = 1 << level;
+
+   for( int dy = -1; dy < 2; dy++ )
+    for( int dx = -1; dx < 2; dx++ )
+     if( (dy == 0) && (dx == 0) ) listOfBBoxes.add(bbox);  // centerbox, this is already extended by margin
+     else if( ((tileY + dy) > 0) && ((tileY + dy) < nrTilesXY) )
+      listOfBBoxes.add( WebMercatorTile.forWeb(level, ((nrTilesXY +(tileX + dx)) % nrTilesXY) , (tileY + dy)).getExtendedBBox(margin) );
+
+   int flag = 0;
+   StringBuilder sb = new StringBuilder();
+   for (BBox b : listOfBBoxes)
+    sb.append(DhString.format("%s%s",( flag++ > 0 ? "," : ""),DhString.format( TweaksSQL.requestedTileBoundsSql , b.minLon(), b.minLat(), b.maxLon(), b.maxLat() )));
+
+   String estimateSubSql = ( relTuples == null ? TweaksSQL.estWithPgClass : DhString.format( TweaksSQL.estWithoutPgClass, relTuples ) );
+
+   return new SQLQuery( DhString.format( TweaksSQL.estimateCountByBboxesSql, sb.toString(), estimateSubSql ) );
+  }
+
+  /** ###################################################################################### */
+
+  private static SQLQuery generateCombinedQueryTweaks(GetFeaturesByBBoxEvent event, SQLQuery indexedQuery, String tweaksgeo, boolean bTestTweaksGeoIfNull, float sampleRatio, boolean bSortByHashedValue)
+    {
+      SQLQuery searchQuery = generateSearchQueryBWC(event);
+     String tSample = ( sampleRatio <= 0.0 ? "" : DhString.format("tablesample system(%.6f) repeatable(499)", 100.0 * sampleRatio) );
+
+     final SQLQuery query = new SQLQuery("select * from ( SELECT");
+
+     query.append(SQLQuery.selectJson(event));
+
+     query.append(DhString.format(",%s as geo",tweaksgeo));
+
+     query.append( DhString.format("FROM ${schema}.${table} %s WHERE",tSample) );
+     query.append(indexedQuery);
+
+     if( searchQuery != null )
+     { query.append(" and ");
+       query.append(searchQuery);
+     }
+
+     if( bSortByHashedValue )
+      query.append( DhString.format( " order by %s ", TweaksSQL.distributionFunctionIndexExpression() ) );
+
+     query.append(DhString.format(" ) tw where %s ", bTestTweaksGeoIfNull ? "geo is not null" : "1 = 1" ) );
+
+     query.append("LIMIT ?", event.getLimit());
+     return query;
+    }
+
+  private static SQLQuery generateCombinedQueryTweaks(GetFeaturesByBBoxEvent event, SQLQuery indexedQuery, String tweaksgeo, boolean bTestTweaksGeoIfNull)
+    { return generateCombinedQueryTweaks(event, indexedQuery, tweaksgeo, bTestTweaksGeoIfNull, -1.0f, false );  }
+
+  public static String getForceMode(boolean isForce2D) {
+    return isForce2D ? "ST_Force2D" : "ST_Force3D";
   }
 
   @Override
   protected SQLQuery buildQuery(E event) throws SQLException {
     //NOTE: So far this query runner only handles queries regarding extended spaces
     if (isExtendedSpace(event) && event.getContext() == DEFAULT) {
-      SQLQuery geoQuery = new SQLQuery("ST_Intersects(geo, ST_MakeEnvelope(#{minLon}, #{minLat}, #{maxLon}, #{maxLat}, 4326))");
-      final BBox bbox = event.getBbox();
-      geoQuery.setNamedParameter("minLon", bbox.minLon());
-      geoQuery.setNamedParameter("minLat", bbox.minLat());
-      geoQuery.setNamedParameter("maxLon", bbox.maxLon());
-      geoQuery.setNamedParameter("maxLat", bbox.maxLat());
-
       SQLQuery query = super.buildQuery(event);
 
-      SQLQuery filterWhereClause = new SQLQuery("${{geoQuery}} AND ${{searchQuery}}");
-      filterWhereClause.setQueryFragment("geoQuery", geoQuery);
-      filterWhereClause.setQueryFragment("searchQuery", query.getQueryFragment("filterWhereClause"));
-      query.setQueryFragment("filterWhereClause", filterWhereClause);
-      return query;
+      final BBox bbox = event.getBbox();
+      SQLQuery geoQuery = new SQLQuery("ST_Intersects(geo, ST_MakeEnvelope(#{minLon}, #{minLat}, #{maxLon}, #{maxLat}, 4326))")
+          .withNamedParameter("minLon", bbox.minLon())
+          .withNamedParameter("minLat", bbox.minLat())
+          .withNamedParameter("maxLon", bbox.maxLon())
+          .withNamedParameter("maxLat", bbox.maxLat());
+
+      SQLQuery filterWhereClause = new SQLQuery("${{geoQuery}} AND ${{searchQuery}}")
+          .withQueryFragment("geoQuery", geoQuery)
+          .withQueryFragment("searchQuery", query.getQueryFragment("filterWhereClause"));
+
+      return query.withQueryFragment("filterWhereClause", filterWhereClause);
     }
     return null;
   }
@@ -102,17 +601,20 @@ public class GetFeaturesByBBox<E extends GetFeaturesByBBoxEvent> extends Spatial
   }
 
   static SQLQuery buildClippedGeoFragment(final GetFeaturesByBBoxEvent event) {
-    boolean convertToGeoJson = SQLQueryBuilder.getResponseType(event) == GEO_JSON;
+    boolean convertToGeoJson = getResponseType(event) == GEO_JSON;
     if (!event.getClip())
       return buildGeoFragment(event, convertToGeoJson);
 
     //TODO: Refactor by re-using geoFilter for clippedGeo (see: GetFeaturesByGeometry#buildClippedGeoFragment())
-    SQLQuery clippedGeo = new SQLQuery("ST_Intersection(ST_MakeValid(geo), ST_MakeEnvelope(#{minLon}, #{minLat}, #{maxLon}, #{maxLat}, 4326))");
+
     final BBox bbox = event.getBbox();
-    clippedGeo.setNamedParameter("minLon", bbox.minLon());
-    clippedGeo.setNamedParameter("minLat", bbox.minLat());
-    clippedGeo.setNamedParameter("maxLon", bbox.maxLon());
-    clippedGeo.setNamedParameter("maxLat", bbox.maxLat());
+
+    SQLQuery clippedGeo = new SQLQuery("ST_Intersection(ST_MakeValid(geo), ST_MakeEnvelope(#{minLon}, #{minLat}, #{maxLon}, #{maxLat}, 4326))")
+        .withNamedParameter("minLon", bbox.minLon())
+        .withNamedParameter("minLat", bbox.minLat())
+        .withNamedParameter("maxLon", bbox.maxLon())
+        .withNamedParameter("maxLat", bbox.maxLat());
+
     return buildGeoFragment(event, convertToGeoJson, clippedGeo);
   }
 }

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeaturesByBBoxClustered.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeaturesByBBoxClustered.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright (C) 2017-2022 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.xyz.psql.query;
+
+import static com.here.xyz.events.GetFeaturesByTileEvent.ResponseType.GEO_JSON;
+import static com.here.xyz.responses.XyzError.ILLEGAL_ARGUMENT;
+
+import com.here.xyz.connectors.ErrorResponseException;
+import com.here.xyz.events.GetFeaturesByBBoxEvent;
+import com.here.xyz.events.GetFeaturesByTileEvent;
+import com.here.xyz.models.geojson.WebMercatorTile;
+import com.here.xyz.models.geojson.coordinates.BBox;
+import com.here.xyz.psql.DatabaseHandler;
+import com.here.xyz.psql.SQLQuery;
+import com.here.xyz.psql.factory.H3SQL;
+import com.here.xyz.psql.factory.QuadbinSQL;
+import com.here.xyz.psql.factory.TweaksSQL;
+import com.here.xyz.psql.tools.DhString;
+import com.here.xyz.responses.XyzResponse;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+
+public class GetFeaturesByBBoxClustered<E extends GetFeaturesByBBoxEvent, R extends XyzResponse> extends GetFeaturesByBBox<E, R> {
+
+  public static final String COUNTMODE_REAL      = "real";  // Real live counts via count(*)
+  public static final String COUNTMODE_ESTIMATED = "estimated"; // Estimated counts, determined with _postgis_selectivity() or EXPLAIN Plan analyze
+  public static final String COUNTMODE_MIXED     = "mixed"; // Combination of real and estimated.
+  public static final String COUNTMODE_BOOL      = "bool"; // no counts but test [0|1] if data exists int tile.
+  private boolean isMvtRequested;
+
+  public GetFeaturesByBBoxClustered(E event, DatabaseHandler dbHandler)
+      throws SQLException, ErrorResponseException {
+    super(event, dbHandler);
+  }
+
+  @Override
+  protected SQLQuery buildQuery(E event) throws SQLException, ErrorResponseException {
+    isMvtRequested = isMvtRequested(event);
+    SQLQuery query;
+    switch(event.getClusteringType().toLowerCase()) {
+      case H3SQL.HEXBIN: {
+        query = buildHexbinClusteringQuery(event);
+
+        if (isMvtRequested)
+          return GetFeaturesByBBox.buildMvtEncapsuledQuery((GetFeaturesByTileEvent) event, query);
+        return query;
+      }
+      case QuadbinSQL.QUAD: {
+        setUseReadReplica(true);
+        query = buildQuadbinClusteringQuery(event, dbHandler);
+
+        if (isMvtRequested)
+          return GetFeaturesByBBox.buildMvtEncapsuledQuery(dbHandler.getConfig().readTableFromEvent(event), (GetFeaturesByTileEvent) event, query);
+        return query;
+      }
+      default: {
+        throw new ErrorResponseException(ILLEGAL_ARGUMENT, "Invalid clustering type provided. Allowed values are: "
+            + H3SQL.HEXBIN + ", " + QuadbinSQL.QUAD);
+      }
+    }
+  }
+
+  @Override
+  public R handle(ResultSet rs) throws SQLException {
+    return isMvtRequested ? (R) dbHandler.defaultBinaryResultSetHandler(rs) : super.handle(rs);
+  }
+
+  /**
+   * Check if request parameters are valid. In case of invalidity throw an Exception
+   */
+  private static void checkQuadbinInput(String countMode, int relResolution, GetFeaturesByBBoxEvent event, DatabaseHandler dbHandler) throws ErrorResponseException
+  {
+    if( countMode != null )
+     switch( countMode.toLowerCase() )
+     { case COUNTMODE_REAL : case COUNTMODE_ESTIMATED: case COUNTMODE_MIXED: case COUNTMODE_BOOL : break;
+       default:
+        throw new ErrorResponseException(ILLEGAL_ARGUMENT,
+             "Invalid request parameters. Unknown clustering.countmode="+countMode+". Available are: ["+ COUNTMODE_REAL
+            +","+ COUNTMODE_ESTIMATED +","+ COUNTMODE_MIXED +","+ COUNTMODE_BOOL +"]!");
+     }
+
+    if(relResolution > 5)
+      throw new ErrorResponseException(ILLEGAL_ARGUMENT,
+          "Invalid request parameters. clustering.relativeResolution="+relResolution+" to high. 5 is maximum!");
+
+    if(event.getPropertiesQuery() != null && event.getPropertiesQuery().get(0).size() != 1)
+      throw new ErrorResponseException(ILLEGAL_ARGUMENT,
+          "Invalid request parameters. Only one Property is allowed");
+
+    checkCanSearchFor(event, dbHandler);
+  }
+
+  /***************************************** CLUSTERING ******************************************************/
+
+    private static int evalH3Resolution( Map<String, Object> clusteringParams, int defaultResForLevel )
+    {
+     int h3res = defaultResForLevel, overzoomingRes = 2; // restrict to "defaultResForLevel + 2" as maximum resolution per level
+
+     if( clusteringParams == null ) return h3res;
+/** deprecated */
+     if( clusteringParams.get(H3SQL.HEXBIN_RESOLUTION) != null )
+      h3res = Math.min((Integer) clusteringParams.get(H3SQL.HEXBIN_RESOLUTION), defaultResForLevel + overzoomingRes);
+/***/
+     if( clusteringParams.get(H3SQL.HEXBIN_RESOLUTION_ABSOLUTE) != null )
+      h3res = Math.min((Integer) clusteringParams.get(H3SQL.HEXBIN_RESOLUTION_ABSOLUTE), defaultResForLevel + overzoomingRes);
+
+     if( clusteringParams.get(H3SQL.HEXBIN_RESOLUTION_RELATIVE) != null )
+      h3res += Math.max(-2, Math.min( 2, (Integer) clusteringParams.get(H3SQL.HEXBIN_RESOLUTION_RELATIVE)));
+
+     return Math.min( Math.min( h3res, defaultResForLevel + overzoomingRes ) , 13 ); // cut to maximum res
+    }
+
+  public static SQLQuery buildHexbinClusteringQuery(
+            GetFeaturesByBBoxEvent event) {
+    BBox bbox = event.getBbox();
+    Map<String, Object> clusteringParams = event.getClusteringParams();
+
+        int zLevel = (event instanceof GetFeaturesByTileEvent ? ((GetFeaturesByTileEvent) event).getLevel() : H3SQL.bbox2zoom(bbox)),
+            defaultResForLevel = H3SQL.zoom2resolution(zLevel),
+            h3res = evalH3Resolution( clusteringParams, defaultResForLevel );
+
+        if( zLevel == 1)  // prevent ERROR:  Antipodal (180 degrees long) edge detected!
+         if( bbox.minLon() == 0.0 )
+          bbox.setEast( bbox.maxLon() - 0.0001 );
+         else
+          bbox.setWest( bbox.minLon() + 0.0001);
+
+        String statisticalProperty = (String) clusteringParams.get(H3SQL.HEXBIN_PROPERTY);
+        boolean statisticalPropertyProvided = (statisticalProperty != null && statisticalProperty.length() > 0),
+                h3cflip = (clusteringParams.get(H3SQL.HEXBIN_POINTMODE) == Boolean.TRUE);
+               /** todo: replace format %.14f with parameterized version*/
+        final String expBboxSql = String
+                .format("st_envelope( st_buffer( ST_MakeEnvelope(%.14f,%.14f,%.14f,%.14f, 4326)::geography, ( 2.5 * edgeLengthM( %d )) )::geometry )",
+                        bbox.minLon(), bbox.minLat(), bbox.maxLon(), bbox.maxLat(), h3res);
+
+        /*clippedGeo - passed bbox is extended by "margin" on service level */
+        String clippedGeo = (!event.getClip() ? "geo" : String
+                .format("ST_Intersection(st_makevalid(geo),ST_MakeEnvelope(%.14f,%.14f,%.14f,%.14f,4326) )", bbox.minLon(), bbox.minLat(), bbox.maxLon(), bbox.maxLat())),
+                fid = (!event.getClip() ? "h3" : DhString.format("h3 || %f || %f", bbox.minLon(), bbox.minLat())),
+                filterEmptyGeo = (!event.getClip() ? "" : DhString.format(" and not st_isempty( %s ) ", clippedGeo));
+
+        final SQLQuery searchQuery = generateSearchQueryBWC(event);
+
+        String aggField = (statisticalPropertyProvided ? "jsonb_set('{}'::jsonb, ? , agg::jsonb)::json" : "agg");
+
+        final SQLQuery query = new SQLQuery(DhString.format(H3SQL.h3sqlBegin, h3res,
+                !h3cflip ? "st_centroid(geo)" : "geo",
+                DhString.format( (getResponseType(event) == GEO_JSON ? "st_asgeojson( %1$s, 7 )::json" : "(%1$s)" ), (h3cflip ? "st_centroid(geo)" : clippedGeo) ),
+                statisticalPropertyProvided ? ", min, max, sum, avg, median" : "",
+                zLevel,
+                !h3cflip ? "centroid" : "hexagon",
+                aggField,
+                fid,
+                expBboxSql));
+
+        if (statisticalPropertyProvided) {
+            ArrayList<String> jpath = new ArrayList<>();
+            jpath.add(statisticalProperty);
+            query.addParameter(jpath.toArray(new String[]{}));
+        }
+
+        int pxSize = H3SQL.adjPixelSize( h3res, defaultResForLevel );
+
+        String h3sqlMid = H3SQL.h3sqlMid( clusteringParams.get(H3SQL.HEXBIN_SINGLECOORD) == Boolean.TRUE );
+
+        int samplingStrength = samplingStrengthFromText((String) clusteringParams.getOrDefault(H3SQL.HEXBIN_SAMPLING, "off"),false);
+        String samplingCondition =  ( samplingStrength <= 0 ? "1 = 1" : TweaksSQL.strengthSql( samplingStrength, true) );
+
+        if (!statisticalPropertyProvided) {
+            query.append(new SQLQuery(DhString.format(h3sqlMid, h3res, "(0.0)::numeric", zLevel, pxSize,expBboxSql,samplingCondition)));
+        } else {
+            ArrayList<String> jpath = new ArrayList<>();
+            jpath.add("properties");
+            jpath.addAll(Arrays.asList(statisticalProperty.split("\\.")));
+
+            query.append(new SQLQuery(DhString.format(h3sqlMid, h3res, "(jsondata#>> ?)::numeric", zLevel, pxSize,expBboxSql,samplingCondition)));
+            query.addParameter(jpath.toArray(new String[]{}));
+        }
+
+        if (searchQuery != null) {
+            query.append(" and ");
+            query.append(searchQuery);
+        }
+
+        query.append(DhString.format(H3SQL.h3sqlEnd, filterEmptyGeo));
+        query.append("LIMIT ?", event.getLimit());
+
+        return query;
+    }
+
+  public static SQLQuery buildQuadbinClusteringQuery(GetFeaturesByBBoxEvent event, DatabaseHandler dbHandler)
+      throws ErrorResponseException {
+
+    final Map<String, Object> clusteringParams = event.getClusteringParams();
+    int relResolution = ( clusteringParams.get(QuadbinSQL.QUADBIN_RESOLUTION) != null ? (int) clusteringParams.get(QuadbinSQL.QUADBIN_RESOLUTION) :
+        ( clusteringParams.get(QuadbinSQL.QUADBIN_RESOLUTION_RELATIVE) != null ? (int) clusteringParams.get(QuadbinSQL.QUADBIN_RESOLUTION_RELATIVE) : 0)),
+        absResolution = clusteringParams.get(QuadbinSQL.QUADBIN_RESOLUTION_ABSOLUTE) != null ? (int) clusteringParams.get(QuadbinSQL.QUADBIN_RESOLUTION_ABSOLUTE) : 0;
+    final String countMode = (String) clusteringParams.get(QuadbinSQL.QUADBIN_COUNTMODE);
+    final boolean noBuffer = (boolean) clusteringParams.getOrDefault(QuadbinSQL.QUADBIN_NOBOFFER,false);
+
+
+    checkQuadbinInput(countMode, relResolution, event, dbHandler);
+    BBox bbox = event.getBbox();
+        boolean isTileRequest = (event instanceof GetFeaturesByTileEvent) && ((GetFeaturesByTileEvent) event).getMargin() == 0,
+                clippedOnBbox = (!isTileRequest && event.getClip());
+
+        final WebMercatorTile tile = getTileFromBbox(bbox);
+
+        if( (absResolution - tile.level) >= 0 )  // case of valid absResolution convert it to a relative resolution and add both resolutions
+         relResolution = Math.min( relResolution + (absResolution - tile.level), 5);
+
+        SQLQuery propQuery;
+        String propQuerySQL = null;
+
+        if (event.getPropertiesQuery() != null) {
+            propQuery = generatePropertiesQueryBWC(event);
+
+            if (propQuery != null) {
+                propQuerySQL = propQuery.text();
+                for (Object param : propQuery.parameters()) {
+                    propQuerySQL = propQuerySQL.replaceFirst("\\?", "'" + param + "'");
+                }
+            }
+        }
+        return QuadbinSQL.generateQuadbinClusteringSQL(dbHandler.getConfig().getDatabaseSettings().getSchema(), dbHandler.getConfig().readTableFromEvent(event), relResolution, countMode, propQuerySQL, tile, bbox, isTileRequest, clippedOnBbox, noBuffer, getResponseType(event) == GEO_JSON);
+    }
+}

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeaturesByBBoxTweaked.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeaturesByBBoxTweaked.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright (C) 2017-2022 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.xyz.psql.query;
+
+import static com.here.xyz.responses.XyzError.ILLEGAL_ARGUMENT;
+
+import com.here.xyz.connectors.ErrorResponseException;
+import com.here.xyz.events.GetFeaturesByBBoxEvent;
+import com.here.xyz.events.GetFeaturesByTileEvent;
+import com.here.xyz.models.geojson.implementation.FeatureCollection;
+import com.here.xyz.psql.DatabaseHandler;
+import com.here.xyz.psql.SQLQuery;
+import com.here.xyz.psql.factory.TweaksSQL;
+import com.here.xyz.psql.query.bbox.GetSamplingStrengthEstimation;
+import com.here.xyz.psql.query.bbox.GetSamplingStrengthEstimation.SamplingStrengthEstimation;
+import com.here.xyz.responses.XyzResponse;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class GetFeaturesByBBoxTweaked<E extends GetFeaturesByBBoxEvent, R extends XyzResponse> extends GetFeaturesByBBox<E, R> {
+
+  private boolean isMvtRequested;
+  private boolean resultIsPartial;
+
+  public GetFeaturesByBBoxTweaked(E event, DatabaseHandler dbHandler)
+      throws SQLException, ErrorResponseException {
+    super(event, dbHandler);
+    setUseReadReplica(true);
+  }
+
+  @Override
+  protected SQLQuery buildQuery(E event) throws SQLException, ErrorResponseException {
+    isMvtRequested = isMvtRequested(event);
+    Map<String, Object> tweakParams = getTweakParams(event);
+    SQLQuery query;
+    switch (event.getTweakType().toLowerCase()) {
+      case TweaksSQL.ENSURE: {
+        tweakParams = getTweakParamsForEnsureMode(event, tweakParams, dbHandler);
+      }
+      case TweaksSQL.SAMPLING: {
+        if (!"off".equals(event.getVizSampling().toLowerCase())) {
+          query = buildSamplingTweaksQuery(event, tweakParams);
+
+          if (isMvtRequested)
+            return buildMvtEncapsuledQuery((GetFeaturesByTileEvent) event, query);
+          else if ((int) tweakParams.get("strength") > 0)
+            resultIsPartial = true; //Either ensure mode or explicit tweaks:sampling request where strength in [1..100]
+          return query;
+        }
+        else
+          //Fall thru tweaks=simplification e.g. mode=viz and vizSampling=off
+          tweakParams.put("algorithm", "gridbytilelevel");
+      }
+
+      case TweaksSQL.SIMPLIFICATION: {
+        query = buildSimplificationTweaksQuery(event, tweakParams);
+
+        if (isMvtRequested)
+          return buildMvtEncapsuledQuery((GetFeaturesByTileEvent) event, query);
+        return query;
+      }
+      default:
+        throw new ErrorResponseException(ILLEGAL_ARGUMENT, "Invalid tweak type provided. Allowed values are: "
+            + TweaksSQL.ENSURE + ", " + TweaksSQL.SAMPLING + ", " + TweaksSQL.SIMPLIFICATION);
+    }
+  }
+
+  @Override
+  public R handle(ResultSet rs) throws SQLException {
+    if (isMvtRequested)
+      return (R) dbHandler.defaultBinaryResultSetHandler(rs);
+    else {
+      FeatureCollection collection = dbHandler.defaultFeatureResultSetHandlerSkipIfGeomIsNull(rs);
+      if (resultIsPartial)
+        collection.setPartial(true);
+      return (R) collection;
+    }
+  }
+
+  static private boolean isVeryLargeSpace( String rTuples )
+  { long tresholdVeryLargeSpace = 350000000L; // 350M Objects
+
+    if( rTuples == null ) return false;
+
+    String[] a = rTuples.split("~");
+    if( a == null || a[0] == null ) return false;
+
+    try{ return tresholdVeryLargeSpace <= Long.parseLong(a[0]); } catch( NumberFormatException e ){}
+
+    return false;
+  }
+
+  public static Map<String, Object> getTweakParams(GetFeaturesByBBoxEvent event) {
+    Map<String, Object> tweakParams;
+
+    if (event.getTweakType() != null)
+      tweakParams = event.getTweakParams();
+    else if (!"viz".equals(event.getOptimizationMode())) {
+      //FIXME: This case can never happen due condition which was met before ("viz".equals(event.getOptimizationMode()))
+      event.setTweakType(TweaksSQL.SIMPLIFICATION);
+      tweakParams = new HashMap<>(Collections.singletonMap("algorithm", "gridbytilelevel"));
+    }
+    else {
+      event.setTweakType(TweaksSQL.ENSURE);
+      tweakParams = getTweakParamsForVizMode(event);
+    }
+
+    tweakParams.put("strength", 1);
+    tweakParams.put("sortByHashedValue", false);
+    return tweakParams;
+  }
+
+  private static Map<String, Object> getTweakParamsForVizMode(GetFeaturesByBBoxEvent event) {
+    Map<String, Object> m = new HashMap<>();
+
+    switch( event.getVizSampling().toLowerCase() ) {
+      case "high":
+        m.put(TweaksSQL.ENSURE_SAMPLINGTHRESHOLD, new Integer( 15 ) );
+        break;
+      case "low":
+        m.put(TweaksSQL.ENSURE_SAMPLINGTHRESHOLD, new Integer( 70 ) );
+        break;
+      case "off":
+        m.put(TweaksSQL.ENSURE_SAMPLINGTHRESHOLD, new Integer( 100 ));
+        break;
+      case "med":
+      default:
+        m.put(TweaksSQL.ENSURE_SAMPLINGTHRESHOLD, new Integer( 30 ) );
+        break;
+    }
+    return m;
+  }
+
+  public static HashMap<String, Object> getTweakParamsForEnsureMode(GetFeaturesByBBoxEvent event,
+      Map<String, Object> tweakParams, DatabaseHandler dbHandler) throws SQLException, ErrorResponseException {
+    SamplingStrengthEstimation estimationResult = new GetSamplingStrengthEstimation<>(event, dbHandler).run();
+
+    HashMap<String, Object> hmap = new HashMap<>();
+
+    hmap.put("sortByHashedValue", isVeryLargeSpace(estimationResult.rTuples));
+
+    boolean bDefaultSelectionHandling = (tweakParams.get(TweaksSQL.ENSURE_DEFAULT_SELECTION) == Boolean.TRUE );
+
+    boolean bSelectionStar = false;
+    if (event.getSelection() != null && "*".equals( event.getSelection().get(0))) {
+      event.setSelection(null);
+      bSelectionStar = true; // differentiation needed, due to different semantic of "event.getSelection() == null" tweaks vs. nonTweaks
+    }
+
+    if (event.getSelection() == null && !bDefaultSelectionHandling && !bSelectionStar)
+      event.setSelection(Arrays.asList("id", "type"));
+
+    hmap.put("algorithm", "distribution");
+    hmap.put("strength", TweaksSQL.calculateDistributionStrength(estimationResult.rCount, Math.max(Math.min((int) tweakParams.getOrDefault(TweaksSQL.ENSURE_SAMPLINGTHRESHOLD, 10), 100), 10) * 1000));
+    return hmap;
+  }
+}

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeaturesByGeometry.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeaturesByGeometry.java
@@ -22,18 +22,19 @@ package com.here.xyz.psql.query;
 import com.here.xyz.connectors.ErrorResponseException;
 import com.here.xyz.events.GetFeaturesByGeometryEvent;
 import com.here.xyz.models.geojson.coordinates.WKTHelper;
+import com.here.xyz.models.geojson.implementation.FeatureCollection;
 import com.here.xyz.psql.DatabaseHandler;
 import com.here.xyz.psql.SQLQuery;
 import java.sql.SQLException;
 
-public class GetFeaturesByGeometry extends Spatial<GetFeaturesByGeometryEvent> {
+public class GetFeaturesByGeometry extends Spatial<GetFeaturesByGeometryEvent, FeatureCollection> {
 
   public GetFeaturesByGeometry(GetFeaturesByGeometryEvent event, DatabaseHandler dbHandler) throws SQLException, ErrorResponseException {
     super(event, dbHandler);
   }
 
   @Override
-  protected SQLQuery buildQuery(GetFeaturesByGeometryEvent event) throws SQLException {
+  protected SQLQuery buildQuery(GetFeaturesByGeometryEvent event) throws SQLException, ErrorResponseException {
     final int radius = event.getRadius();
 
     SQLQuery geoFilter = event.getH3Index() != null

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeaturesByGeometry.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeaturesByGeometry.java
@@ -49,7 +49,8 @@ public class GetFeaturesByGeometry extends Spatial<GetFeaturesByGeometryEvent, F
           .withNamedParameter("radius", radius);
 
     SQLQuery query = super.buildQuery(event);
-    SQLQuery geoQuery = new SQLQuery("ST_Intersects(geo, ${{geoFilter}})").withQueryFragment("geoFilter", geoFilter);
+    SQLQuery geoQuery = new SQLQuery("ST_Intersects(geo, ${{geoFilter}})")
+        .withQueryFragment("geoFilter", geoFilter);
 
     SQLQuery filterWhereClause = new SQLQuery("${{geoQuery}} AND ${{searchQuery}}")
         .withQueryFragment("geoQuery", geoQuery)

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeaturesById.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeaturesById.java
@@ -21,18 +21,19 @@ package com.here.xyz.psql.query;
 
 import com.here.xyz.connectors.ErrorResponseException;
 import com.here.xyz.events.GetFeaturesByIdEvent;
+import com.here.xyz.models.geojson.implementation.FeatureCollection;
 import com.here.xyz.psql.DatabaseHandler;
 import com.here.xyz.psql.SQLQuery;
 import java.sql.SQLException;
 
-public class GetFeaturesById extends GetFeatures<GetFeaturesByIdEvent> {
+public class GetFeaturesById extends GetFeatures<GetFeaturesByIdEvent, FeatureCollection> {
 
   public GetFeaturesById(GetFeaturesByIdEvent event, DatabaseHandler dbHandler) throws SQLException, ErrorResponseException {
     super(event, dbHandler);
   }
 
   @Override
-  protected SQLQuery buildQuery(GetFeaturesByIdEvent event) throws SQLException {
+  protected SQLQuery buildQuery(GetFeaturesByIdEvent event) throws SQLException, ErrorResponseException {
     String[] idArray = event.getIds().toArray(new String[0]);
     String filterWhereClause = "${{idColumn}} = ANY(#{ids})";
 

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/IterateFeatures.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/IterateFeatures.java
@@ -51,7 +51,7 @@ import java.util.stream.Collectors;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
-public class IterateFeatures extends SearchForFeatures<IterateFeaturesEvent> {
+public class IterateFeatures extends SearchForFeatures<IterateFeaturesEvent, FeatureCollection> {
 
   public static final String HPREFIX = "h07~";
   private static final String HANDLE_ENCRYPTION_PHRASE = "findFeaturesSort";
@@ -72,7 +72,7 @@ public class IterateFeatures extends SearchForFeatures<IterateFeaturesEvent> {
   }
 
   @Override
-  protected SQLQuery buildQuery(IterateFeaturesEvent event) throws SQLException {
+  protected SQLQuery buildQuery(IterateFeaturesEvent event) throws SQLException, ErrorResponseException {
     if (isExtendedSpace(event) && event.getContext() == SpaceContext.DEFAULT) {
 
       SQLQuery extensionQuery = super.buildQuery(event);

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/LoadFeatures.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/LoadFeatures.java
@@ -23,6 +23,7 @@ import static com.here.xyz.events.ContextAwareEvent.SpaceContext.DEFAULT;
 
 import com.here.xyz.connectors.ErrorResponseException;
 import com.here.xyz.events.LoadFeaturesEvent;
+import com.here.xyz.models.geojson.implementation.FeatureCollection;
 import com.here.xyz.psql.DatabaseHandler;
 import com.here.xyz.psql.SQLQuery;
 import java.sql.SQLException;
@@ -32,14 +33,14 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-public class LoadFeatures extends GetFeatures<LoadFeaturesEvent> {
+public class LoadFeatures extends GetFeatures<LoadFeaturesEvent, FeatureCollection> {
 
   public LoadFeatures(LoadFeaturesEvent event, DatabaseHandler dbHandler) throws SQLException, ErrorResponseException {
     super(event, dbHandler);
   }
 
   @Override
-  protected SQLQuery buildQuery(LoadFeaturesEvent event) throws SQLException {
+  protected SQLQuery buildQuery(LoadFeaturesEvent event) throws SQLException, ErrorResponseException {
     final Map<String, String> idMap = event.getIdsMap();
 
     SQLQuery filterWhereClause = new SQLQuery("${{idColumn}} = ANY(#{ids})")

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/SearchForFeatures.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/SearchForFeatures.java
@@ -25,8 +25,12 @@ import com.here.xyz.events.PropertyQuery;
 import com.here.xyz.events.QueryEvent;
 import com.here.xyz.events.SearchForFeaturesEvent;
 import com.here.xyz.events.TagsQuery;
+import com.here.xyz.models.geojson.implementation.FeatureCollection;
+import com.here.xyz.psql.Capabilities;
 import com.here.xyz.psql.DatabaseHandler;
 import com.here.xyz.psql.SQLQuery;
+import com.here.xyz.responses.XyzError;
+import com.here.xyz.responses.XyzResponse;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -38,7 +42,7 @@ NOTE: All subclasses of QueryEvent are deprecated except SearchForFeaturesEvent.
 Once refactoring is complete, all members of SearchForFeaturesEvent can be pulled up to QueryEvent and QueryEvent
 can be renamed to SearchForFeaturesEvent again.
  */
-public class SearchForFeatures<E extends SearchForFeaturesEvent> extends GetFeatures<E> {
+public class SearchForFeatures<E extends SearchForFeaturesEvent, R extends XyzResponse> extends GetFeatures<E, R> {
 
   protected boolean hasSearch;
 
@@ -46,8 +50,14 @@ public class SearchForFeatures<E extends SearchForFeaturesEvent> extends GetFeat
     super(event, dbHandler);
   }
 
+  public static void checkCanSearchFor(SearchForFeaturesEvent event, DatabaseHandler dbHandler) throws ErrorResponseException {
+    if (!Capabilities.canSearchFor(dbHandler.getConfig().readTableFromEvent(event), event.getPropertiesQuery(), dbHandler))
+      throw new ErrorResponseException(XyzError.ILLEGAL_ARGUMENT,
+          "Invalid request parameters. Search for the provided properties is not supported for this space.");
+  }
+
   @Override
-  protected SQLQuery buildQuery(E event) throws SQLException {
+  protected SQLQuery buildQuery(E event) throws SQLException, ErrorResponseException {
     SQLQuery query = super.buildQuery(event);
 
     SQLQuery searchQuery = buildSearchFragment(event);

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/SearchForFeatures.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/SearchForFeatures.java
@@ -73,7 +73,7 @@ public class SearchForFeatures<E extends SearchForFeaturesEvent> extends GetFeat
 
   //TODO: Can be removed after completion of refactoring
   @Deprecated
-  public static SQLQuery generatePropertiesQueryBWC(QueryEvent event) {
+  protected static SQLQuery generatePropertiesQueryBWC(QueryEvent event) {
     SQLQuery query = generatePropertiesQuery(event);
     if (query != null)
       query.replaceNamedParameters();

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/Spatial.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/Spatial.java
@@ -23,9 +23,10 @@ import com.here.xyz.connectors.ErrorResponseException;
 import com.here.xyz.events.SpatialQueryEvent;
 import com.here.xyz.psql.DatabaseHandler;
 import com.here.xyz.psql.SQLQuery;
+import com.here.xyz.responses.XyzResponse;
 import java.sql.SQLException;
 
-public abstract class Spatial<E extends SpatialQueryEvent> extends SearchForFeatures<E> {
+public abstract class Spatial<E extends SpatialQueryEvent, R extends XyzResponse> extends SearchForFeatures<E, R> {
 
   public Spatial(E event, DatabaseHandler dbHandler) throws SQLException, ErrorResponseException {
     super(event, dbHandler);

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/bbox/GetSamplingStrengthEstimation.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/bbox/GetSamplingStrengthEstimation.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2017-2022 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.xyz.psql.query.bbox;
+
+import static com.here.xyz.psql.query.GetFeaturesByBBox.getTileFromBbox;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.here.xyz.connectors.ErrorResponseException;
+import com.here.xyz.events.GetFeaturesByBBoxEvent;
+import com.here.xyz.events.GetFeaturesByTileEvent;
+import com.here.xyz.models.geojson.WebMercatorTile;
+import com.here.xyz.models.geojson.coordinates.BBox;
+import com.here.xyz.models.geojson.implementation.Feature;
+import com.here.xyz.models.geojson.implementation.FeatureCollection;
+import com.here.xyz.psql.DatabaseHandler;
+import com.here.xyz.psql.SQLQuery;
+import com.here.xyz.psql.factory.TweaksSQL;
+import com.here.xyz.psql.query.XyzEventBasedQueryRunner;
+import com.here.xyz.psql.query.bbox.GetSamplingStrengthEstimation.SamplingStrengthEstimation;
+import com.here.xyz.psql.tools.DhString;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+public class GetSamplingStrengthEstimation<E extends GetFeaturesByBBoxEvent> extends XyzEventBasedQueryRunner<E, SamplingStrengthEstimation> {
+
+  private static TupleTime tTime = new TupleTime();
+  private String rTuples;
+  private String spaceId;
+
+  private static class TupleTime {
+    private static Map<String, String> rTuplesMap = new ConcurrentHashMap<>();
+    private long expireTs = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(15);
+    private boolean expired() {
+      return System.currentTimeMillis() > expireTs;
+    }
+  }
+
+  public GetSamplingStrengthEstimation(E event, DatabaseHandler dbHandler)
+      throws SQLException, ErrorResponseException {
+    super(event, dbHandler);
+  }
+  @Override
+  protected SQLQuery buildQuery(E event) throws SQLException, ErrorResponseException {
+    if (tTime.expired())
+      tTime = new TupleTime();
+    rTuples = TupleTime.rTuplesMap.get(event.getSpace()); //TODO: Check semantics of that tuples cache
+    spaceId = event.getSpace();
+
+    return buildEstimateSamplingStrengthQuery(event, event.getBbox(), rTuples);
+  }
+
+  @Override
+  public SamplingStrengthEstimation handle(ResultSet rs) throws SQLException {
+    FeatureCollection collection = dbHandler.defaultFeatureResultSetHandler(rs);
+    Feature estimateFtr = null;
+    try {
+      estimateFtr = collection.getFeatures().get(0);
+    }
+    catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+
+    if (rTuples == null) {
+      rTuples = estimateFtr.get("rtuples");
+      TupleTime.rTuplesMap.put(spaceId, rTuples);
+    }
+
+    SamplingStrengthEstimation result = new SamplingStrengthEstimation();
+    result.rCount = estimateFtr.get("rcount");
+    result.rTuples = rTuples;
+
+    return result;
+  }
+
+  public static class SamplingStrengthEstimation {
+    public String rTuples;
+    public int rCount;
+  }
+
+  public static SQLQuery buildEstimateSamplingStrengthQuery(GetFeaturesByBBoxEvent event, BBox bbox, String relTuples)
+  {
+    int level, tileX, tileY, margin = 0;
+
+    if( event instanceof GetFeaturesByTileEvent)
+    { GetFeaturesByTileEvent tevnt = (GetFeaturesByTileEvent) event;
+      level = tevnt.getLevel();
+      tileX = tevnt.getX();
+      tileY = tevnt.getY();
+      margin = tevnt.getMargin();
+    }
+    else
+    { final WebMercatorTile tile = getTileFromBbox(bbox);
+      level = tile.level;
+      tileX = tile.x;
+      tileY = tile.y;
+    }
+
+    ArrayList<BBox> listOfBBoxes = new ArrayList<BBox>();
+    int nrTilesXY = 1 << level;
+
+    for( int dy = -1; dy < 2; dy++ )
+      for( int dx = -1; dx < 2; dx++ )
+        if( (dy == 0) && (dx == 0) ) listOfBBoxes.add(bbox);  // centerbox, this is already extended by margin
+        else if( ((tileY + dy) > 0) && ((tileY + dy) < nrTilesXY) )
+          listOfBBoxes.add( WebMercatorTile.forWeb(level, ((nrTilesXY +(tileX + dx)) % nrTilesXY) , (tileY + dy)).getExtendedBBox(margin) );
+
+    int flag = 0;
+    StringBuilder sb = new StringBuilder();
+    for (BBox b : listOfBBoxes)
+      sb.append(DhString.format("%s%s",( flag++ > 0 ? "," : ""),DhString.format( TweaksSQL.requestedTileBoundsSql , b.minLon(), b.minLat(), b.maxLon(), b.maxLat() )));
+
+    String estimateSubSql = ( relTuples == null ? TweaksSQL.estWithPgClass : DhString.format( TweaksSQL.estWithoutPgClass, relTuples ) );
+
+    return new SQLQuery( DhString.format( TweaksSQL.estimateCountByBboxesSql, sb.toString(), estimateSubSql ) );
+  }
+}

--- a/xyz-psql-connector/src/test/java/com/here/xyz/psql/PSQLAbstractIT.java
+++ b/xyz-psql-connector/src/test/java/com/here/xyz/psql/PSQLAbstractIT.java
@@ -20,14 +20,18 @@
 package com.here.xyz.psql;
 
 import com.amazonaws.util.IOUtils;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.here.xyz.Payload;
 import com.here.xyz.XyzSerializable;
+import com.here.xyz.connectors.ErrorResponseException;
 import com.here.xyz.events.HealthCheckEvent;
 import com.here.xyz.events.ModifySpaceEvent;
 import com.here.xyz.models.hub.Space;
 import com.here.xyz.psql.tools.GSContext;
 import com.here.xyz.psql.tools.Helper;
+import com.here.xyz.responses.ErrorResponse;
 import com.here.xyz.responses.SuccessResponse;
+import com.here.xyz.responses.XyzResponse;
 import com.jayway.jsonpath.JsonPath;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -140,6 +144,13 @@ public abstract class PSQLAbstractIT extends Helper {
     String response = IOUtils.toString(
             Payload.prepareInputStream(new ByteArrayInputStream(os.toByteArray())));
     LOGGER.info("Response from lambda - {}", response);
+    return response;
+  }
+
+  protected XyzResponse deserializeResponse(String jsonResponse) throws JsonProcessingException, ErrorResponseException {
+    XyzResponse response = XyzSerializable.deserialize(jsonResponse);
+    if (response instanceof ErrorResponse)
+      throw new ErrorResponseException(((ErrorResponse) response).getError(), ((ErrorResponse) response).getErrorMessage());
     return response;
   }
 }

--- a/xyz-psql-connector/src/test/java/com/here/xyz/psql/PSQLReadIT.java
+++ b/xyz-psql-connector/src/test/java/com/here/xyz/psql/PSQLReadIT.java
@@ -74,7 +74,7 @@ public class PSQLReadIT extends PSQLAbstractIT {
 
         String queryResponse = invokeLambda(getFeaturesByBBoxEvent.serialize());
         assertNotNull(queryResponse);
-        FeatureCollection featureCollection = XyzSerializable.deserialize(queryResponse);
+        FeatureCollection featureCollection = (FeatureCollection) deserializeResponse(queryResponse);
         assertNotNull(featureCollection);
         List<Feature> features = featureCollection.getFeatures();
         assertNotNull(features);


### PR DESCRIPTION
- Move all methods related to GetFeaturesByBBox into the according QR
- Refactor processGetFeaturesByBBoxEvent, move parts into differen QRs
- Create new GetFeaturesByBBoxClustered QR which handles clustering
- Create new GetFeaturesByBBoxTweaked QR which handles tweaking
- Create new bbox related QR helper GetSamplingStrengthEstimation
- Move general implementation for GetFeaturesByBBoxEvent into GetFeaturesByBBox QR
- Add new method deserializeResponse() to PSLQAbstractIT test class, so that all sub-classes can use it to deserialize connector responses and respect returned ErrorResponses rather than always throwing a cast-exception
- Deprecate constructor for ErrorResponseException which takes a stream ID as that is obsolete. The stream ID will be set on the resulting ErrorResponse by the abstract connector implementation just before an error is sent
- Refactor GetFeaturesByBBox QR / combine execution-paths
- GetFeaturesByBBox QR now re-uses the queries from the parent QueryRunners (e.g. GetFeatures, SearchForFeatures), that fixes the following automatically: clipping & mvt-support for composite spaces, tile- & bbox-requests for spaces with history (versionsToKeep > 1)
- Pull up general query building parts of GetFeaturesByBBox & GetFeaturesByGeometry