### PR TITLE
Streamline source- / target-definition of job configurations

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/httpconnector/util/jobs/DatasetDescription.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/httpconnector/util/jobs/DatasetDescription.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2017-2023 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.xyz.httpconnector.util.jobs;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.here.xyz.Typed;
+import com.here.xyz.httpconnector.util.jobs.DatasetDescription.Files;
+import com.here.xyz.httpconnector.util.jobs.DatasetDescription.Map;
+import com.here.xyz.httpconnector.util.jobs.DatasetDescription.Space;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonTypeInfo(use = Id.NAME, property = "type")
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = Map.class, name = "Map"),
+    @JsonSubTypes.Type(value = Space.class, name = "Space"),
+    @JsonSubTypes.Type(value = Files.class, name = "Files")
+})
+public abstract class DatasetDescription implements Typed {
+
+  public abstract static class Identifiable extends DatasetDescription {
+
+    private String id;
+
+    public String getId() {
+      return id;
+    }
+
+    public void setId(String id) {
+      this.id = id;
+    }
+
+    public <T extends Identifiable> T withId(String id) {
+      setId(id);
+      return (T) this;
+    }
+  }
+
+  public static class Files extends DatasetDescription {
+
+  }
+
+  public static class Map extends Identifiable {
+
+  }
+
+  public static class Space extends Identifiable {
+
+  }
+}

--- a/xyz-hub-service/src/main/java/com/here/xyz/httpconnector/util/jobs/Export.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/httpconnector/util/jobs/Export.java
@@ -30,12 +30,10 @@ import com.here.xyz.httpconnector.CService;
 import com.here.xyz.httpconnector.config.JDBCExporter;
 import com.here.xyz.httpconnector.config.JDBCImporter;
 import com.here.xyz.httpconnector.rest.HApiParam;
+import com.here.xyz.httpconnector.util.jobs.DatasetDescription.Files;
 import com.here.xyz.hub.Core;
 import com.here.xyz.hub.rest.ApiParam;
-import com.here.xyz.hub.rest.HttpException;
 import com.here.xyz.models.geojson.implementation.Geometry;
-
-import io.vertx.core.Future;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -44,7 +42,7 @@ import org.apache.logging.log4j.Logger;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-public class Export extends Job {
+public class Export extends Job<Export> {
     private static final Logger logger = LogManager.getLogger();
     public static String ERROR_TYPE_HTTP_TRIGGER_FAILED = "http_trigger_failed";
     public static String ERROR_TYPE_TARGET_ID_INVALID = "targetId_invalid";
@@ -121,6 +119,11 @@ public class Export extends Job {
         this.processingList = processingList;
     }
 
+    public Export withProcessingList(List<String> processingList) {
+        setProcessingList(processingList);
+        return this;
+    }
+
     public long getEstimatedFeatureCount() {
         return estimatedFeatureCount;
     }
@@ -129,12 +132,22 @@ public class Export extends Job {
         this.estimatedFeatureCount = estimatedFeatureCount;
     }
 
+    public Export withEstimatedFeatureCount(long estimatedFeatureCount){
+        setEstimatedFeatureCount(estimatedFeatureCount);
+        return this;
+    }
+
     public Map<String,Long> getSearchableProperties() {
         return searchableProperties;
     }
 
-    public void setSearchableProperties( Map<String,Long> searchableProperties ) {
+    public void setSearchableProperties(Map<String,Long> searchableProperties) {
         this.searchableProperties = searchableProperties;
+    }
+
+    public Export withSearchableProperties(Map<String,Long> searchableProperties) {
+        setSearchableProperties(searchableProperties);
+        return this;
     }
 
     public ExportStatistic getStatistic(){
@@ -175,12 +188,39 @@ public class Export extends Job {
         this.exportObjects = exportObjects;
     }
 
+    public Export withExportObjects(Map<String, ExportObject> exportObjects) {
+        setExportObjects(exportObjects);
+        return this;
+    }
+
+    /**
+     * @deprecated Please use method {@link #getTarget()} instead.
+     */
+    @Deprecated
     public ExportTarget getExportTarget() {
         return exportTarget;
     }
 
+    /**
+     * @deprecated Please use method {@link #setTarget(DatasetDescription)} instead.
+     * @param exportTarget
+     */
+    @Deprecated
     public void setExportTarget(ExportTarget exportTarget) {
         this.exportTarget = exportTarget;
+        //Keep BWC
+        if (getTarget() == null && (exportTarget.getType() == ExportTarget.Type.S3 || exportTarget.getType() == ExportTarget.Type.DOWNLOAD))
+            setTarget(new Files());
+    }
+
+    /**
+     * @deprecated Please use method {@link #withTarget(DatasetDescription)} instead.
+     * @param exportTarget
+     */
+    @Deprecated
+    public Export withExportTarget(final ExportTarget exportTarget) {
+        setExportTarget(exportTarget);
+        return this;
     }
 
     public Integer getTargetLevel() {
@@ -191,12 +231,22 @@ public class Export extends Job {
         this.targetLevel = targetLevel;
     }
 
+    public Export withTargetLevel(final Integer targetLevel) {
+        setTargetLevel(targetLevel);
+        return this;
+    }
+
     public String getPartitionKey() {
         return partitionKey;
     }
 
     public void setPartitionKey(String partitionKey) {
         this.partitionKey = partitionKey;
+    }
+
+    public Export withPartitionKey(final String partitionKey) {
+        setPartitionKey(partitionKey);
+        return this;
     }
 
     public String getTargetVersion() {
@@ -207,12 +257,22 @@ public class Export extends Job {
         this.targetVersion = targetVersion;
     }
 
+    public Export withTargetVersion(final String targetVersion) {
+        setTargetVersion(targetVersion);
+        return this;
+    }
+
     public int getMaxTilesPerFile() {
         return maxTilesPerFile;
     }
 
     public void setMaxTilesPerFile(int maxTilesPerFile) {
         this.maxTilesPerFile = maxTilesPerFile;
+    }
+
+    public Export withMaxTilesPerFile(final int maxTilesPerFile) {
+        setMaxTilesPerFile(maxTilesPerFile);
+        return this;
     }
 
     public Boolean getClipped() {
@@ -223,6 +283,11 @@ public class Export extends Job {
         this.clipped = clipped;
     }
 
+    public Export withClipped(final boolean clipped) {
+        setClipped(clipped);
+        return this;
+    }
+
     public Filters getFilters() {
         return filters;
     }
@@ -231,159 +296,14 @@ public class Export extends Job {
         this.filters = filters;
     }
 
-    public String getTriggerId() { return triggerId; }
-
-    public void setTriggerId(String triggerId) { this.triggerId = triggerId; }
-
-    public Export withId(final String id) {
-        setId(id);
-        return this;
-    }
-
-    public Export withProcessingList(List<String> processingList) {
-        setProcessingList(processingList);
-        return this;
-    }
-
-    public Export withEstimatedFeatureCount(long estimatedFeatureCount){
-        setEstimatedFeatureCount(estimatedFeatureCount);
-        return this;
-    }
-
-    public Export withSearchableProperties(Map<String,Long> searchableProperties) {
-        setSearchableProperties(searchableProperties);
-        return this;
-    }
-
-    public Export withExportObjects(Map<String, ExportObject> exportObjects) {
-        setExportObjects(exportObjects);
-        return this;
-    }
-
-    public Export withErrorDescription(final String errorDescription) {
-        setErrorDescription(errorDescription);
-        return this;
-    }
-
-    public Export withDescription(final String description) {
-        setDescription(description);
-        return this;
-    }
-
-    public Export withTargetSpaceId(final String targetSpaceId) {
-        setTargetSpaceId(targetSpaceId);
-        return this;
-    }
-
-    public Export withTargetTable(final String targetTable) {
-        setTargetTable(targetTable);
-        return this;
-    }
-
-    public Export withStatus(final Job.Status status) {
-        setStatus(status);
-        return this;
-    }
-
-    public Export withCsvFormat(CSVFormat csv_format) {
-        setCsvFormat(csv_format);
-        return this;
-    }
-
-    public Export withCsvFormat(Strategy importStrategy) {
-        setStrategy(importStrategy);
-        return this;
-    }
-
-    public Export withCreatedAt(final long createdAt) {
-        setCreatedAt(createdAt);
-        return this;
-    }
-
-    public Export withUpdatedAt(final long updatedAt) {
-        setUpdatedAt(updatedAt);
-        return this;
-    }
-
-    public Export withExecutedAt(final Long startedAt) {
-        setExecutedAt(startedAt);
-        return this;
-    }
-
-    public Export withFinalizedAt(final Long finalizedAt) {
-        setFinalizedAt(finalizedAt);
-        return this;
-    }
-
-    public Export withExp(final Long exp) {
-        setExp(exp);
-        return this;
-    }
-
-    public Export withTargetConnector(String targetConnector) {
-        setTargetConnector(targetConnector);
-        return this;
-    }
-
-    public Export withErrorType(String errorType) {
-        setErrorType(errorType);
-        return this;
-    }
-
-    public Export withSpaceVersion(final long spaceVersion) {
-        setSpaceVersion(spaceVersion);
-        return this;
-    }
-
-    public Export withAuthor(String author) {
-        setAuthor(author);
-        return this;
-    }
-
-    public Export withMaxTilesPerFile(final int maxTilesPerFile) {
-        setMaxTilesPerFile(maxTilesPerFile);
-        return this;
-    }
-
-    public Export withClipped(final boolean clipped) {
-        setClipped(clipped);
-        return this;
-    }
-
-    public Export withOmitOnNull(final boolean omitOnNull) {
-        setOmitOnNull(omitOnNull);
-        return this;
-    }
-
     public Export withFilters(final Filters filters) {
         setFilters(filters);
         return this;
     }
 
-    public Export withExportTarget(final ExportTarget exportTarget) {
-        setExportTarget(exportTarget);
-        return this;
-    }
+    public String getTriggerId() { return triggerId; }
 
-    public Export withTargetLevel(final Integer targetLevel) {
-        setTargetLevel(targetLevel);
-        return this;
-    }
-
-    public Export withPartitionKey(final String partitionKey) {
-        setPartitionKey(partitionKey);
-        return this;
-    }
-
-    public Export withTargetVersion(final String targetVersion) {
-        setTargetVersion(targetVersion);
-        return this;
-    }
-
-    public Export withParams(Map params) {
-        setParams(params);
-        return this;
-    }
+    public void setTriggerId(String triggerId) { this.triggerId = triggerId; }
 
     public Export withTriggerId(String triggerId) {
         setTriggerId(triggerId);
@@ -596,12 +516,22 @@ public class Export extends Job {
             this.geometry = geometry;
         }
 
+        public SpatialFilter withGeometry(Geometry geometry){
+            this.setGeometry(geometry);
+            return this;
+        }
+
         public int getRadius() {
             return radius;
         }
 
         public void setRadius(int radius) {
             this.radius = radius;
+        }
+
+        public SpatialFilter withRadius(final int radius) {
+            setRadius(radius);
+            return this;
         }
 
         public boolean isClipped() {
@@ -612,14 +542,6 @@ public class Export extends Job {
             this.clipped = clipped;
         }
 
-        public SpatialFilter withGeometry(Geometry geometry){
-            this.setGeometry(geometry);
-            return this;
-        }
-        public SpatialFilter withRadius(final int radius) {
-            setRadius(radius);
-            return this;
-        }
         public SpatialFilter withClipped(final boolean clipped) {
             setClipped(clipped);
             return this;
@@ -641,6 +563,11 @@ public class Export extends Job {
             this.propertyFilter = propertyFilter;
         }
 
+        public Filters withPropertyFilter(String propertyFilter) {
+            setPropertyFilter(propertyFilter);
+            return this;
+        }
+
         public SpatialFilter getSpatialFilter() {
             return spatialFilter;
         }
@@ -651,11 +578,6 @@ public class Export extends Job {
 
         public Filters withSpatialFilter(SpatialFilter spatialFilter) {
             setSpatialFilter(spatialFilter);
-            return this;
-        }
-
-        public Filters withPropertyFilter(String propertyFilter) {
-            setPropertyFilter(propertyFilter);
             return this;
         }
     }

--- a/xyz-hub-service/src/main/java/com/here/xyz/httpconnector/util/jobs/Import.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/httpconnector/util/jobs/Import.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2022 HERE Europe B.V.
+ * Copyright (C) 2017-2023 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,6 @@ import static com.here.xyz.httpconnector.util.scheduler.JobQueue.updateJobStatus
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonView;
-
 import com.here.xyz.httpconnector.CService;
 import com.here.xyz.httpconnector.config.JDBCImporter;
 import com.here.xyz.httpconnector.util.status.RDSStatus;
@@ -42,7 +41,7 @@ import org.apache.logging.log4j.Logger;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public class Import extends Job {
+public class Import extends Job<Import> {
     private static final Logger logger = LogManager.getLogger();
     public static String ERROR_TYPE_NO_DB_CONNECTION = "no_db_connection";
 
@@ -68,7 +67,7 @@ public class Import extends Job {
     @JsonView({Internal.class})
     private List<String> idxList;
 
-    public Import(){ }
+    public Import() {}
 
     public Import(String description, String targetSpaceId, String targetTable,CSVFormat csvFormat, Strategy strategy) {
         this.description = description;
@@ -100,98 +99,8 @@ public class Import extends Job {
         this.idxList = idxList;
     }
 
-    public Import withId(final String id) {
-        setId(id);
-        return this;
-    }
-
     public Import withImportObjects(Map<String, ImportObject> importObjects) {
         setImportObjects(importObjects);
-        return this;
-    }
-
-    public Import withErrorDescription(final String errorDescription) {
-        setErrorDescription(errorDescription);
-        return this;
-    }
-
-    public Import withDescription(final String description) {
-        setDescription(description);
-        return this;
-    }
-
-    public Import withTargetSpaceId(final String targetSpaceId) {
-        setTargetSpaceId(targetSpaceId);
-        return this;
-    }
-
-    public Import withTargetTable(final String targetTable) {
-        setTargetTable(targetTable);
-        return this;
-    }
-
-    public Import withStatus(final Job.Status status) {
-        setStatus(status);
-        return this;
-    }
-
-    public Import withCsvFormat(CSVFormat csv_format) {
-        setCsvFormat(csv_format);
-        return this;
-    }
-
-    public Import withCsvFormat(Strategy importStrategy) {
-        setStrategy(importStrategy);
-        return this;
-    }
-
-    public Import withCreatedAt(final long createdAt) {
-        setCreatedAt(createdAt);
-        return this;
-    }
-
-    public Import withUpdatedAt(final long updatedAt) {
-        setUpdatedAt(updatedAt);
-        return this;
-    }
-
-    public Import withExecutedAt(final Long startedAt) {
-        setExecutedAt(startedAt);
-        return this;
-    }
-
-    public Import withFinalizedAt(final Long finalizedAt) {
-        setFinalizedAt(finalizedAt);
-        return this;
-    }
-
-    public Import withExp(final Long exp) {
-        setExp(exp);
-        return this;
-    }
-
-    public Import withTargetConnector(String targetConnector) {
-        setTargetConnector(targetConnector);
-        return this;
-    }
-
-    public Import withErrorType(String errorType) {
-        setErrorType(errorType);
-        return this;
-    }
-
-    public Import withSpaceVersion(final long spaceVersion) {
-        setSpaceVersion(spaceVersion);
-        return this;
-    }
-
-    public Import withAuthor(String author) {
-        setAuthor(author);
-        return this;
-    }
-
-    public Import withParams(Map params) {
-        setParams(params);
         return this;
     }
 

--- a/xyz-hub-service/src/main/java/com/here/xyz/httpconnector/util/jobs/Job.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/httpconnector/util/jobs/Job.java
@@ -16,6 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  * License-Filename: LICENSE
  */
+
 package com.here.xyz.httpconnector.util.jobs;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -35,11 +36,11 @@ import java.util.Objects;
         include = JsonTypeInfo.As.EXISTING_PROPERTY,
         property = "type")
 @JsonSubTypes({
-        @JsonSubTypes.Type(value = Import.class , name = "Import"),
-        @JsonSubTypes.Type(value = Export.class , name = "Export")
+        @JsonSubTypes.Type(value = Import.class, name = "Import"),
+        @JsonSubTypes.Type(value = Export.class, name = "Export")
 })
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-public abstract class Job {
+public abstract class Job<T extends Job> {
     public static String ERROR_TYPE_VALIDATION_FAILED = "validation_failed";
     public static String ERROR_TYPE_PREPARATION_FAILED = "preparation_failed";
     public static String ERROR_TYPE_EXECUTION_FAILED = "execution_failed";
@@ -220,12 +221,20 @@ public abstract class Job {
     @JsonView({Internal.class})
     protected Map<String, Object> params;
 
+    private DatasetDescription source;
+    private DatasetDescription target;
+
     public String getId(){
         return id;
     }
 
     public void setId(final String id){
         this.id = id;
+    }
+
+    public T withId(final String id) {
+        setId(id);
+        return (T) this;
     }
 
     public String getErrorDescription() {
@@ -236,6 +245,11 @@ public abstract class Job {
         this.errorDescription = errorDescription;
     }
 
+    public T withErrorDescription(final String errorDescription) {
+        setErrorDescription(errorDescription);
+        return (T) this;
+    }
+
     public String getDescription() {
         return description;
     }
@@ -244,12 +258,43 @@ public abstract class Job {
         this.description = description;
     }
 
+    public T withDescription(final String description) {
+        setDescription(description);
+        return (T) this;
+    }
+
+    /**
+     * @deprecated Please use methods {@link #getTarget()} or {@link #getSource()} instead.
+     * @return
+     */
+    @Deprecated
     public String getTargetSpaceId() {
         return targetSpaceId;
     }
 
+    /**
+     * @deprecated Please use methods {@link #setTarget(DatasetDescription)} or {@link #setSource(DatasetDescription)} instead.
+     * @param targetSpaceId
+     */
+    @Deprecated
     public void setTargetSpaceId(String targetSpaceId) {
         this.targetSpaceId = targetSpaceId;
+        //Keep BWC
+        if (this instanceof Import && target == null)
+            setTarget(new DatasetDescription.Space().withId(targetSpaceId));
+        else if (this instanceof Export && source == null)
+            setSource(new DatasetDescription.Space().withId(targetSpaceId));
+    }
+
+    /**
+     * @deprecated Please use methods {@link #withTarget(DatasetDescription)} or {@link #withSource(DatasetDescription)} instead.
+     * @param targetSpaceId
+     * @return
+     */
+    @Deprecated
+    public T withTargetSpaceId(final String targetSpaceId) {
+        setTargetSpaceId(targetSpaceId);
+        return (T) this;
     }
 
     public String getTargetTable() {
@@ -260,6 +305,11 @@ public abstract class Job {
         this.targetTable = targetTable;
     }
 
+    public T withTargetTable(final String targetTable) {
+        setTargetTable(targetTable);
+        return (T) this;
+    }
+
     public Status getStatus() { return status; }
 
     public void setStatus(Job.Status status) {
@@ -268,6 +318,11 @@ public abstract class Job {
         if((status.equals(Status.aborted) || status.equals(Status.failed)) && lastStatus == null)
             lastStatus = this.status;
         this.status = status;
+    }
+
+    public T withStatus(final Job.Status status) {
+        setStatus(status);
+        return (T) this;
     }
 
     public void resetStatus(Job.Status status) {
@@ -284,8 +339,13 @@ public abstract class Job {
         return csvFormat;
     }
 
-    public void setCsvFormat(CSVFormat csv_format) {
-        this.csvFormat = csv_format;
+    public void setCsvFormat(CSVFormat csvFormat) {
+        this.csvFormat = csvFormat;
+    }
+
+    public T withCsvFormat(CSVFormat csvFormat) {
+        setCsvFormat(csvFormat);
+        return (T) this;
     }
 
     public Strategy getStrategy() {
@@ -296,12 +356,22 @@ public abstract class Job {
         this.strategy = strategy;
     }
 
+    public T withCsvFormat(Strategy strategy) {
+        setStrategy(strategy);
+        return (T) this;
+    }
+
     public long getCreatedAt() {
         return createdAt;
     }
 
     public void setCreatedAt(final long createdAt) {
         this.createdAt = createdAt;
+    }
+
+    public T withCreatedAt(final long createdAt) {
+        setCreatedAt(createdAt);
+        return (T) this;
     }
 
     public long getUpdatedAt() {
@@ -312,6 +382,11 @@ public abstract class Job {
         this.updatedAt = updatedAt;
     }
 
+    public T withUpdatedAt(final long updatedAt) {
+        setUpdatedAt(updatedAt);
+        return (T) this;
+    }
+
     public Long getExecutedAt() {
         return executedAt;
     }
@@ -320,12 +395,22 @@ public abstract class Job {
         this.executedAt = executedAt;
     }
 
+    public T withExecutedAt(final Long startedAt) {
+        setExecutedAt(startedAt);
+        return (T) this;
+    }
+
     public Long getFinalizedAt() {
         return finalizedAt;
     }
 
     public void setFinalizedAt(final Long finalizedAt) {
         this.finalizedAt = finalizedAt;
+    }
+
+    public T withFinalizedAt(final Long finalizedAt) {
+        setFinalizedAt(finalizedAt);
+        return (T) this;
     }
 
     public abstract void finalizeJob();
@@ -338,6 +423,11 @@ public abstract class Job {
         this.exp = exp;
     }
 
+    public T withExp(final Long exp) {
+        setExp(exp);
+        return (T) this;
+    }
+
     public String getTargetConnector() {
         return targetConnector;
     }
@@ -346,12 +436,22 @@ public abstract class Job {
         this.targetConnector = targetConnector;
     }
 
-    public void setErrorType(String errorType){
-        this.errorType = errorType;
+    public T withTargetConnector(String targetConnector) {
+        setTargetConnector(targetConnector);
+        return (T) this;
     }
 
     public String getErrorType() {
         return errorType;
+    }
+
+    public void setErrorType(String errorType){
+        this.errorType = errorType;
+    }
+
+    public T withErrorType(String errorType) {
+        setErrorType(errorType);
+        return (T) this;
     }
 
     public Long getSpaceVersion() {
@@ -362,12 +462,22 @@ public abstract class Job {
         this.spaceVersion = spaceVersion;
     }
 
+    public T withSpaceVersion(final long spaceVersion) {
+        setSpaceVersion(spaceVersion);
+        return (T) this;
+    }
+
     public String getAuthor() {
         return author;
     }
 
     public void setAuthor(String author) {
         this.author = author;
+    }
+
+    public T withAuthor(String author) {
+        setAuthor(author);
+        return (T) this;
     }
 
     public Boolean getClipped() {
@@ -386,6 +496,11 @@ public abstract class Job {
         this.omitOnNull = omitOnNull;
     }
 
+    public T withOmitOnNull(final boolean omitOnNull) {
+        setOmitOnNull(omitOnNull);
+        return (T) this;
+    }
+
     public Object getParam(String key) {
         if(params == null)
             return null;
@@ -398,6 +513,43 @@ public abstract class Job {
 
     public void setParams(Map<String, Object> params) {
         this.params = params;
+    }
+
+    public T withParams(Map params) {
+        setParams(params);
+        return (T) this;
+    }
+
+    public DatasetDescription getSource() {
+        return source;
+    }
+
+    public void setSource(DatasetDescription source) {
+        this.source = source;
+        //Keep BWC
+//        if (source instanceof DatasetDescription.Space)
+//            setTargetSpaceId(((DatasetDescription.Space) source).getId());
+    }
+
+    public T withSource(DatasetDescription source) {
+        setSource(source);
+        return (T) this;
+    }
+
+    public DatasetDescription getTarget() {
+        return target;
+    }
+
+    public void setTarget(DatasetDescription target) {
+        this.target = target;
+        //Keep BWC
+//        if (target instanceof DatasetDescription.Space)
+//            setTargetSpaceId(((DatasetDescription.Space) source).getId());
+    }
+
+    public T withTarget(DatasetDescription target) {
+        setTarget(target);
+        return (T) this;
     }
 
     public void addParam(String key, Object value){

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/config/dynamo/DynamoSpaceConfigClient.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/config/dynamo/DynamoSpaceConfigClient.java
@@ -19,6 +19,8 @@
 
 package com.here.xyz.hub.config.dynamo;
 
+import static com.here.xyz.XyzSerializable.Mappers.STATIC_MAPPER;
+
 import com.amazonaws.handlers.AsyncHandler;
 import com.amazonaws.services.dynamodbv2.document.BatchGetItemOutcome;
 import com.amazonaws.services.dynamodbv2.document.Item;
@@ -36,7 +38,6 @@ import com.amazonaws.services.dynamodbv2.model.PutItemRequest;
 import com.amazonaws.services.dynamodbv2.model.PutItemResult;
 import com.amazonaws.util.CollectionUtils;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.here.xyz.XyzSerializable;
 import com.here.xyz.events.PropertiesQuery;
 import com.here.xyz.hub.Service;
 import com.here.xyz.hub.config.SpaceConfigClient;
@@ -166,7 +167,7 @@ public class DynamoSpaceConfigClient extends SpaceConfigClient {
   }
 
   private void storeSpaceSync(Space space, Promise<Void> p) {
-    final Map<String, Object> itemData = XyzSerializable.STATIC_MAPPER.get().convertValue(space, new TypeReference<Map<String, Object>>() {});
+    final Map<String, Object> itemData = STATIC_MAPPER.get().convertValue(space, new TypeReference<Map<String, Object>>() {});
     itemData.put("shared", space.isShared() ? 1 : 0); //Shared value must be a number because it's also used as index
     sanitize(itemData);
     spaces.putItem(Item.fromMap(itemData));

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/config/jdbc/JDBCSpaceConfigClient.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/config/jdbc/JDBCSpaceConfigClient.java
@@ -19,11 +19,11 @@
 
 package com.here.xyz.hub.config.jdbc;
 
+import static com.here.xyz.XyzSerializable.Mappers.STATIC_MAPPER;
 import static com.here.xyz.hub.config.jdbc.JDBCConfig.SPACE_TABLE;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.here.xyz.XyzSerializable;
 import com.here.xyz.events.PropertiesQuery;
 import com.here.xyz.hub.config.SpaceConfigClient;
 import com.here.xyz.hub.connectors.models.Space;
@@ -38,7 +38,6 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.jackson.DatabindCodec;
 import io.vertx.ext.sql.SQLClient;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -100,7 +99,7 @@ public class JDBCSpaceConfigClient extends SpaceConfigClient {
     SQLQuery query = null;
     try {
       //NOTE: The following is a temporary implementation to keep backwards compatibility for non-versioned spaces
-      final Map<String, Object> itemData = XyzSerializable.STATIC_MAPPER.get().convertValue(space, new TypeReference<Map<String, Object>>() {});
+      final Map<String, Object> itemData = STATIC_MAPPER.get().convertValue(space, new TypeReference<Map<String, Object>>() {});
       if (itemData.get("versionsToKeep") != null && itemData.get("versionsToKeep") instanceof Integer && ((int) itemData.get("versionsToKeep")) == 0)
         itemData.remove("versionsToKeep");
       query = new SQLQuery(
@@ -108,7 +107,7 @@ public class JDBCSpaceConfigClient extends SpaceConfigClient {
           .withNamedParameter("spaceId", space.getId())
           .withNamedParameter("owner", space.getOwner())
           .withNamedParameter("cid", space.getCid())
-          .withNamedParameter("spaceJson", XyzSerializable.STATIC_MAPPER.get().writeValueAsString(itemData))
+          .withNamedParameter("spaceJson", STATIC_MAPPER.get().writeValueAsString(itemData))
           .withNamedParameter("region", space.getRegion());
       return JDBCConfig.updateWithParams(query).mapEmpty();
     }

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/RpcClient.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/RpcClient.java
@@ -19,6 +19,7 @@
 
 package com.here.xyz.hub.connectors;
 
+import static com.here.xyz.XyzSerializable.Mappers.DEFAULT_MAPPER;
 import static com.here.xyz.events.GetFeaturesByTileEvent.ResponseType.MVT;
 import static com.here.xyz.events.GetFeaturesByTileEvent.ResponseType.MVT_FLATTENED;
 import static io.netty.handler.codec.http.HttpHeaderValues.APPLICATION_JSON;
@@ -550,7 +551,7 @@ public class RpcClient {
    */
   private HttpException getJsonMappingErrorMessage(final String stringResponse) {
     try {
-      final JsonNode node = XyzSerializable.DEFAULT_MAPPER.get().readTree(stringResponse);
+      final JsonNode node = DEFAULT_MAPPER.get().readTree(stringResponse);
       if (node.has("errorMessage")) {
         final String errorMessage = node.get("errorMessage").asText();
         if (errorMessage.contains("Task timed out after ")) {

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/task/ModifyFeatureOp.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/task/ModifyFeatureOp.java
@@ -19,6 +19,7 @@
 
 package com.here.xyz.hub.task;
 
+import static com.here.xyz.XyzSerializable.Mappers.DEFAULT_MAPPER;
 import static com.here.xyz.hub.task.FeatureTask.FeatureKey.AUTHOR;
 import static com.here.xyz.hub.task.FeatureTask.FeatureKey.CREATED_AT;
 import static com.here.xyz.hub.task.FeatureTask.FeatureKey.PROPERTIES;
@@ -124,7 +125,7 @@ public class ModifyFeatureOp extends ModifyOp<Feature, FeatureEntry> {
       } catch (Exception e) {
         try {
           throw new HttpException(HttpResponseStatus.BAD_REQUEST,
-              "Unable to create a Feature from the provided input: " + XyzSerializable.DEFAULT_MAPPER.get().writeValueAsString(map));
+              "Unable to create a Feature from the provided input: " + DEFAULT_MAPPER.get().writeValueAsString(map));
         } catch (JsonProcessingException jsonProcessingException) {
           throw new HttpException(HttpResponseStatus.BAD_REQUEST,
               "Unable to create a Feature from the provided input. id: " + map.get("id") + ",type: " + map.get("type"));

--- a/xyz-models/src/main/java/com/here/xyz/LazyParsable.java
+++ b/xyz-models/src/main/java/com/here/xyz/LazyParsable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2017-2023 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@
 
 package com.here.xyz;
 
+
+import static com.here.xyz.XyzSerializable.Mappers.DEFAULT_MAPPER;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonCreator.Mode;
@@ -59,7 +61,7 @@ public class LazyParsable<T> {
   public T get() throws JsonProcessingException {
     if (valueString != null) {
       //TODO: Make generic
-      value = (T) XyzSerializable.DEFAULT_MAPPER.get().readValue(valueString, FEATURE_LIST);
+      value = (T) DEFAULT_MAPPER.get().readValue(valueString, FEATURE_LIST);
       valueString = null;
     }
     return value;

--- a/xyz-models/src/main/java/com/here/xyz/Payload.java
+++ b/xyz-models/src/main/java/com/here/xyz/Payload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2021 HERE Europe B.V.
+ * Copyright (C) 2017-2023 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@
  */
 
 package com.here.xyz;
+
+import static com.here.xyz.XyzSerializable.Mappers.SORTED_MAPPER;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSubTypes;

--- a/xyz-models/src/main/java/com/here/xyz/XyzSerializable.java
+++ b/xyz-models/src/main/java/com/here/xyz/XyzSerializable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2021 HERE Europe B.V.
+ * Copyright (C) 2017-2023 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@
 
 package com.here.xyz;
 
+import static com.here.xyz.XyzSerializable.Mappers.DEFAULT_MAPPER;
 import static com.here.xyz.responses.XyzError.EXCEPTION;
 import static com.here.xyz.responses.XyzError.TIMEOUT;
 
@@ -32,18 +33,51 @@ import com.here.xyz.models.hub.Space.Static;
 import com.here.xyz.responses.ErrorResponse;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Scanner;
+import java.util.WeakHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import org.apache.commons.lang3.StringUtils;
 
 public interface XyzSerializable {
 
-  ThreadLocal<ObjectMapper> DEFAULT_MAPPER = ThreadLocal.withInitial(() -> new ObjectMapper().setSerializationInclusion(Include.NON_NULL));
-  ThreadLocal<ObjectMapper> SORTED_MAPPER = ThreadLocal.withInitial(() ->
-      new ObjectMapper().configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true).setSerializationInclusion(Include.NON_NULL));
-  ThreadLocal<ObjectMapper> STATIC_MAPPER = ThreadLocal.withInitial(() -> new ObjectMapper().setConfig(
-      DEFAULT_MAPPER.get().getSerializationConfig().withView(Static.class)));
+  class Mappers {
+    private static final Collection<Class<?>> REGISTERED_SUBTYPES = new ConcurrentLinkedQueue<>();
+
+    private static final Collection<ObjectMapper> ALL_MAPPERS = Collections.newSetFromMap(Collections.synchronizedMap(new WeakHashMap<>()));
+    private static ObjectMapper registerNewMapper(ObjectMapper om) {
+      ALL_MAPPERS.add(om);
+      om.registerSubtypes(REGISTERED_SUBTYPES.toArray(Class<?>[]::new));
+      return om;
+    }
+
+    private static void registerSubtypes(Class<?>... classes) {
+      //Add the new subtypes to the list of registered subtypes so that they will be registered on new ObjectMappers
+      REGISTERED_SUBTYPES.addAll(Arrays.asList(classes));
+      //Register the new subtypes on all existing mappers
+      ALL_MAPPERS.forEach(om -> om.registerSubtypes(classes));
+    }
+    public static final ThreadLocal<ObjectMapper> DEFAULT_MAPPER = ThreadLocal.withInitial(
+        () -> registerNewMapper(new ObjectMapper().setSerializationInclusion(Include.NON_NULL)));
+    public static final ThreadLocal<ObjectMapper> STATIC_MAPPER = ThreadLocal.withInitial(
+        () -> registerNewMapper(new ObjectMapper().setConfig(DEFAULT_MAPPER.get().getSerializationConfig().withView(Static.class))));
+    public static final ThreadLocal<ObjectMapper> SORTED_MAPPER = ThreadLocal.withInitial(
+        () -> registerNewMapper(new ObjectMapper().configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true)
+            .setSerializationInclusion(Include.NON_NULL)));
+  }
+
+  /**
+   * Can be used to register additional subtypes at runtime for types which will be deserialized polymorphically.
+   * The subtypes will be registered on all newly created {@link ObjectMapper}s as well as on all existing ones immediately.
+   * @param classes The classes to register for deserialization purposes
+   */
+  static void registerSubtypes(Class<?>... classes) {
+    Mappers.registerSubtypes(classes);
+  }
 
   @SuppressWarnings("unused")
   static <T extends Typed> String serialize(T object) {


### PR DESCRIPTION
- Introduce new general "DatasetDescription" of which the sub-types can be used to define source- / target-definitions of a job more generically to make configurationes more extensible
- Introduce DatasetDescription stubs for following types so far: Files, Map, Space
- Move all chainable with-setters from sub-classes of Job to parent level to reduce code-duplication
- Enhance XyzSerializable to support registering new sub-types during run-time for polimorphic deserialization. That will support registering sub-types which are dependency-injected