### PR TITLE
Implement dynamic setting of service configuration at runtime

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/config/DynamoClient.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/config/DynamoClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2022 HERE Europe B.V.
+ * Copyright (C) 2017-2023 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClientBuilder;
 import com.amazonaws.services.dynamodbv2.document.DynamoDB;
+import com.amazonaws.services.dynamodbv2.document.Table;
 import com.amazonaws.services.dynamodbv2.model.AttributeDefinition;
 import com.amazonaws.services.dynamodbv2.model.BillingMode;
 import com.amazonaws.services.dynamodbv2.model.CreateTableRequest;
@@ -84,6 +85,10 @@ public class DynamoClient {
     client = builder.build();
     db = new DynamoDB(client);
     tableName = new ARN(tableArn).getResourceWithoutType();
+  }
+
+  public Table getTable() {
+    return db.getTable(tableName);
   }
 
   public void createTable(String tableName, String attributes, String keys, String indexes, String ttl) {

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/config/SettingsConfigClient.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/config/SettingsConfigClient.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2017-2023 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.xyz.hub.config;
+
+import com.here.xyz.hub.Service;
+import com.here.xyz.hub.config.dynamo.DynamoSettingsConfigClient;
+import com.here.xyz.hub.config.settings.Setting;
+import io.vertx.core.Future;
+import java.util.concurrent.TimeUnit;
+import net.jodah.expiringmap.ExpirationPolicy;
+import net.jodah.expiringmap.ExpiringMap;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.Marker;
+
+public abstract class SettingsConfigClient implements Initializable {
+
+  protected static final Logger logger = LogManager.getLogger();
+
+  private static final ExpiringMap<String, Setting> cache = ExpiringMap.builder()
+      .expirationPolicy(ExpirationPolicy.CREATED)
+      .expiration(3, TimeUnit.MINUTES)
+      .build();
+
+  public static SettingsConfigClient getInstance() {
+    if (Service.configuration.SETTINGS_DYNAMODB_TABLE_ARN != null)
+      return new DynamoSettingsConfigClient(Service.configuration.SETTINGS_DYNAMODB_TABLE_ARN);
+    else
+      //No overrides are needed when running locally
+      return new SettingsConfigClient() {
+        @Override
+        protected Future<Setting> getSetting(Marker marker, String settingId) {
+          return Future.succeededFuture();
+        }
+      };
+  }
+
+
+  public Future<Setting> get(Marker marker, String settingId) {
+    Setting cached = cache.get(settingId);
+    if (cached != null) {
+      logger.info(marker, "Loaded setting with id \"{}\" from cache", settingId);
+      return Future.succeededFuture(cached);
+    }
+    return getSetting(marker, settingId);
+  }
+
+  protected abstract Future<Setting> getSetting(Marker marker, String settingId);
+
+}

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/config/dynamo/DynamoSettingsConfigClient.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/config/dynamo/DynamoSettingsConfigClient.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2017-2023 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.xyz.hub.config.dynamo;
+
+import com.amazonaws.services.dynamodbv2.document.Item;
+import com.amazonaws.services.dynamodbv2.document.Table;
+import com.amazonaws.services.dynamodbv2.model.AmazonDynamoDBException;
+import com.here.xyz.hub.config.DynamoClient;
+import com.here.xyz.hub.config.SettingsConfigClient;
+import com.here.xyz.hub.config.settings.Setting;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.json.jackson.DatabindCodec;
+import java.util.Map;
+import org.apache.logging.log4j.Marker;
+
+public class DynamoSettingsConfigClient extends SettingsConfigClient {
+
+  private DynamoClient dynamoClient;
+  private Table settings;
+
+  public DynamoSettingsConfigClient(String tableArn) {
+    dynamoClient = new DynamoClient(tableArn);
+    logger.info("Instantiating a reference to Dynamo Table {}", dynamoClient.tableName);
+    settings = dynamoClient.getTable();
+  }
+
+  @Override
+  protected Future<Setting> getSetting(Marker marker, String settingId) {
+    logger.info(marker, "Getting setting with ID: {}", settingId);
+    return DynamoClient.dynamoWorkers.executeBlocking(p -> {
+      try {
+        Item settingItem = settings.getItem("id", settingId);
+        if (settingItem == null) {
+          logger.info(marker, "Getting setting with ID: {} returned null", settingId);
+          p.complete();
+        }
+        else {
+          Map<String, Object> itemData = settingItem.asMap();
+          final Setting setting = DatabindCodec.mapper().convertValue(itemData, Setting.class);
+          if (setting != null)
+            logger.info(marker, "Setting ID: {} has been decoded", settingId);
+          else
+            logger.info(marker, "Setting ID: {} has been decoded to null", settingId);
+          p.complete(setting);
+        }
+      }
+      catch (Exception e) {
+        p.fail(e);
+      }
+    });
+  }
+
+  @Override
+  public void init(Handler<AsyncResult<Void>> onReady) {
+    if (dynamoClient.isLocal()) {
+      logger.info("DynamoDB running locally, initializing tables.");
+
+      try {
+        dynamoClient.createTable(settings.getTableName(), "id:S", "id", null, null);
+      }
+      catch (AmazonDynamoDBException e) {
+        logger.error("Failure during creating table on DynamoSettingsConfigClient init", e);
+        onReady.handle(Future.failedFuture(e));
+        return;
+      }
+    }
+    onReady.handle(Future.succeededFuture());
+  }
+}

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/config/settings/EnvironmentVariableOverrides.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/config/settings/EnvironmentVariableOverrides.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2017-2023 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.xyz.hub.config.settings;
+
+import com.here.xyz.hub.Service;
+import java.util.Map;
+import java.util.Map.Entry;
+
+public class EnvironmentVariableOverrides extends SingletonSetting<Map<String, Object>> {
+
+  public  EnvironmentVariableOverrides() {
+    super();
+  }
+
+  /**
+   * Applies all environment variable overrides contained in this setting object by setting / overwriting its values at the service
+   * configuration object.
+   */
+  public void applyOverrides() throws VariableOverrideException {
+    for (Entry<String, Object> e : data.entrySet())
+      overrideServiceConfigurationValue(e.getKey(), e.getValue());
+  }
+
+  private void overrideServiceConfigurationValue(String variableName, Object overrideValue) throws VariableOverrideException {
+    try {
+      Service.configuration.getClass().getDeclaredField(variableName).set(Service.configuration, overrideValue);
+    }
+    catch (IllegalAccessException | NoSuchFieldException e) {
+      throw new VariableOverrideException(variableName, "Error trying to override variable \"" + variableName + "\".", e);
+    }
+  }
+
+  public static class VariableOverrideException extends Exception {
+
+    public String variableName;
+
+    public VariableOverrideException(String variableName, String message, Throwable cause) {
+      super(message, cause);
+      this.variableName = variableName;
+    }
+  }
+}

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/config/settings/Setting.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/config/settings/Setting.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2017-2023 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.xyz.hub.config.settings;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+
+@JsonTypeInfo(use = Id.NAME, property = "id")
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = SingletonSetting.class)
+})
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Setting<T> {
+
+  @JsonIgnore
+  public String id;
+
+  public T data;
+
+}

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/config/settings/SingletonSetting.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/config/settings/SingletonSetting.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2017-2023 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.xyz.hub.config.settings;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+
+/**
+ * A setting which may only exist ones for the whole service and also only once inside the settings config table.
+ * The ID of a SingletonSetting is always its class name.
+ */
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = EnvironmentVariableOverrides.class)
+})
+public abstract class SingletonSetting<T> extends Setting<T> {
+
+  public SingletonSetting() {
+    this.id = getClass().getSimpleName();
+  }
+
+}


### PR DESCRIPTION
- Add new SettingsConfigClient which fetchess service settings during runtime
- Add DynamoDB implementation for SettingsConfigClient
- Add implementation of a setting model which enables overriding Service configuration / environment variables
- Refactor BurstAndUpdateThread, rename it to "ConfigUpdateThread"
- Enhance ConfigUpdateThread to not only update connector configs, but also settings configs