### PR TITLE
Improve performance in some cases where next_version index was not used

### DIFF
--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/SQLQueryBuilder.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/SQLQueryBuilder.java
@@ -271,10 +271,10 @@ public class SQLQueryBuilder {
           event);
   }
 
-  private static String buildUuidCheckFragment(ModifyFeaturesEvent event) {
+  private static SQLQuery buildUuidCheckFragment(ModifyFeaturesEvent event) {
     //NOTE: The following is a temporary implementation for backwards compatibility for old spaces
-    return event.getEnableUUID() ? " AND (#{puuid}::TEXT IS NULL OR jsondata->'properties'->'@ns:com:here:xyz'->>'uuid' = #{puuid})" : "";
-    //return event.getEnableUUID() ? (DatabaseHandler.readVersionsToKeep(event) > 0 ? " AND (CASE WHEN #{baseVersion}::BIGINT IS NULL THEN next_version = max_bigint() ELSE version = #{baseVersion} END)" : " AND (#{puuid}::TEXT IS NULL OR jsondata->'properties'->'@ns:com:here:xyz'->>'uuid' = #{puuid})") : "";
+    return new SQLQuery(event.getEnableUUID() ? " AND (#{puuid}::TEXT IS NULL OR jsondata->'properties'->'@ns:com:here:xyz'->>'uuid' = #{puuid})" : "");
+    //return new SQLQuery(event.getEnableUUID() ? (DatabaseHandler.readVersionsToKeep(event) > 0 ? " AND (CASE WHEN #{baseVersion}::BIGINT IS NULL THEN next_version = #{MAX_BIGINT} ELSE version = #{baseVersion} END)" : " AND (#{puuid}::TEXT IS NULL OR jsondata->'properties'->'@ns:com:here:xyz'->>'uuid' = #{puuid})") : "").withNamedParameter("MAX_BIGINT", MAX_BIGINT);
   }
 
   public static String deleteOldHistoryEntries(final String schema, final String table, long maxAllowedVersion){


### PR DESCRIPTION
- In some cases the next_version index was not used when an expression was used instead of a scalar value