### PR TITLE
Fix missing version in legacy history

### DIFF
--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseWriter.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseWriter.java
@@ -85,20 +85,23 @@ public class DatabaseWriter {
 
     private static PGobject featureToPGobject(ModifyFeaturesEvent event, final Feature feature, long version) throws SQLException {
         final Geometry geometry = feature.getGeometry();
-        feature.setGeometry(null); // Do not serialize the geometry in the JSON object
+        feature.setGeometry(null); //Do not serialize the geometry in the JSON object
 
         final String json;
-
         try {
-            //NOTE: The following is a temporary implementation for backwards compatibility for old table structures
+            //Remove the version from the JSON data, because it should not be written into the "jsondata" column. The version has its own column.
+            feature.getProperties().getXyzNamespace().setVersion(-1);
+
+            //NOTE: The following is a temporary implementation for backwards compatibility for old table structures with legacy history
             if (event.isEnableGlobalVersioning() && version != -1)
                 feature.getProperties().getXyzNamespace().setVersion(version);
 
-            if (event.getVersionsToKeep() <= 1) {
+            if (event.getVersionsToKeep() <= 1)
               feature.getProperties().getXyzNamespace().setAuthor(null);
-            }
+
             json = feature.serialize();
-        } finally {
+        }
+        finally {
             feature.setGeometry(geometry);
         }
 

--- a/xyz-psql-connector/src/main/resources/xyz_ext.sql
+++ b/xyz-psql-connector/src/main/resources/xyz_ext.sql
@@ -3069,7 +3069,6 @@ $BODY$
         updated_rows INTEGER;
         minVersion BIGINT;
     BEGIN
-        jsondata := jsondata #- '{properties,@ns:com:here:xyz,version}';
         EXECUTE
            format('INSERT INTO %I.%I (id, version, operation, author, jsondata, geo) VALUES (%L, %L, %L, %L, %L, %L)',
                schema, tableName, id, version, operation, author, jsondata, CASE WHEN geo::geometry IS NULL THEN NULL ELSE ST_Force3D(ST_GeomFromWKB(geo::BYTEA, 4326)) END);


### PR DESCRIPTION
- If legacy history was used in combination with new history, the version field in the XYZ namespace was not written.