### PR TITLE
Implement automated purging of old / unneeded versions

### DIFF
--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/SQLQueryBuilder.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/SQLQueryBuilder.java
@@ -201,11 +201,13 @@ public class SQLQueryBuilder {
 
   protected static SQLQuery buildMultiModalInsertStmtQuery(DatabaseHandler dbHandler, ModifyFeaturesEvent event) {
       return new SQLQuery("SELECT xyz_write_versioned_modification_operation(#{id}, #{version}, #{operation}, #{jsondata}, #{geo}, "
-          + "#{schema}, #{table}, #{concurrencyCheck}, #{partitionSize})")
+          + "#{schema}, #{table}, #{concurrencyCheck}, #{partitionSize}, #{versionsToKeep}, #{pw})")
           .withNamedParameter("schema", dbHandler.config.getDatabaseSettings().getSchema())
           .withNamedParameter("table", dbHandler.config.readTableFromEvent(event))
           .withNamedParameter("concurrencyCheck", event.getEnableUUID())
-          .withNamedParameter("partitionSize", PARTITION_SIZE);
+          .withNamedParameter("partitionSize", PARTITION_SIZE)
+          .withNamedParameter("versionsToKeep", event.getVersionsToKeep())
+          .withNamedParameter("pw", dbHandler.getConfig().getDatabaseSettings().getPassword());
   }
 
   protected static SQLQuery buildInsertStmtQuery(DatabaseHandler dbHandler, ModifyFeaturesEvent event) {


### PR DESCRIPTION
- Enhance PG function xyz_write_versioned_modification_operation() to trigger asynchronous auto-purging of old versions when needed
- Enhance building multi-modal insert query, adding new parameters

Signed-off-by: Benjamin Rögner <benjamin.roegner@here.com>