### PR TITLE
Add implementation for partitioning of spaces

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/task/FeatureTaskHandler.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/task/FeatureTaskHandler.java
@@ -1683,9 +1683,13 @@ public class FeatureTaskHandler {
         if (task.getEvent().getVersionsToKeep() > 1) {
           long version = feature.getProperties().getXyzNamespace().getVersion();
           long requestedVersion = requestedUuid == null ? -1 : Long.parseLong(requestedUuid);
-          if (task.modifyOp.entries.get(position).head == null || version != -1 && version != requestedVersion)
+
+          if (task.modifyOp.entries.get(position).head == null || version != -1 && version != requestedVersion) {
             task.modifyOp.entries.get(position).head = feature;
-          if (task.modifyOp.entries.get(position).base == null || version != -1 && version == requestedVersion && task.getEvent().getEnableUUID())
+            task.modifyOp.entries.get(position).base = feature;
+          }
+
+          if (version != -1 && version == requestedVersion && task.getEvent().getEnableUUID())
             task.modifyOp.entries.get(position).base = feature;
         }
         else {

--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/VersioningIT.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/VersioningIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2022 HERE Europe B.V.
+ * Copyright (C) 2017-2023 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.FixMethodOrder;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -54,11 +53,6 @@ public class VersioningIT extends TestSpaceWithFeature {
   final String FEATURE_ID_3 = "Q1370732";
   final String USER_1= "XYZ-01234567-89ab-cdef-0123-456789aUSER1";
   final String USER_2= "XYZ-01234567-89ab-cdef-0123-456789aUSER2";
-
-  @BeforeClass
-  public static void setupClass() {
-    remove();
-  }
 
   @Before
   public void setup() {

--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/httpconnector/HCMaintenanceTestIT.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/httpconnector/HCMaintenanceTestIT.java
@@ -281,7 +281,7 @@ public class HCMaintenanceTestIT {
                 .then()
                 .statusCode(OK.code())
                 .body("idxCreationFinished", equalTo(true))
-                .body("idxAvailable.size", equalTo(15))
+                .body("idxAvailable.size", equalTo(14))
                 .body("idxManual.searchableProperties.foo", equalTo(true))
                 .body("idxManual.sortableProperties", nullValue());
     }

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseHandler.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseHandler.java
@@ -129,7 +129,7 @@ public abstract class DatabaseHandler extends StorageConnector {
 
     private static String INCLUDE_OLD_STATES = "includeOldStates"; // read from event params
 
-    private static final long PARTITION_SIZE = 100_000;
+    public static final long PARTITION_SIZE = 100_000;
 
     /**
      * The data source connections factory.

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseHandler.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2022 HERE Europe B.V.
+ * Copyright (C) 2017-2023 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import static com.here.xyz.psql.DatabaseWriter.ModificationType.DELETE;
 import static com.here.xyz.psql.DatabaseWriter.ModificationType.INSERT;
 import static com.here.xyz.psql.DatabaseWriter.ModificationType.UPDATE;
 import static com.here.xyz.psql.QueryRunner.SCHEMA;
-import static com.here.xyz.psql.query.helpers.GetNextVersion.VERSION_SEQUENCE_SUFFIX;
+import static com.here.xyz.psql.query.helpers.versioning.GetNextVersion.VERSION_SEQUENCE_SUFFIX;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -58,13 +58,13 @@ import com.here.xyz.psql.query.GetFeaturesByBBox;
 import com.here.xyz.psql.query.ModifySpace;
 import com.here.xyz.psql.query.helpers.FetchExistingIds;
 import com.here.xyz.psql.query.helpers.FetchExistingIds.FetchIdsInput;
-import com.here.xyz.psql.query.helpers.GetNextVersion;
+import com.here.xyz.psql.query.helpers.versioning.GetNextVersion;
 import com.here.xyz.psql.query.helpers.GetTablesWithColumn;
 import com.here.xyz.psql.query.helpers.GetTablesWithColumn.GetTablesWithColumnInput;
 import com.here.xyz.psql.query.helpers.GetTablesWithComment;
 import com.here.xyz.psql.query.helpers.GetTablesWithComment.GetTablesWithCommentInput;
-import com.here.xyz.psql.query.helpers.SetVersion;
-import com.here.xyz.psql.query.helpers.SetVersion.SetVersionInput;
+import com.here.xyz.psql.query.helpers.versioning.SetVersion;
+import com.here.xyz.psql.query.helpers.versioning.SetVersion.SetVersionInput;
 import com.here.xyz.psql.tools.DhString;
 import com.here.xyz.responses.BinaryResponse;
 import com.here.xyz.responses.ErrorResponse;

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseHandler.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseHandler.java
@@ -1232,7 +1232,7 @@ public abstract class DatabaseHandler extends StorageConnector {
     }
 
     private void createHeadPartition(Statement stmt, String schema, String rootTable) throws SQLException {
-        SQLQuery q = new SQLQuery("CREATE TABLE ${schema}.${partitionTable} "
+        SQLQuery q = new SQLQuery("CREATE TABLE IF NOT EXISTS ${schema}.${partitionTable} "
             + "PARTITION OF ${schema}.${rootTable} FOR VALUES FROM (max_bigint()) TO (MAXVALUE)")
             .withVariable(SCHEMA, schema)
             .withVariable("rootTable", rootTable)

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseHandler.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseHandler.java
@@ -1252,6 +1252,7 @@ public abstract class DatabaseHandler extends StorageConnector {
     }
 
     private void createSpaceTableStatement(Statement stmt, String schema, String table, long versionsToKeep) throws SQLException {
+        boolean withPartitioning = true;
         String tableFields =
             "id TEXT NOT NULL, "
                 + "version BIGINT NOT NULL, "
@@ -1263,7 +1264,7 @@ public abstract class DatabaseHandler extends StorageConnector {
                 + "i BIGSERIAL"
                 + ", CONSTRAINT ${constraintName} PRIMARY KEY (id, version, next_version)";
 
-        SQLQuery q = new SQLQuery("CREATE TABLE IF NOT EXISTS ${schema}.${table} (${{tableFields}}) PARTITION BY RANGE (next_version)")
+        SQLQuery q = new SQLQuery("CREATE TABLE IF NOT EXISTS ${schema}.${table} (${{tableFields}})" + (withPartitioning ? " PARTITION BY RANGE (next_version)" : ""))
             .withQueryFragment("tableFields", tableFields)
             .withVariable("schema", schema)
             .withVariable("table", table)

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseMaintainer.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseMaintainer.java
@@ -19,6 +19,8 @@
 
 package com.here.xyz.psql;
 
+import static com.here.xyz.psql.query.ModifySpace.XYZ_CONFIG_SCHEMA;
+
 import com.here.xyz.connectors.AbstractConnectorHandler.TraceItem;
 import com.here.xyz.psql.config.PSQLConfig;
 import com.here.xyz.psql.factory.MaintenanceSQL;
@@ -155,7 +157,7 @@ public class DatabaseMaintainer {
                     }
 
                     if (!configSchema && hasPropertySearch) {
-                        logger.debug("{} Create missing Schema {} on database: {} / {}@{}", traceItem, MaintenanceSQL.XYZ_CONFIG_SCHEMA, config.getDatabaseSettings().getDb(), config.getDatabaseSettings().getUser(), config.getDatabaseSettings().getHost());
+                        logger.debug("{} Create missing Schema {} on database: {} / {}@{}", traceItem, XYZ_CONFIG_SCHEMA, config.getDatabaseSettings().getDb(), config.getDatabaseSettings().getUser(), config.getDatabaseSettings().getHost());
                         stmt.execute(MaintenanceSQL.configSchemaAndSystemTablesSQL);
                     }
 

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/SQLQuery.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/SQLQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2022 HERE Europe B.V.
+ * Copyright (C) 2017-2023 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@ import static com.here.xyz.psql.DatabaseHandler.HISTORY_TABLE_SUFFIX;
 import com.here.xyz.events.PropertyQuery;
 import com.here.xyz.events.QueryEvent;
 import com.here.xyz.psql.query.GetFeatures;
-import com.here.xyz.psql.query.helpers.GetNextVersion;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/SQLQueryBuilder.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/SQLQueryBuilder.java
@@ -193,7 +193,7 @@ public class SQLQueryBuilder {
     }
 
     protected static SQLQuery generateIDXStatusQuery(final String space){
-        return new SQLQuery("SELECT idx_available FROM "+ ModifySpace.IDX_STATUS_TABLE+" WHERE spaceid=? AND count >=?", space, BIG_SPACE_THRESHOLD);
+        return new SQLQuery("SELECT idx_available FROM "+ ModifySpace.IDX_STATUS_TABLE_FQN +" WHERE spaceid=? AND count >=?", space, BIG_SPACE_THRESHOLD);
     }
 
   protected static SQLQuery buildMultiModalInsertStmtQuery(DatabaseHandler dbHandler, ModifyFeaturesEvent event) {

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/SQLQueryBuilder.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/SQLQueryBuilder.java
@@ -18,6 +18,8 @@
  */
 package com.here.xyz.psql;
 
+import static com.here.xyz.psql.DatabaseHandler.PARTITION_SIZE;
+
 import com.here.xyz.events.ContextAwareEvent;
 import com.here.xyz.events.Event;
 import com.here.xyz.events.GetHistoryStatisticsEvent;
@@ -198,10 +200,11 @@ public class SQLQueryBuilder {
 
   protected static SQLQuery buildMultiModalInsertStmtQuery(DatabaseHandler dbHandler, ModifyFeaturesEvent event) {
       return new SQLQuery("SELECT xyz_write_versioned_modification_operation(#{id}, #{version}, #{operation}, #{jsondata}, #{geo}, "
-          + "#{schema}, #{table}, #{concurrencyCheck})")
+          + "#{schema}, #{table}, #{concurrencyCheck}, #{partitionSize})")
           .withNamedParameter("schema", dbHandler.config.getDatabaseSettings().getSchema())
           .withNamedParameter("table", dbHandler.config.readTableFromEvent(event))
-          .withNamedParameter("concurrencyCheck", event.getEnableUUID());
+          .withNamedParameter("concurrencyCheck", event.getEnableUUID())
+          .withNamedParameter("partitionSize", PARTITION_SIZE);
   }
 
   protected static SQLQuery buildInsertStmtQuery(DatabaseHandler dbHandler, ModifyFeaturesEvent event) {

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/DeleteChangesets.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/DeleteChangesets.java
@@ -66,8 +66,7 @@ public class DeleteChangesets extends XyzQueryRunner<DeleteChangesetsEvent, Succ
     long previousMinRangeMin = new GetOldestPartitionRangeMin(event, dbHandler).run();
     String sql = "";
     for (long partitionNo = previousMinRangeMin / PARTITION_SIZE; partitionNo < (event.getMinVersion() + 1) / PARTITION_SIZE; partitionNo++)
-      sql += "ALTER TABLE IF EXISTS ${schema}.${table} DETACH PARTITION \"" + table + "_p" + partitionNo + "\" CONCURRENTLY;"
-          + "DROP TABLE IF EXISTS ${schema}.\"" + table + "_p" + partitionNo + "\";";
+      sql += "DROP TABLE IF EXISTS ${schema}.\"" + table + "_p" + partitionNo + "\";";
     return new SQLQuery(sql);
   }
 

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/DeleteChangesets.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/DeleteChangesets.java
@@ -26,7 +26,7 @@ import com.here.xyz.connectors.ErrorResponseException;
 import com.here.xyz.events.DeleteChangesetsEvent;
 import com.here.xyz.psql.DatabaseHandler;
 import com.here.xyz.psql.SQLQuery;
-import com.here.xyz.psql.query.helpers.GetHeadVersion;
+import com.here.xyz.psql.query.helpers.versioning.GetHeadVersion;
 import com.here.xyz.psql.query.helpers.versioning.GetOldestPartitionRangeMin;
 import com.here.xyz.responses.SuccessResponse;
 import java.sql.ResultSet;
@@ -53,6 +53,7 @@ public class DeleteChangesets extends XyzQueryRunner<DeleteChangesetsEvent, Succ
 
   @Override
   protected SQLQuery buildQuery(DeleteChangesetsEvent event) throws SQLException, ErrorResponseException {
+    //TODO: Execute asynchronously in DB
     return new SQLQuery("${{removePartitions}}${{purgeRemainder}}")
         .withQueryFragment("removePartitions", buildRemovePartitionsQuery(event))
         .withQueryFragment("purgeRemainder", buildPurgeRemainderFromOldestPartition(event))

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetStorageStatistics.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetStorageStatistics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2022 HERE Europe B.V.
+ * Copyright (C) 2017-2023 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@ import static com.here.xyz.psql.DatabaseHandler.HISTORY_TABLE_SUFFIX;
 import com.here.xyz.connectors.ErrorResponseException;
 import com.here.xyz.events.GetStorageStatisticsEvent;
 import com.here.xyz.psql.DatabaseHandler;
-import com.here.xyz.psql.QueryRunner;
 import com.here.xyz.psql.SQLQuery;
 import com.here.xyz.responses.StatisticsResponse.Value;
 import com.here.xyz.responses.StorageStatistics;
@@ -60,7 +59,6 @@ public class GetStorageStatistics extends XyzQueryRunner<GetStorageStatisticsEve
     event.getSpaceIds().forEach(spaceId -> {
       String tableName = resolveTableName(spaceId);
       tableNames.add(tableName);
-      tableNames.add(tableName + HISTORY_TABLE_SUFFIX);
     });
     return new SQLQuery( "SELECT relname                                                AS " + TABLE_NAME + ","
                             + "       pg_indexes_size(c.oid)                                 AS " + INDEX_BYTES + ","
@@ -69,10 +67,10 @@ public class GetStorageStatistics extends XyzQueryRunner<GetStorageStatisticsEve
                             + "         LEFT JOIN pg_namespace n ON n.oid = c.relnamespace "
                             + " WHERE relkind = 'r'"
                             + " AND nspname = '" + getSchema() + "'"
-                            + " AND relname IN (" + tableNames
+                            + " AND relname LIKE ANY (array[" + tableNames
                                                       .stream()
-                                                      .map(tableName -> "'" + tableName + "'")
-                                                      .collect(Collectors.joining(",")) + ")");
+                                                      .map(tableName -> "'" + tableName + "%'") //TODO: replace % by _% once all tables have been migrated to new partitioned table style
+                                                      .collect(Collectors.joining(",")) + "])");
   }
 
   private String resolveTableName(String spaceId) {
@@ -94,15 +92,16 @@ public class GetStorageStatistics extends XyzQueryRunner<GetStorageStatisticsEve
     //Read the space / history info from the returned ResultSet
     while (rs.next()) {
       String tableName = rs.getString(TABLE_NAME);
-      boolean isHistoryTable = tableName.endsWith(HISTORY_TABLE_SUFFIX);
-      tableName = isHistoryTable ? tableName.substring(0, tableName.length() - HISTORY_TABLE_SUFFIX.length()) : tableName;
+      int suffixPos = tableName.lastIndexOf('_');
+      //TODO: The following is a backwards-compatibility implementation for the old table style and can be removed once all tables have been migrated to the new partitioned table style
+      tableName = suffixPos != -1 ? tableName.substring(0, suffixPos) : tableName;
       String spaceId = tableName2SpaceId.containsKey(tableName) ? tableName2SpaceId.get(tableName) : tableName;
 
       long tableBytes = rs.getLong(TABLE_BYTES),
            indexBytes = rs.getLong(INDEX_BYTES);
 
       SpaceByteSizes sizes = byteSizes.computeIfAbsent(spaceId, k -> new SpaceByteSizes());
-      if (isHistoryTable)
+      if (isHistoryTable(tableName))
         sizes.setHistoryBytes(new Value<>(tableBytes + indexBytes).withEstimated(true));
       else {
         sizes.setContentBytes(new Value<>(tableBytes).withEstimated(true));
@@ -116,5 +115,15 @@ public class GetStorageStatistics extends XyzQueryRunner<GetStorageStatisticsEve
           .withContentBytes(new Value<>(0L).withEstimated(true)));
 
     return stats;
+  }
+
+  private static boolean isHistoryTable(String tableName) {
+    int suffixPos = tableName.lastIndexOf('_');
+    if (suffixPos == -1)
+      return false;
+    String suffix = tableName.substring(suffixPos);
+    if (suffix.startsWith("_p"))
+      return true;
+    return tableName.endsWith(HISTORY_TABLE_SUFFIX);
   }
 }

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/ModifySpace.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/ModifySpace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2022 HERE Europe B.V.
+ * Copyright (C) 2017-2023 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ package com.here.xyz.psql.query;
 import static com.here.xyz.events.ModifySpaceEvent.Operation.CREATE;
 import static com.here.xyz.events.ModifySpaceEvent.Operation.DELETE;
 import static com.here.xyz.events.ModifySpaceEvent.Operation.UPDATE;
-import static com.here.xyz.psql.query.helpers.GetNextVersion.VERSION_SEQUENCE_SUFFIX;
+import static com.here.xyz.psql.query.helpers.versioning.GetNextVersion.VERSION_SEQUENCE_SUFFIX;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/helpers/GetTablesWithComment.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/helpers/GetTablesWithComment.java
@@ -45,6 +45,8 @@ public class GetTablesWithComment extends QueryRunner<GetTablesWithCommentInput,
         + "WHERE "
         + "  t.table_name != 'spatial_ref_sys' "
         + "  AND t.table_name NOT LIKE '%_hst' "
+        + "  AND t.table_name NOT LIKE '%_head' "
+        + "  AND t.table_name NOT LIKE '%_p%' "
         + "  AND t.table_type = 'BASE TABLE' "
         + "  AND t.table_schema = 'public' "
         + "  AND reltuples < #{tableSizeLimit} "

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/helpers/versioning/GetNextVersion.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/helpers/versioning/GetNextVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2022 HERE Europe B.V.
+ * Copyright (C) 2017-2023 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package com.here.xyz.psql.query.helpers;
+package com.here.xyz.psql.query.helpers.versioning;
 
 import com.here.xyz.connectors.ErrorResponseException;
 import com.here.xyz.events.Event;
@@ -27,23 +27,25 @@ import com.here.xyz.psql.query.XyzEventBasedQueryRunner;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
-public class GetHeadVersion<E extends Event> extends XyzEventBasedQueryRunner<E, Long> {
+public class GetNextVersion<E extends Event> extends XyzEventBasedQueryRunner<E, Long> {
 
-  public GetHeadVersion(E input, DatabaseHandler dbHandler) throws SQLException, ErrorResponseException {
+  public static final String VERSION_SEQUENCE_SUFFIX = "_version_seq";
+
+  public GetNextVersion(E input, DatabaseHandler dbHandler) throws SQLException, ErrorResponseException {
     super(input, dbHandler);
   }
 
   @Override
   protected SQLQuery buildQuery(E event) throws SQLException, ErrorResponseException {
-    return new SQLQuery("SELECT max(version) FROM ${schema}.${table}")
+    return new SQLQuery("SELECT nextval('${schema}.${sequence}')")
         .withVariable(SCHEMA, getSchema())
-        .withVariable(TABLE, getDefaultTable(event));
+        .withVariable("sequence", getDefaultTable(event) + VERSION_SEQUENCE_SUFFIX);
   }
 
   @Override
   public Long handle(ResultSet rs) throws SQLException {
     if (rs.next())
       return rs.getLong(1);
-    throw new SQLException("Unable to retrieve HEAD version from space.");
+    throw new SQLException("Unable to increase version sequence.");
   }
 }

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/helpers/versioning/GetOldestPartitionRangeMin.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/helpers/versioning/GetOldestPartitionRangeMin.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2017-2023 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.xyz.psql.query.helpers.versioning;
+
+import static com.here.xyz.psql.DatabaseHandler.PARTITION_SIZE;
+
+import com.here.xyz.connectors.ErrorResponseException;
+import com.here.xyz.events.Event;
+import com.here.xyz.psql.DatabaseHandler;
+import com.here.xyz.psql.SQLQuery;
+import com.here.xyz.psql.query.XyzEventBasedQueryRunner;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class GetOldestPartitionRangeMin extends XyzEventBasedQueryRunner<Event, Long> {
+
+  private String tableName;
+
+  public GetOldestPartitionRangeMin(Event input, DatabaseHandler dbHandler) throws SQLException, ErrorResponseException {
+    super(input, dbHandler);
+  }
+
+  @Override
+  protected SQLQuery buildQuery(Event event) throws SQLException, ErrorResponseException {
+    tableName = getDefaultTable(event);
+    return new SQLQuery("SELECT pg_get_expr(relpartbound, oid, true) FROM pg_class "
+        + "WHERE relname LIKE #{partitionPattern} AND relkind = 'r'")
+        .withNamedParameter("partitionPattern", tableName + "_p%");
+  }
+
+  private long getRangeMinFromExpression(String boundsExpression) {
+    String boundsPart = boundsExpression.substring(18);
+    return Long.parseLong(boundsPart.substring(0, boundsPart.indexOf("'")));
+  }
+
+  @Override
+  public Long handle(ResultSet rs) throws SQLException {
+    long minRangeMin = Long.MAX_VALUE;
+    while (rs.next())
+      minRangeMin = Math.min(minRangeMin, getRangeMinFromExpression(rs.getString(1)));
+    if (minRangeMin == Long.MAX_VALUE)
+      throw new SQLException("Unable to get oldest partition for table.");
+    else
+      return minRangeMin / PARTITION_SIZE;
+  }
+}

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/helpers/versioning/GetOldestPartitionRangeMin.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/helpers/versioning/GetOldestPartitionRangeMin.java
@@ -19,8 +19,6 @@
 
 package com.here.xyz.psql.query.helpers.versioning;
 
-import static com.here.xyz.psql.DatabaseHandler.PARTITION_SIZE;
-
 import com.here.xyz.connectors.ErrorResponseException;
 import com.here.xyz.events.Event;
 import com.here.xyz.psql.DatabaseHandler;
@@ -58,6 +56,6 @@ public class GetOldestPartitionRangeMin extends XyzEventBasedQueryRunner<Event, 
     if (minRangeMin == Long.MAX_VALUE)
       throw new SQLException("Unable to get oldest partition for table.");
     else
-      return minRangeMin / PARTITION_SIZE;
+      return minRangeMin;
   }
 }

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/helpers/versioning/SetVersion.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/helpers/versioning/SetVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2022 HERE Europe B.V.
+ * Copyright (C) 2017-2023 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,16 +17,16 @@
  * License-Filename: LICENSE
  */
 
-package com.here.xyz.psql.query.helpers;
+package com.here.xyz.psql.query.helpers.versioning;
 
-import static com.here.xyz.psql.query.helpers.GetNextVersion.VERSION_SEQUENCE_SUFFIX;
+import static com.here.xyz.psql.query.helpers.versioning.GetNextVersion.VERSION_SEQUENCE_SUFFIX;
 
 import com.here.xyz.connectors.ErrorResponseException;
 import com.here.xyz.events.ModifyFeaturesEvent;
 import com.here.xyz.psql.DatabaseHandler;
 import com.here.xyz.psql.QueryRunner;
 import com.here.xyz.psql.SQLQuery;
-import com.here.xyz.psql.query.helpers.SetVersion.SetVersionInput;
+import com.here.xyz.psql.query.helpers.versioning.SetVersion.SetVersionInput;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 

--- a/xyz-psql-connector/src/main/resources/xyz_ext.sql
+++ b/xyz-psql-connector/src/main/resources/xyz_ext.sql
@@ -20,49 +20,6 @@
 -- CREATE EXTENSION IF NOT EXISTS postgis SCHEMA public;
 -- CREATE EXTENSION IF NOT EXISTS postgis_topology;
 -- CREATE EXTENSION IF NOT EXISTS tsm_system_rows SCHEMA public;
-
--- DROP FUNCTION xyz_index_status();
--- DROP FUNCTION xyz_create_idxs_over_dblink(text, integer, integer, integer, text[], text, text, text,text, integer, text);
--- DROP FUNCTION xyz_space_bbox(text, text, integer);
--- DROP FUNCTION xyz_update_dummy_v5();
--- DROP FUNCTION xyz_index_check_comments(text, text);
--- DROP FUNCTION xyz_index_creation_on_property_object(text, text, text, text, text, character);
--- DROP FUNCTION xyz_maintain_idxs_for_space(text, text);
--- DROP FUNCTION xyz_create_idxs(text, integer, integer, integer, text[]);
--- DROP FUNCTION xyz_property_path_to_array(text);
--- DROP FUNCTION xyz_property_path(text);
--- DROP FUNCTION xyz_property_datatype(text, text, text, integer);
--- DROP FUNCTION xyz_property_statistic(text, text, integer);
--- DROP FUNCTION xyz_statistic_newest_spaces_changes(text, text[], integer);
--- DROP FUNCTION xyz_write_newest_idx_analyses(text);
--- DROP FUNCTION xyz_write_newest_statistics(text, text[], integer);
--- DROP FUNCTION xyz_statistic_all_spaces(text, text[], integer);
--- DROP FUNCTION xyz_property_evaluation(text, text, text, integer);
--- DROP FUNCTION xyz_index_proposals_on_properties(text, text);
--- DROP FUNCTION xyz_index_creation_on_property(text, text, text, character);
--- DROP FUNCTION xyz_geotype(geometry);
--- DROP FUNCTION xyz_index_name_for_property(text, text, character);
--- DROP FUNCTION xyz_index_list_all_available(text, text);
--- DROP FUNCTION xyz_index_name_dissolve_to_property(text,text);
--- DROP FUNCTION xyz_index_property_available(text, text, text);
--- DROP FUNCTION xyz_property_statistic_v2(text, text, integer);
--- DROP FUNCTION xyz_tag_statistic(text, text, integer);
--- DROP FUNCTION xyz_statistic_searchable(jsonb);
--- DROP FUNCTION xyz_statistic_xl_space(text, text, integer);
--- DROP FUNCTION xyz_statistic_space(text, text);
--- DROP FUNCTION xyz_statistic_xs_space(text, text);
--- DROP FUNCTION xyz_create_idxs_for_space(text, text);
--- DROP FUNCTION xyz_remove_unnecessary_idx(text, integer);
--- DROP FUNCTION xyz_index_dissolve_datatype(text);
--- DROP FUNCTION xyz_index_get_plain_propkey(text);
--- DROP FUNCTION IF EXISTS xyz_qk_point2lrc(geometry, integer);
--- DROP FUNCTION IF EXISTS xyz_qk_lrc2qk(integer,integer,integer);
--- DROP FUNCTION IF EXISTS xyz_qk_qk2lrc(text );
--- DROP FUNCTION IF EXISTS xyz_qk_lrc2bbox(integer,integer,integer);
--- DROP FUNCTION IF EXISTS xyz_qk_qk2bbox(text );
--- DROP FUNCTION IF EXISTS xyz_qk_point2qk(geometry,integer );
--- DROP FUNCTION IF EXISTS xyz_qk_bbox2zooml(geometry);
--- DROP FUNCTION IF EXISTS xyz_qk_envelope2lrc(geometry, integer);
 DROP FUNCTION IF EXISTS xyz_statistic_history(text, text);
 --
 ------ SAMPLE QUERIES ----
@@ -247,8 +204,6 @@ $BODY$
 LANGUAGE plpgsql VOLATILE;
 ------------------------------------------------
 ------------------------------------------------
--- Function: xyz_index_dissolve_datatype(text)
--- DROP FUNCTION xyz_index_dissolve_datatype(text);
 CREATE OR REPLACE FUNCTION xyz_index_dissolve_datatype(propkey text)
   RETURNS text AS
 $BODY$
@@ -278,8 +233,6 @@ $BODY$
   LANGUAGE plpgsql VOLATILE;
 ------------------------------------------------
 ------------------------------------------------
--- Function: xyz_statistic_history(text, text)
--- DROP FUNCTION xyz_statistic_history(text, text);
 CREATE OR REPLACE FUNCTION xyz_statistic_history(
     IN schema text,
     IN spaceid text)
@@ -349,8 +302,6 @@ $BODY$
 LANGUAGE plpgsql VOLATILE;
 ------------------------------------------------
 ------------------------------------------------
--- Function: xyz_index_get_plain_propkey(text)
--- DROP FUNCTION xyz_index_get_plain_propkey(text);
 CREATE OR REPLACE FUNCTION xyz_index_get_plain_propkey(propkey text)
   RETURNS text AS
 $BODY$
@@ -380,8 +331,6 @@ $BODY$
   LANGUAGE plpgsql VOLATILE;
 ------------------------------------------------
 ------------------------------------------------
--- Function: xyz_trigger_historywriter_versioned()
--- DROP FUNCTION xyz_trigger_historywriter_versioned();
 CREATE OR REPLACE FUNCTION xyz_trigger_historywriter_versioned()
   RETURNS trigger AS
 $BODY$
@@ -623,8 +572,6 @@ $body$
 language plpgsql immutable;
 ------------------------------------------------
 ------------------------------------------------
--- Function: xyz_index_status()
--- DROP FUNCTION xyz_index_status();
 CREATE OR REPLACE FUNCTION xyz_index_status()
   RETURNS INTEGER AS
 $BODY$
@@ -682,8 +629,6 @@ $BODY$
   LANGUAGE plpgsql VOLATILE;
 ------------------------------------------------
 ------------------------------------------------
--- Function: xyz_create_idxs_over_dblink(text, integer, integer, integer, text[], text, text, text, text, integer, text)
--- DROP FUNCTION xyz_create_idxs_over_dblink(text, integer, integer, integer, text[], text, text, text, text, integer, text);
 CREATE OR REPLACE FUNCTION xyz_create_idxs_over_dblink(
 	schema text,
 	lim integer,
@@ -726,8 +671,6 @@ CREATE OR REPLACE FUNCTION xyz_create_idxs_over_dblink(
 LANGUAGE plpgsql VOLATILE;
 ------------------------------------------------
 ------------------------------------------------
--- Function: xyz_space_bbox(text, text, integer)
--- DROP FUNCTION xyz_space_bbox(text, text, integer);
 CREATE OR REPLACE FUNCTION xyz_space_bbox(
     schema text,
     space_id text,
@@ -781,8 +724,6 @@ $BODY$
   LANGUAGE plpgsql VOLATILE;
 ------------------------------------------------
 ------------------------------------------------
--- Function: xyz_index_list_all_available(text, text)
--- DROP FUNCTION xyz_index_list_all_available(text, text);
 CREATE OR REPLACE FUNCTION xyz_index_list_all_available(
     IN schema text,
     IN spaceid text)
@@ -841,8 +782,6 @@ $BODY$
   LANGUAGE plpgsql VOLATILE;
  ------------------------------------------------
 ------------------------------------------------
--- Function: xyz_index_check_comments(text, text)
--- DROP FUNCTION xyz_index_check_comments(text, text);
 CREATE OR REPLACE FUNCTION xyz_index_check_comments(
     schema text,
     space_id text)
@@ -918,8 +857,6 @@ $BODY$
   LANGUAGE plpgsql VOLATILE;
 ------------------------------------------------
 ------------------------------------------------
--- Function: xyz_index_creation_on_property_object(text, text, text, text, text, character);
--- DROP FUNCTION xyz_index_creation_on_property_object(text, text, text, text, text, character);
 CREATE OR REPLACE FUNCTION xyz_index_creation_on_property_object(
     schema text,
     spaceid text,
@@ -1085,8 +1022,7 @@ $body$
 $body$
 language sql immutable;
 
--- Function: xyz_maintain_o_idxs_for_space(text, text)
--- DROP FUNCTION xyz_maintain_o_idxs_for_space(text, text);
+
 create or replace function xyz_maintain_o_idxs_for_space( schema text, space text)
   returns void as
 $body$
@@ -1121,8 +1057,6 @@ language plpgsql volatile;
 
 ------------------------------------------------
 ------------------------------------------------
--- Function: xyz_maintain_idxs_for_space(text, text)
--- DROP FUNCTION xyz_maintain_idxs_for_space(text, text);
 CREATE OR REPLACE FUNCTION xyz_maintain_idxs_for_space(
     schema text,
     space text)
@@ -1302,8 +1236,6 @@ $BODY$
   LANGUAGE plpgsql VOLATILE;
 ------------------------------------------------
 ------------------------------------------------
--- Function: xyz_create_idxs(text, integer, integer, integer, text[])
--- DROP FUNCTION xyz_create_idxs(text, integer, integer, integer, text[]);
 CREATE OR REPLACE FUNCTION xyz_create_idxs(
     schema text,
     lim integer,
@@ -1355,8 +1287,6 @@ $BODY$
   LANGUAGE plpgsql VOLATILE;
 ------------------------------------------------
 ------------------------------------------------
--- Function: xyz_property_path_to_array(text)
--- DROP FUNCTION xyz_property_path_to_array(text);
 CREATE OR REPLACE FUNCTION xyz_property_path_to_array(propertypath text)
   RETURNS text[] AS
 $BODY$
@@ -1386,8 +1316,6 @@ $BODY$
   LANGUAGE plpgsql VOLATILE;
 ------------------------------------------------
 ------------------------------------------------
--- Function: xyz_property_path(text)
--- DROP FUNCTION xyz_property_path(text);
 CREATE OR REPLACE FUNCTION xyz_property_path(propertypath TEXT)
   RETURNS TEXT AS
 $BODY$
@@ -1419,8 +1347,6 @@ $BODY$
   LANGUAGE plpgsql VOLATILE;
 ------------------------------------------------
 ------------------------------------------------
--- Function: xyz_property_datatype(text, text, text, integer)
--- DROP FUNCTION xyz_property_datatype(text, text, text, integer);
 CREATE OR REPLACE FUNCTION xyz_property_datatype(
 	schema text,
     spaceid text,
@@ -1469,8 +1395,6 @@ $BODY$
   LANGUAGE plpgsql VOLATILE;
 ------------------------------------------------
 ------------------------------------------------
--- Function: xyz_property_statistic(text, text, integer)
--- DROP FUNCTION xyz_property_statistic(text, text, integer);
 CREATE OR REPLACE FUNCTION xyz_property_statistic_v2(
     IN schema text,
     IN spaceid text,
@@ -1562,8 +1486,6 @@ $BODY$
   LANGUAGE plpgsql VOLATILE;
 ------------------------------------------------
 ------------------------------------------------
--- Function: xyz_statistic_newest_spaces_changes(text, text[], integer)
--- DROP FUNCTION xyz_statistic_newest_spaces_changes(text, text[], integer);
 CREATE OR REPLACE FUNCTION xyz_statistic_newest_spaces_changes(
     IN schema text,
     IN owner_list text[],
@@ -1615,7 +1537,7 @@ $BODY$
 			spaceid := xyz_spaces.spaceid;
 
             --skip history tables
-            IF substring(spaceid,length(spaceid)-3) = '_hst' THEN
+            IF NOT xyz_is_space_table(schema, spaceid) THEN
                 CONTINUE;
             END IF;
 
@@ -1631,8 +1553,22 @@ $BODY$
   LANGUAGE plpgsql VOLATILE;
 ------------------------------------------------
 ------------------------------------------------
--- Function: xyz_write_newest_idx_analyses(text)
--- DROP FUNCTION xyz_write_newest_idx_analyses(text);
+CREATE OR REPLACE FUNCTION xyz_is_space_table(schema TEXT, tableName TEXT) RETURNS BOOLEAN AS
+$BODY$
+BEGIN
+    -- TODO: Improve this function to not rely on the table's name anymore
+    IF length(tableName) < 5 THEN
+        RETURN TRUE;
+    END IF;
+    RETURN tableName != 'spatial_ref_sys' AND -- It's the spatial reference system table fro postGIS (system table)
+           substring(tableName, length(tableName) - 3) != '_hst' AND -- It's a legacy history table
+           substring(tableName, length(tableName) - 4) != '_head' AND -- It's a HEAD partition
+           tableName  !~ '.+\_p[0-9]'; -- It's a history partition
+END
+$BODY$
+LANGUAGE plpgsql VOLATILE;
+------------------------------------------------
+------------------------------------------------
 CREATE OR REPLACE FUNCTION xyz_write_newest_idx_analyses(schema text)
   RETURNS void AS
 $BODY$
@@ -1684,8 +1620,6 @@ $BODY$
   LANGUAGE plpgsql VOLATILE;
 ------------------------------------------------
 ------------------------------------------------
--- Function: xyz_write_newest_statistics(text, text[], integer)
--- DROP FUNCTION xyz_write_newest_statistics(text, text[], integer);
 CREATE OR REPLACE FUNCTION xyz_write_newest_statistics(
     schema text,
     owner_list text[],
@@ -1781,8 +1715,6 @@ $BODY$
   LANGUAGE plpgsql VOLATILE;
 ------------------------------------------------
 ------------------------------------------------
--- Function: xyz_statistic_all_spaces(text, text[], integer)
--- DROP FUNCTION xyz_statistic_all_spaces(text, text[], integer);
 CREATE OR REPLACE FUNCTION xyz_statistic_all_spaces(
     IN schema text,
     IN owner_list text[],
@@ -1838,8 +1770,6 @@ $BODY$
   LANGUAGE plpgsql VOLATILE;
 ------------------------------------------------
 ------------------------------------------------
--- Function: xyz_property_evaluation(text, text, text, integer)
--- DROP FUNCTION xyz_property_evaluation(text, text, text, integer);
 CREATE OR REPLACE FUNCTION xyz_property_evaluation(
     IN schema text,
     IN spaceid text,
@@ -1915,8 +1845,6 @@ $BODY$
   LANGUAGE plpgsql VOLATILE;
 ------------------------------------------------
 ------------------------------------------------
--- Function: xyz_index_proposals_on_properties(text, text)
--- DROP FUNCTION xyz_index_proposals_on_properties(text, text);
 CREATE OR REPLACE FUNCTION xyz_index_proposals_on_properties(
     IN schema text,
     IN _spaceid text)
@@ -2071,8 +1999,6 @@ $BODY$
   LANGUAGE plpgsql VOLATILE;
 ------------------------------------------------
 ------------------------------------------------
--- Function: xyz_index_creation_on_property(text, text, text, character
--- DROP FUNCTION xyz_index_creation_on_property(text, text, text, character);
 CREATE OR REPLACE FUNCTION xyz_index_creation_on_property(
     schema text,
     spaceid text,
@@ -2126,8 +2052,6 @@ $BODY$
   LANGUAGE plpgsql VOLATILE;
 ------------------------------------------------
 ------------------------------------------------
--- Function: xyz_geotype(geometry)
--- DROP FUNCTION xyz_geotype(geometry);
 CREATE OR REPLACE FUNCTION xyz_geotype(geo geometry)
   RETURNS text AS
 $BODY$
@@ -2160,8 +2084,6 @@ $BODY$
   LANGUAGE plpgsql VOLATILE;
 ------------------------------------------------
 ------------------------------------------------
--- Function: xyz_index_name_for_property(text, text, character)
--- DROP FUNCTION xyz_index_name_for_property(text, text, character);
 CREATE OR REPLACE FUNCTION xyz_index_name_for_property(
     spaceid text,
     propkey text,
@@ -2205,8 +2127,6 @@ $BODY$
   LANGUAGE plpgsql VOLATILE;
 ------------------------------------------------
 ------------------------------------------------
--- Function: xyz_index_find_missing_system_indexes(text, text[])
--- DROP FUNCTION xyz_index_find_missing_system_indexes(text, text[]);
 CREATE OR REPLACE FUNCTION xyz_index_find_missing_system_indexes(
     IN schema text,
     IN owner_list text[])
@@ -2249,8 +2169,6 @@ $BODY$
   LANGUAGE plpgsql VOLATILE;
 ------------------------------------------------
 ------------------------------------------------
--- Function: xyz_index_name_dissolve_to_property(text,text)
--- DROP FUNCTION xyz_index_name_dissolve_to_property(text,text);
 CREATE OR REPLACE FUNCTION xyz_index_name_dissolve_to_property(IN idx_name text, space_id text)
   RETURNS TABLE(spaceid text, propkey text, source character) AS
 $BODY$
@@ -2288,8 +2206,6 @@ $BODY$
   LANGUAGE plpgsql VOLATILE;
 ------------------------------------------------
 ------------------------------------------------
--- Function: xyz_index_property_available(text, text, text)
--- DROP FUNCTION xyz_index_property_available(text, text, text);
 CREATE OR REPLACE FUNCTION xyz_index_property_available(
     schema text,
     spaceid text,
@@ -2330,8 +2246,6 @@ $BODY$
   LANGUAGE plpgsql VOLATILE;
 ------------------------------------------------
 ------------------------------------------------
--- Function: xyz_property_statistic(text, text, integer)
--- DROP FUNCTION xyz_property_statistic(text, text, integer);
 CREATE OR REPLACE FUNCTION xyz_property_statistic(
     IN schema text,
     IN spaceid text,
@@ -2395,8 +2309,6 @@ $BODY$
   LANGUAGE plpgsql VOLATILE;
 ------------------------------------------------
 ------------------------------------------------
--- Function: xyz_tag_statistic(text, text, integer)
--- DROP FUNCTION xyz_tag_statistic(text, text, integer);
 CREATE OR REPLACE FUNCTION xyz_tag_statistic(
     IN schema text,
     IN spaceid text,
@@ -2448,8 +2360,6 @@ $BODY$
   LANGUAGE plpgsql VOLATILE;
 ------------------------------------------------
 ------------------------------------------------
--- Function: xyz_statistic_searchable(jsonb)
--- DROP FUNCTION xyz_statistic_searchable(jsonb);
 CREATE OR REPLACE FUNCTION xyz_statistic_searchable(prop_stat jsonb)
   RETURNS text AS
 $BODY$
@@ -2490,8 +2400,6 @@ $BODY$
   LANGUAGE plpgsql VOLATILE;
 ------------------------------------------------
 ------------------------------------------------
--- Function: xyz_statistic_xl_space(text, text, integer)
--- DROP FUNCTION xyz_statistic_xl_space(text, text, integer);
 CREATE OR REPLACE FUNCTION xyz_statistic_xl_space(
     IN schema text,
     IN spaceid text,
@@ -2565,8 +2473,6 @@ $BODY$
   LANGUAGE plpgsql VOLATILE;
 ------------------------------------------------
 ------------------------------------------------
--- Function: xyz_statistic_space(text, text)
--- DROP FUNCTION xyz_statistic_space(text, text);
 CREATE OR REPLACE FUNCTION xyz_statistic_space(
     IN schema text,
     IN spaceid text)
@@ -2602,17 +2508,15 @@ $BODY$
 		SELECT reltuples into estimate_cnt FROM pg_class WHERE oid = concat('"',$1, '"."', $2, '"')::regclass;
 
 		IF estimate_cnt > big_space_threshold THEN
-			RETURN QUERY EXECUTE 'select * from xyz_statistic_xl_space('''||schema||''', '''||spaceid||''' , '||tablesamplecnt||')';
+			RETURN QUERY EXECUTE 'select * from xyz_statistic_xl_space('''||schema||''', ''' || xyz_get_head_table(schema, spaceid) || ''' , '||tablesamplecnt||')';
 		ELSE
-			RETURN QUERY EXECUTE 'select * from xyz_statistic_xs_space('''||schema||''','''||spaceid||''')';
+			RETURN QUERY EXECUTE 'select * from xyz_statistic_xs_space('''||schema||''',''' || xyz_get_head_table(schema, spaceid) || ''')';
 		END IF;
         END;
 $BODY$
   LANGUAGE plpgsql VOLATILE;
 ------------------------------------------------
 ------------------------------------------------
--- Function: xyz_statistic_xs_space(text, text)
--- DROP FUNCTION xyz_statistic_xs_space(text, text);
 CREATE OR REPLACE FUNCTION xyz_statistic_xs_space(
     IN schema text,
     IN spaceid text)
@@ -2671,8 +2575,6 @@ $BODY$
   LANGUAGE plpgsql VOLATILE;
 ------------------------------------------------
 ------------------------------------------------
--- Function: xyz_create_idxs_for_space(text, text)
--- DROP FUNCTION xyz_create_idxs_for_space(text, text);
 CREATE OR REPLACE FUNCTION xyz_create_idxs_for_space(
     schema text,
     space text)
@@ -2733,8 +2635,6 @@ $BODY$
   LANGUAGE plpgsql VOLATILE;
 ------------------------------------------------
 ------------------------------------------------
--- Function: xyz_remove_unnecessary_idx(text, integer)
--- DROP FUNCTION xyz_remove_unnecessary_idx(text, integer);
 CREATE OR REPLACE FUNCTION xyz_remove_unnecessary_idx(
     schema text,
     min_table_count integer)
@@ -3270,6 +3170,32 @@ BEGIN
         format('CREATE TABLE %I.%I PARTITION OF %I.%I FOR VALUES FROM (%L) TO (%L)',
             schema, (rootTable || '_p' || partitionNo), schema, rootTable,
             partitionSize * partitionNo, partitionSize * (partitionNo + 1));
+END
+$BODY$
+LANGUAGE plpgsql VOLATILE;
+------------------------------------------------
+------------------------------------------------
+CREATE OR REPLACE FUNCTION xyz_get_head_table(schema TEXT, tableName TEXT) RETURNS TEXT AS
+$BODY$
+BEGIN
+    IF xyz_table_exists(schema, tableName || '_head') THEN
+        RETURN tableName || '_head';
+    ELSE
+        RETURN tableName;
+    END IF;
+END
+$BODY$
+    LANGUAGE plpgsql VOLATILE;
+------------------------------------------------
+------------------------------------------------
+CREATE OR REPLACE FUNCTION xyz_table_exists(schema TEXT, tableName TEXT) RETURNS BOOLEAN AS
+$BODY$
+DECLARE
+    existsResult RECORD;
+BEGIN
+    EXECUTE
+        format('SELECT EXISTS (SELECT FROM pg_tables WHERE schemaname = %L AND tablename = %L) AS tableExists', schema, tableName) INTO existsResult;
+    RETURN existsResult.tableExists;
 END
 $BODY$
 LANGUAGE plpgsql VOLATILE;

--- a/xyz-psql-connector/src/main/resources/xyz_ext.sql
+++ b/xyz-psql-connector/src/main/resources/xyz_ext.sql
@@ -3167,7 +3167,7 @@ CREATE OR REPLACE FUNCTION xyz_create_history_partition(schema TEXT, rootTable T
 $BODY$
 BEGIN
     EXECUTE
-        format('CREATE TABLE %I.%I PARTITION OF %I.%I FOR VALUES FROM (%L) TO (%L)',
+        format('CREATE TABLE IF NOT EXISTS %I.%I PARTITION OF %I.%I FOR VALUES FROM (%L) TO (%L)',
             schema, (rootTable || '_p' || partitionNo), schema, rootTable,
             partitionSize * partitionNo, partitionSize * (partitionNo + 1));
 END

--- a/xyz-psql-connector/src/test/java/com/here/xyz/psql/PSQLAbstractIT.java
+++ b/xyz-psql-connector/src/test/java/com/here/xyz/psql/PSQLAbstractIT.java
@@ -147,10 +147,10 @@ public abstract class PSQLAbstractIT extends Helper {
     return response;
   }
 
-  protected XyzResponse deserializeResponse(String jsonResponse) throws JsonProcessingException, ErrorResponseException {
+  protected <T extends XyzResponse> T deserializeResponse(String jsonResponse) throws JsonProcessingException, ErrorResponseException {
     XyzResponse response = XyzSerializable.deserialize(jsonResponse);
     if (response instanceof ErrorResponse)
       throw new ErrorResponseException(((ErrorResponse) response).getError(), ((ErrorResponse) response).getErrorMessage());
-    return response;
+    return (T) response;
   }
 }

--- a/xyz-psql-connector/src/test/java/com/here/xyz/psql/PSQLExtendedSpacesIT.java
+++ b/xyz-psql-connector/src/test/java/com/here/xyz/psql/PSQLExtendedSpacesIT.java
@@ -171,7 +171,7 @@ public class PSQLExtendedSpacesIT extends PSQLAbstractIT {
     }
 
     protected static void checkIDXTable(int szenario, boolean baselayerSwitch) throws Exception{
-        String q = "SELECT * FROM "+ ModifySpace.IDX_STATUS_TABLE+" WHERE spaceid IN ('"+ BASE1 +"','"+BASE2+"','"+DELTA1+"','"+DELTA2+"');";
+        String q = "SELECT * FROM "+ ModifySpace.IDX_STATUS_TABLE_FQN +" WHERE spaceid IN ('"+ BASE1 +"','"+BASE2+"','"+DELTA1+"','"+DELTA2+"');";
         JSONObject base1_ref = null;
         JSONObject base2_ref = new JSONObject("{\"searchableProperties\": {\"search_test_base2\": true}}");;
         JSONObject delta1_ref = null;

--- a/xyz-psql-connector/src/test/java/com/here/xyz/psql/PSQLHashedSpaceIdIT.java
+++ b/xyz-psql-connector/src/test/java/com/here/xyz/psql/PSQLHashedSpaceIdIT.java
@@ -19,6 +19,7 @@
 
 package com.here.xyz.psql;
 
+import static com.here.xyz.psql.query.ModifySpace.IDX_STATUS_TABLE_FQN;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -32,7 +33,12 @@ import com.here.xyz.util.Hasher;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.Statement;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.junit.After;
@@ -100,7 +106,7 @@ public class PSQLHashedSpaceIdIT extends PSQLAbstractIT {
     /** Needed to trigger update on pg_stat */
     try (final Connection connection = LAMBDA.dataSource.getConnection()) {
       Statement stmt = connection.createStatement();
-      stmt.execute("DELETE FROM xyz_config.xyz_idxs_status WHERE spaceid='" + hashedSpaceId + "';");
+      stmt.execute("DELETE FROM " + IDX_STATUS_TABLE_FQN + " WHERE spaceid='" + hashedSpaceId + "';");
       stmt.execute("ANALYZE \"" + hashedSpaceId + "\";");
     }
 
@@ -110,7 +116,7 @@ public class PSQLHashedSpaceIdIT extends PSQLAbstractIT {
     try (final Connection connection = LAMBDA.dataSource.getConnection()) {
       Statement stmt = connection.createStatement();
       // check for the index status
-      try (ResultSet rs = stmt.executeQuery("SELECT * FROM xyz_config.xyz_idxs_status where spaceid = '" + hashedSpaceId + "';")) {
+      try (ResultSet rs = stmt.executeQuery("SELECT * FROM " + IDX_STATUS_TABLE_FQN + " where spaceid = '" + hashedSpaceId + "';")) {
         assertTrue(rs.next());
         assertTrue(rs.getBoolean("idx_creation_finished"));
         assertEquals(11_000L, rs.getInt("count"));
@@ -143,7 +149,7 @@ public class PSQLHashedSpaceIdIT extends PSQLAbstractIT {
       }
 
       /* Clean-up maintenance entry */
-      stmt.execute("DELETE FROM xyz_config.xyz_idxs_status WHERE spaceid='" + hashedSpaceId + "';");
+      stmt.execute("DELETE FROM " + IDX_STATUS_TABLE_FQN + " WHERE spaceid='" + hashedSpaceId + "';");
     }
   }
 }

--- a/xyz-psql-connector/src/test/java/com/here/xyz/psql/PSQLHistoryCompactIT.java
+++ b/xyz-psql-connector/src/test/java/com/here/xyz/psql/PSQLHistoryCompactIT.java
@@ -269,6 +269,7 @@ public class PSQLHistoryCompactIT extends PSQLAbstractIT {
         invokeLambda(mfevent.serialize());
 
         //DELETE feature
+        mfevent.setInsertFeatures(null);
         mfevent.setUpdateFeatures(null);
         mfevent.setDeleteFeatures(new HashMap<String,String>(){{put("1234",null);}});
         invokeLambda(mfevent.serialize());

--- a/xyz-psql-connector/src/test/java/com/here/xyz/psql/PSQLIndexIT.java
+++ b/xyz-psql-connector/src/test/java/com/here/xyz/psql/PSQLIndexIT.java
@@ -29,6 +29,8 @@ import com.here.xyz.psql.tools.FeatureGenerator;
 import com.here.xyz.responses.*;
 import com.here.xyz.psql.tools.DhString;
 
+import java.util.Arrays;
+import java.util.Collections;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -176,22 +178,21 @@ public class PSQLIndexIT extends PSQLAbstractIT {
 
         try (final Connection connection = LAMBDA.dataSource.getConnection()) {
             /** Default System Indices */
-            List<String> systemIndices = new ArrayList<String>(){{
-                add("createdAt");
-                add("updatedAt");
-                add("serial");
-                add("geo");
-                add("tags");
-                add("id");
-                add("viz");
-                add("idnew");
-                add("version");
-                add("nextversion");
-                add("idversion");
-                add("idversionnextversion");
-                add("operation");
-                add("author");
-            }};
+            List<String> systemIndices = Arrays.asList(
+                "createdAt",
+                "updatedAt",
+                "serial",
+                "geo",
+                "tags",
+                "id",
+                "viz",
+                "idnew",
+                "version",
+                "nextversion",
+                "idversion",
+                "operation",
+                "author"
+            );
 
             String sqlSpaceSchema = "(select schema_name::text from information_schema.schemata where schema_name in ('xyz','public') order by 1 desc limit 1)";
 
@@ -214,7 +215,7 @@ public class PSQLIndexIT extends PSQLAbstractIT {
 
             }
             /** If all System Indices could get found the list should be empty */
-            assertEquals(0,systemIndices.size());
+            assertEquals(Collections.emptyList(), systemIndices);
             /** If foo1:foo5 could get found only foo6 & foo7 should be in the map */
             assertEquals(2,searchableProperties.size());
         }
@@ -338,12 +339,7 @@ public class PSQLIndexIT extends PSQLAbstractIT {
                 .withConnectorParams(connectorParams);
         // =========== Invoke GetStatisticsEvent ==========
         String stringResponse = invokeLambda(statisticsEvent.serialize());
-        StatisticsResponse response;
-        XyzResponse rawResp = XyzSerializable.deserialize(stringResponse);
-        if (rawResp instanceof ErrorResponse)
-            throw new ErrorResponseException(((ErrorResponse) rawResp).getError(), ((ErrorResponse) rawResp).getErrorMessage());
-        else
-            response = XyzSerializable.deserialize(stringResponse);
+        StatisticsResponse response = deserializeResponse(stringResponse);
 
         assertNotNull(response);
         assertEquals(new Long(11000), response.getCount().getValue());

--- a/xyz-psql-connector/src/test/java/com/here/xyz/psql/PSQLIndexIT.java
+++ b/xyz-psql-connector/src/test/java/com/here/xyz/psql/PSQLIndexIT.java
@@ -178,7 +178,7 @@ public class PSQLIndexIT extends PSQLAbstractIT {
 
         try (final Connection connection = LAMBDA.dataSource.getConnection()) {
             /** Default System Indices */
-            List<String> systemIndices = Arrays.asList(
+            List<String> systemIndices = new ArrayList<>(Arrays.asList(
                 "createdAt",
                 "updatedAt",
                 "serial",
@@ -192,7 +192,7 @@ public class PSQLIndexIT extends PSQLAbstractIT {
                 "idversion",
                 "operation",
                 "author"
-            );
+            ));
 
             String sqlSpaceSchema = "(select schema_name::text from information_schema.schemata where schema_name in ('xyz','public') order by 1 desc limit 1)";
 

--- a/xyz-psql-connector/src/test/java/com/here/xyz/psql/PSQLIndexIT.java
+++ b/xyz-psql-connector/src/test/java/com/here/xyz/psql/PSQLIndexIT.java
@@ -277,37 +277,37 @@ public class PSQLIndexIT extends PSQLAbstractIT {
 
                 switch (idx_property){
                     case "foo" :
-                        assertEquals("CREATE INDEX "+idx_name+" ON public.foo USING btree ((((jsondata -> 'properties'::text) -> 'foo'::text)))",indexdef);
+                        assertEquals("CREATE INDEX "+idx_name+" ON ONLY public.foo USING btree ((((jsondata -> 'properties'::text) -> 'foo'::text)))",indexdef);
                         break;
                     case "foo2" :
-                        assertEquals("CREATE INDEX "+idx_name+" ON public.foo USING gin ((((jsondata -> 'properties'::text) -> 'foo2'::text)))",indexdef);
+                        assertEquals("CREATE INDEX "+idx_name+" ON ONLY public.foo USING gin ((((jsondata -> 'properties'::text) -> 'foo2'::text)))",indexdef);
                         break;
                     case "foo.nested" :
-                        assertEquals("CREATE INDEX "+idx_name+" ON public.foo USING btree (((((jsondata -> 'properties'::text) -> 'foo'::text) -> 'nested'::text)))",indexdef);
+                        assertEquals("CREATE INDEX "+idx_name+" ON ONLY public.foo USING btree (((((jsondata -> 'properties'::text) -> 'foo'::text) -> 'nested'::text)))",indexdef);
                         break;
                     case "f.fooroot" :
-                        assertEquals("CREATE INDEX "+idx_name+" ON public.foo USING btree (((jsondata -> 'fooroot'::text)))",indexdef);
+                        assertEquals("CREATE INDEX "+idx_name+" ON ONLY public.foo USING btree (((jsondata -> 'fooroot'::text)))",indexdef);
                         break;
                     case "f.geometry.type" :
-                        assertEquals("CREATE INDEX "+idx_name+" ON public.foo USING btree (geometrytype(geo))",indexdef);
+                        assertEquals("CREATE INDEX "+idx_name+" ON ONLY public.foo USING btree (geometrytype(geo))",indexdef);
                         break;
                     case "id" :
-                        assertEquals("CREATE INDEX idx_foo_id ON public.foo USING btree (((jsondata ->> 'id'::text)))",indexdef);
+                        assertEquals("CREATE INDEX idx_foo_id ON ONLY public.foo USING btree (((jsondata ->> 'id'::text)))",indexdef);
                         break;
                     case "geo" :
-                        assertEquals("CREATE INDEX idx_foo_geo ON public.foo USING gist (geo)",indexdef);
+                        assertEquals("CREATE INDEX idx_foo_geo ON ONLY public.foo USING gist (geo)",indexdef);
                         break;
                     case "serial" :
-                        assertEquals("CREATE INDEX idx_foo_serial ON public.foo USING btree (i)",indexdef);
+                        assertEquals("CREATE INDEX idx_foo_serial ON ONLY public.foo USING btree (i)",indexdef);
                         break;
                     case "tags" :
-                        assertEquals("CREATE INDEX idx_foo_tags ON public.foo USING gin (((((jsondata -> 'properties'::text) -> '@ns:com:here:xyz'::text) -> 'tags'::text)))",indexdef);
+                        assertEquals("CREATE INDEX idx_foo_tags ON ONLY public.foo USING gin (((((jsondata -> 'properties'::text) -> '@ns:com:here:xyz'::text) -> 'tags'::text)))",indexdef);
                         break;
                     case "createdAt" :
-                        assertEquals("CREATE INDEX \"idx_foo_createdAt\" ON public.foo USING btree (((((jsondata -> 'properties'::text) -> '@ns:com:here:xyz'::text) -> 'createdAt'::text)), ((jsondata ->> 'id'::text)))",indexdef);
+                        assertEquals("CREATE INDEX \"idx_foo_createdAt\" ON ONLY public.foo USING btree (((((jsondata -> 'properties'::text) -> '@ns:com:here:xyz'::text) -> 'createdAt'::text)), ((jsondata ->> 'id'::text)))",indexdef);
                         break;
                     case "updatedAt" :
-                        assertEquals("CREATE INDEX \"idx_foo_updatedAt\" ON public.foo USING btree (((((jsondata -> 'properties'::text) -> '@ns:com:here:xyz'::text) -> 'updatedAt'::text)), ((jsondata ->> 'id'::text)))",indexdef);
+                        assertEquals("CREATE INDEX \"idx_foo_updatedAt\" ON ONLY public.foo USING btree (((((jsondata -> 'properties'::text) -> '@ns:com:here:xyz'::text) -> 'updatedAt'::text)), ((jsondata ->> 'id'::text)))",indexdef);
                         break;
                 }
             }

--- a/xyz-psql-connector/src/test/java/com/here/xyz/psql/PSQLLoadFeatures.java
+++ b/xyz-psql-connector/src/test/java/com/here/xyz/psql/PSQLLoadFeatures.java
@@ -79,10 +79,7 @@ public class PSQLLoadFeatures extends PSQLAbstractIT {
           put("F2", "0");
         }});
 
-    XyzResponse response = XyzSerializable.deserialize(invokeLambda(event.serialize()));
-    if (response instanceof ErrorResponse)
-      throw new RuntimeException(((ErrorResponse) response).getErrorMessage());
-    FeatureCollection loadedFeatures = (FeatureCollection) response;
+    FeatureCollection loadedFeatures = deserializeResponse(invokeLambda(event.serialize()));
     assertEquals(2, loadedFeatures.getFeatures().size());
     assertTrue(loadedFeatures.getFeatures().stream().anyMatch(f -> "F1".equals(f.getId())));
     assertTrue(loadedFeatures.getFeatures().stream().anyMatch(f -> "F2".equals(f.getId())));

--- a/xyz-psql-connector/src/test/java/com/here/xyz/psql/PSQLReadIT.java
+++ b/xyz-psql-connector/src/test/java/com/here/xyz/psql/PSQLReadIT.java
@@ -74,7 +74,7 @@ public class PSQLReadIT extends PSQLAbstractIT {
 
         String queryResponse = invokeLambda(getFeaturesByBBoxEvent.serialize());
         assertNotNull(queryResponse);
-        FeatureCollection featureCollection = (FeatureCollection) deserializeResponse(queryResponse);
+        FeatureCollection featureCollection = deserializeResponse(queryResponse);
         assertNotNull(featureCollection);
         List<Feature> features = featureCollection.getFeatures();
         assertNotNull(features);
@@ -107,9 +107,7 @@ public class PSQLReadIT extends PSQLAbstractIT {
 
         queryResponse = invokeLambda(getFeaturesByBBoxEvent.serialize());
         assertNotNull(queryResponse);
-        XyzResponse response = XyzSerializable.deserialize(queryResponse);
-        if (response instanceof ErrorResponse)
-            failWithError((ErrorResponse) response);
+        XyzResponse response = deserializeResponse(queryResponse);
         featureCollection = (FeatureCollection) response;
         assertNotNull(featureCollection);
         features = featureCollection.getFeatures();
@@ -366,9 +364,7 @@ public class PSQLReadIT extends PSQLAbstractIT {
                 .withSelection(new ArrayList<>(Collections.singletonList("properties.foo2")));
 
         queryResponse = invokeLambda(geometryEvent.serialize());
-        XyzResponse response = XyzSerializable.deserialize(queryResponse);
-        if (response instanceof ErrorResponse)
-            failWithError((ErrorResponse) response);
+        XyzResponse response = deserializeResponse(queryResponse);
         featureCollection = XyzSerializable.deserialize(queryResponse);
         assertNotNull(featureCollection);
         assertEquals(213, featureCollection.getFeatures().size());
@@ -702,13 +698,6 @@ public class PSQLReadIT extends PSQLAbstractIT {
         final String response = invokeLambdaFromFile("/events/IterateMySpace.json");
         final FeatureCollection features = XyzSerializable.deserialize(response);
         features.serialize(true);
-    }
-
-    private void failWithError(ErrorResponse error) {
-        if (error instanceof ErrorResponse)
-            fail("Received error response: [" + error.getError() + "] " + error.getErrorMessage());
-        else
-            fail("Failing without a valid ErrorResponse was provided.");
     }
 
     @SafeVarargs


### PR DESCRIPTION
- Enhance DatabaseHandler to create partitioned tables with one HEAD table instead of a normal table for a space
- Add function "xyz_create_history_partition" in xyz_ext which creates new history partitions for a given root table
- Change GetTablesWithComment QR to ignore partitions, but only respect root tables
- Set partition size to 100_000
- Change function "xyz_write_versioned_modification_operation" in xyz_ext to create a new history partition upfront when the previous one is half way filled
- Minor refactoring of some PSQL tests
- Fix history trigger implementation to work with partitioning
- Fix on demand indexing / updating of history trigger to work with partitioning
- Adjust auto-indexing to be able to work on a partitioned table
- Fix storage statistics QR to work correctly with partitioning

Minor refactoring of maintenance SQL:

- Use one single constant for all usages of xyz_idxs_status table
- Add new function "xyz_is_space_table" in xyz_ext which enables distinguising between non-space-tables and main space-tables and use it where previously only tables with suffix "_hst" where ignored
- Add new function "xyz_table_exists" function in xyz_ext which for a given table returns true if it exists
- Add new funtion "xyz_get_head_table" function in xyz_ext which always returns the HEAD table for a given main space table
- Fix test PSQLIndexIT#testAutoIndexing to report error responses correctly

Improve DeletChangesets QR to support partitioning:

- Add GetOldestPartitionRangeMin helper-QR which returns the minimum version of the oldest partition for a given root table name
- Change DeleteChangesets QR to additionally detach & drop old partitions which are not needed anymore; For that use the new GetOldestPartitionRangeMin helper-QR to find out where to start with the potential removal of partitions
- Refactor: move versioning-related QR-helpers into "versioning" package