### PR TITLE
Pull in job execution logic into the job classes to streamline architecture

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/httpconnector/util/jobs/Job.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/httpconnector/util/jobs/Job.java
@@ -18,14 +18,13 @@
  */
 package com.here.xyz.httpconnector.util.jobs;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonView;
 import com.here.xyz.models.hub.Space;
-
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -67,7 +66,23 @@ public abstract class Job {
     public enum Status {
         waiting, queued, validating, validated, preparing, prepared, executing, executed,
             executing_trigger, trigger_executed, collecting_trigger_status, trigger_status_collected,
-            finalizing, finalized, aborted, failed;
+            finalizing, finalized(true), aborted(true), failed(true);
+
+        private final boolean isFinal;
+
+
+        Status() {
+            this(false);
+        }
+
+        Status(boolean isFinal) {
+            this.isFinal = isFinal;
+        }
+
+        public boolean isFinal() {
+            return isFinal;
+        }
+
         public static Status of(String value) {
             if (value == null) {
                 return null;
@@ -313,6 +328,8 @@ public abstract class Job {
         this.finalizedAt = finalizedAt;
     }
 
+    public abstract void finalizeJob();
+
     public Long getExp() {
         return exp;
     }
@@ -394,6 +411,8 @@ public abstract class Job {
 
     @JsonIgnore
     public abstract String getQueryIdentifier();
+
+    public abstract void execute();
 
     public static class Public {
     }

--- a/xyz-hub-service/src/main/java/com/here/xyz/httpconnector/util/scheduler/ImportQueue.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/httpconnector/util/scheduler/ImportQueue.java
@@ -21,28 +21,22 @@ package com.here.xyz.httpconnector.util.scheduler;
 import com.here.xyz.httpconnector.CService;
 import com.here.xyz.httpconnector.config.JDBCImporter;
 import com.here.xyz.httpconnector.util.jobs.Import;
-import com.here.xyz.httpconnector.util.jobs.ImportObject;
 import com.here.xyz.httpconnector.util.jobs.validate.ImportValidator;
 import com.here.xyz.httpconnector.util.jobs.Job;
-import com.here.xyz.httpconnector.util.status.RDSStatus;
 import com.here.xyz.hub.Core;
 import com.mchange.v3.decode.CannotDecodeException;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.pgclient.PgException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.ArrayList;
-import java.util.Map;
-import java.util.List;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 /**
  * Job-Queue for IMPORT-Jobs (S3 -> RDS)
  */
-public class ImportQueue extends JobQueue{
+public class ImportQueue extends JobQueue {
     private static final Logger logger = LogManager.getLogger();
     public static volatile long NODE_EXECUTED_IMPORT_MEMORY;
     protected static ScheduledThreadPoolExecutor executorService = new ScheduledThreadPoolExecutor(CORE_POOL_SIZE, Core.newThreadFactory("import-queue"));
@@ -94,11 +88,11 @@ public class ImportQueue extends JobQueue{
                                 break;
                             case prepared:
                                 updateJobStatus(currentJobConfig,Job.Status.executing)
-                                        .onSuccess(j -> executeJob(j));
+                                        .onSuccess(j -> j.execute());
                                 break;
                             case executed:
                                 updateJobStatus(currentJobConfig,Job.Status.finalizing)
-                                        .onSuccess(j -> finalizeJob(j));
+                                        .onSuccess(j -> j.finalizeJob());
                                 break;
                         }
 
@@ -133,120 +127,6 @@ public class ImportQueue extends JobQueue{
                         setJobFailed(j, Import.ERROR_DESCRIPTION_SEQUENCE_NOT_0, Job.ERROR_TYPE_PREPARATION_FAILED);
                     else
                         setJobFailed(j, Import.ERROR_DESCRIPTION_UNEXPECTED, Job.ERROR_TYPE_PREPARATION_FAILED);
-                });
-    }
-
-    @Override
-    protected void executeJob(Job j){
-        j.setExecutedAt(Core.currentTimeMillis() / 1000L);
-        String defaultSchema = JDBCImporter.getDefaultSchema(j.getTargetConnector());
-        List<Future> importFutures = new ArrayList<>();
-
-        Map<String, ImportObject> importObjects = ((Import) j).getImportObjects();
-        for (String key : importObjects.keySet()) {
-            if(!importObjects.get(key).isValid())
-                continue;
-
-            if(importObjects.get(key).getStatus().equals(ImportObject.Status.imported)
-                || importObjects.get(key).getStatus().equals(ImportObject.Status.failed))
-                continue;
-
-            /** compressed processing of 9,5GB leads into ~120 GB RDS Mem */
-            long curFileSize = Long.valueOf(importObjects.get(key).isCompressed() ? (importObjects.get(key).getFilesize() * 12)  : importObjects.get(key).getFilesize());
-            double maxMemInGB = new RDSStatus.Limits(CService.rdsLookupCapacity.get(j.getTargetConnector())).getMaxMemInGB();
-
-            logger.info("job[{}] IMPORT_MEMORY {}/{} = {}% of max", j.getId(), NODE_EXECUTED_IMPORT_MEMORY, (maxMemInGB * 1024 * 1024 * 1024) , (NODE_EXECUTED_IMPORT_MEMORY/ (maxMemInGB * 1024 * 1024 * 1024)));
-
-            //TODO: Also view RDS METRICS?
-            if(NODE_EXECUTED_IMPORT_MEMORY < CService.configuration.JOB_MAX_RDS_INFLIGHT_IMPORT_BYTES){
-                importObjects.get(key).setStatus(ImportObject.Status.processing);
-                NODE_EXECUTED_IMPORT_MEMORY += curFileSize;
-                logger.info("job[{}] start execution of {}! mem: {}", j.getId(), importObjects.get(key).getS3Key(j.getId(), key), NODE_EXECUTED_IMPORT_MEMORY);
-
-                importFutures.add(
-                        CService.jdbcImporter.executeImport(j.getId(), j.getTargetConnector(), defaultSchema, j.getTargetTable(),
-                                        CService.configuration.JOBS_S3_BUCKET, importObjects.get(key).getS3Key(j.getId(), key), CService.configuration.JOBS_REGION, curFileSize, j.getCsvFormat() )
-                                .onSuccess(result -> {
-                                            NODE_EXECUTED_IMPORT_MEMORY -= curFileSize;
-                                            logger.info("job[{}] Import of '{}' succeeded!", j.getId(), importObjects.get(key));
-
-                                            importObjects.get(key).setStatus(ImportObject.Status.imported);
-                                            if(result != null && result.indexOf("imported") !=1) {
-                                                //242579 rows imported int…sv.gz of 56740921 bytes
-                                                importObjects.get(key).setDetails(result.substring(0,result.indexOf("imported")+8));
-                                            }
-                                        }
-                                )
-                                .onFailure(e -> {
-                                            NODE_EXECUTED_IMPORT_MEMORY -= curFileSize;
-                                            logger.warn("JOB[{}] Import of '{}' failed - mem: {}!", j.getId(), importObjects.get(key), NODE_EXECUTED_IMPORT_MEMORY, e);
-                                            importObjects.get(key).setStatus(ImportObject.Status.failed);
-                                        }
-                                )
-                );
-            }else {
-                importObjects.get(key).setStatus(ImportObject.Status.waiting);
-            }
-        }
-
-        CompositeFuture.join(importFutures)
-                .onComplete(
-                        t -> {
-                            if(t.failed()){
-                                logger.warn("job[{}] Import of '{}' failed! ", j.getId(), j.getTargetSpaceId(), t);
-
-                                if(t.cause().getMessage() != null && t.cause().getMessage().equalsIgnoreCase("Fail to read any response from the server, the underlying connection might get lost unexpectedly."))
-                                    setJobAborted(j);
-                                else if(t.cause().getMessage() != null && t.cause().getMessage().contains("duplicate key value violates unique constraint")){
-                                    setJobFailed(j, Import.ERROR_DESCRIPTION_IDS_NOT_UNIQUE, Job.ERROR_TYPE_EXECUTION_FAILED);
-                                }else
-                                    setJobFailed(j, Import.ERROR_DESCRIPTION_UNEXPECTED, Job.ERROR_TYPE_EXECUTION_FAILED);
-                            }else{
-                                int cntInvalid = 0;
-
-                                for (String key : importObjects.keySet()) {
-                                    if(importObjects.get(key).getStatus() == ImportObject.Status.failed)
-                                        cntInvalid++;
-                                    if(importObjects.get(key).getStatus() == ImportObject.Status.waiting){
-                                        /** Some Imports are still queued - execute again */
-                                        updateJobStatus(j, Job.Status.prepared);
-                                    }
-                                }
-
-                                if(cntInvalid == importObjects.size()) {
-                                    j.setErrorDescription(Import.ERROR_DESCRIPTION_ALL_IMPORTS_FAILED);
-                                }
-                                else if(cntInvalid > 0 && cntInvalid < importObjects.size()) {
-                                    j.setErrorDescription(Import.ERROR_DESCRIPTION_IMPORTS_PARTIALLY_FAILED);
-                                }
-
-                                updateJobStatus(j, Job.Status.executed);
-                            }
-                    });
-    }
-
-    @Override
-    protected void finalizeJob(Job j){
-        String getDefaultSchema = JDBCImporter.getDefaultSchema(j.getTargetConnector());
-
-        //@TODO: Limit parallel Creations
-        CService.jdbcImporter.finalizeImport(j, getDefaultSchema)
-                .onFailure(f -> {
-                    logger.warn("job[{}] finalization failed!", j.getId(), f);
-
-                    if(f.getMessage().equalsIgnoreCase(Import.ERROR_TYPE_ABORTED))
-                        setJobAborted(j);
-                    else
-                        setJobFailed(j, null, Job.ERROR_TYPE_EXECUTION_FAILED);
-                })
-                .compose(
-                    f -> {
-                        j.setFinalizedAt(Core.currentTimeMillis() / 1000L);
-                        logger.info("job[{}] finalization finished!", j.getId());
-                        if(j.getErrorDescription() != null)
-                            return updateJobStatus(j, Job.Status.failed);
-
-                        return updateJobStatus(j, Job.Status.finalized);
                 });
     }
 

--- a/xyz-hub-service/src/main/java/com/here/xyz/httpconnector/util/scheduler/JobQueue.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/httpconnector/util/scheduler/JobQueue.java
@@ -59,10 +59,6 @@ public abstract class JobQueue implements Runnable {
 
     protected abstract void prepareJob(Job j);
 
-    protected abstract void executeJob(Job j);
-
-    protected abstract void finalizeJob(Job j0);
-
     protected abstract boolean needRdsCheck(Job j0);
 
     protected Future<Void> isProcessingPossible(Job job){
@@ -192,11 +188,11 @@ public abstract class JobQueue implements Runnable {
         return JOB_QUEUE.size();
     }
 
-    protected static Future<Job> setJobFailed(Job j, String errorDescription, String errorType){
+    public static Future<Job> setJobFailed(Job j, String errorDescription, String errorType){
         return updateJobStatus(j, Job.Status.failed, errorDescription, errorType);
     }
 
-    protected static Future<Job> setJobAborted(Job j){
+    public static Future<Job> setJobAborted(Job j){
         removeJob(j);
         return updateJobStatus(j, Job.Status.aborted);
     }
@@ -205,7 +201,7 @@ public abstract class JobQueue implements Runnable {
         return updateJobStatus(j, j.getStatus(), j.getErrorDescription(), j.getErrorType());
     }
 
-    protected static Future<Job> updateJobStatus(Job j, Job.Status status) {
+    public static Future<Job> updateJobStatus(Job j, Job.Status status) {
         return updateJobStatus(j, status, null, null);
     }
 


### PR DESCRIPTION
- Introduce execute() / finalizeJob() methods on Job (Export / Import)
- Introduce isFinal() on job status enums to check if some job state is final