### PR TITLE
Fix OTA phaseX migration to properly create all indices on root table

### DIFF
--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/PSQLXyzConnector.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/PSQLXyzConnector.java
@@ -74,11 +74,6 @@ import org.apache.logging.log4j.Logger;
 public class PSQLXyzConnector extends DatabaseHandler {
 
   private static final Logger logger = LogManager.getLogger();
-  /**
-   * The context for this request.
-   */
-  @SuppressWarnings("WeakerAccess")
-  protected Context context;
 
   @Override
   protected XyzResponse processHealthCheckEvent(HealthCheckEvent event) {

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/SQLQuery.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/SQLQuery.java
@@ -261,12 +261,6 @@ public class SQLQuery {
     setText(m.replaceAll("?"));
   }
 
-  //TODO: Replace usages by calls to #substitute()
-  @Deprecated
-  protected static String replaceVars(String query, Map<String, String> replacements, String schema, String table) {
-    return replaceVars(replaceVars(query, schema, table), replacements);
-  }
-
   private static String replaceVars(String queryText, Map<String, String> replacements) {
     for (String key : replacements.keySet())
       queryText = queryText.replaceAll(VAR_PREFIX + key + VAR_SUFFIX, sqlQuote(replacements.get(key)));


### PR DESCRIPTION
- Properly rename all indexes of the old main table to indexes of the new head table
- Properly create exactly the same indices on the new root table as they existed on the old main table
- Refactor legacy way of performing SQL replacements by using new style from SQLQuery class, to get rid of hard-coded replacements and to not be dependent by the connector's event initialization process anymore
- Remove deprecated method SQLQuery#replaceVars()

Signed-off-by: Benjamin Rögner <benjamin.roegner@here.com>