### PR TITLE
Improve fix for write operation

### DIFF
--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseHandler.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseHandler.java
@@ -24,7 +24,6 @@ import static com.here.xyz.models.hub.Space.DEFAULT_VERSIONS_TO_KEEP;
 import static com.here.xyz.psql.DatabaseWriter.ModificationType.DELETE;
 import static com.here.xyz.psql.DatabaseWriter.ModificationType.INSERT;
 import static com.here.xyz.psql.DatabaseWriter.ModificationType.UPDATE;
-import static com.here.xyz.psql.DatabaseWriter.ModificationType.UPDATE_DELETED;
 import static com.here.xyz.psql.QueryRunner.SCHEMA;
 import static com.here.xyz.psql.QueryRunner.TABLE;
 
@@ -71,7 +70,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -454,15 +452,12 @@ public abstract class DatabaseHandler extends StorageConnector {
         List<Feature> inserts = Optional.ofNullable(event.getInsertFeatures()).orElse(new ArrayList<>());
         List<Feature> updates = Optional.ofNullable(event.getUpdateFeatures()).orElse(new ArrayList<>());
         List<Feature> upserts = Optional.ofNullable(event.getUpsertFeatures()).orElse(new ArrayList<>());
-        List<Feature> reinserts = new ArrayList<>();
 
         Map<String, String> deletes = Optional.ofNullable(event.getDeleteFeatures()).orElse(new HashMap<>());
         List<FeatureCollection.ModificationFailure> fails = Optional.ofNullable(event.getFailed()).orElse(new ArrayList<>());
 
-        List<String> originalInserts = inserts.stream().map(Feature::getId).collect(Collectors.toList());
         List<String> originalUpdates = updates.stream().map(Feature::getId).collect(Collectors.toList());
         List<String> originalDeletes = new ArrayList<>(deletes.keySet());
-
         //Handle deletes / updates on extended spaces
         if (isForExtendingSpace(event) && event.getContext() == DEFAULT) {
             if (!deletes.isEmpty()) {
@@ -487,30 +482,11 @@ public abstract class DatabaseHandler extends StorageConnector {
                 }
             }
 
-            // TODO in case LFE updates the behaviour to include "hidden" features from composite spaces, the below statement is invalid
-            if (!inserts.isEmpty()) {
-              // transform the incoming inserts into upserts when the feature is marked in the database as "deleted"
-              if (event.getVersionsToKeep() == 1) {
-                List<String> existingIds = new FetchExistingIds(new FetchIdsInput(table, originalInserts), this).run();
-
-                /*
-                 * The inserts, updates and deletes are populated according to the existence of the feature on LFE,
-                 * When the space is extended, the feature may have been marked as "deleted" by the operations H or J,
-                 * respectively INSERT_HIDE_COMPOSITE and UPDATE_HIDE_COMPOSITE. In this case, the feature is not loaded during LFE.
-                 *
-                 * This means, from the user's perspective, the insertion of a feature with the same ID means an insert.
-                 * However, for the system, when using the v2k=1 (one row per feature) the operation to be performed is an update.
-                 * Converting the existing "hidden" feature (operations H or J), into a new (as of new) feature with the same previous ID
-                 * and operations = I (insert).
-                 */
-                for (Iterator<Feature> it = inserts.iterator(); it.hasNext();) {
-                  Feature feature = it.next();
-                  if (existingIds.contains(feature.getId())) {
-                    reinserts.add(feature);
-                    it.remove();
-                  }
-                }
-              }
+            //TODO: The following is a workaround for a bug in the implementation LFE (in GetFeatures QR) that it filters out operations "H" / "J" which it should not in that case
+            if (!inserts.isEmpty() && readVersionsToKeep(event) == 1) {
+              //Transform the incoming inserts into upserts. That way on the creation of the query we make sure to always check again whether some object exists already for the ID
+              upserts.addAll(inserts);
+              inserts.clear();
             }
 
             if (!updates.isEmpty()) {
@@ -562,9 +538,6 @@ public abstract class DatabaseHandler extends StorageConnector {
                 }
                 if (updates.size() > 0) {
                     DatabaseWriter.modifyFeatures(this, event, UPDATE, collection, fails, updates, connection, version);
-                }
-                if (reinserts.size() > 0) {
-                    DatabaseWriter.modifyFeatures(this, event, UPDATE_DELETED, collection, fails, reinserts, connection, version);
                 }
 
                 if (event.getTransaction()) {


### PR DESCRIPTION
This fix improves / simplifies the write operation of previously deleted objects on a composite space without history. In rare cases this could've lead to duplicates in the dataset.