### PR TITLE
Change roleARN validation to allow slash

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/task/ConnectorHandler.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/task/ConnectorHandler.java
@@ -294,7 +294,7 @@ public class ConnectorHandler {
       throw new HttpException(BAD_REQUEST, "Parameter 'remoteFunction.lambdaARN' must be a valid Lambda function ARN.");
 
     if (rf.roleARN != null)
-      if (!rf.roleARN.matches("arn:aws:iam::\\d{12}:role/[a-zA-Z0-9_+=,.@-]+"))
+      if (!rf.roleARN.matches("arn:aws:iam::\\d{12}:role/[a-zA-Z0-9_+/=,.@-]+"))
         throw new HttpException(BAD_REQUEST, "Parameter 'remoteFunction.roleARN' must be a valid IAM role ARN");
 
     if (rf.warmUp < 0 || rf.warmUp > 32)


### PR DESCRIPTION
ConnectorHandler.java: Fix role ARN validation to allow path after 'role/'. Validation should pass for ARN like: `arn:aws:iam::6660066644444:role/managed/prd-IAMServiceRole-AA` which is legit ARN.
Signed-off-by: Ryszard Olkusnik <ryszard.olkusnik@here.com>