### PR TITLE
Simplify / remove redundant code for export of composite extension

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/httpconnector/util/jobs/Export.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/httpconnector/util/jobs/Export.java
@@ -34,7 +34,6 @@ import static com.here.xyz.httpconnector.util.scheduler.JobQueue.updateJobStatus
 import static com.here.xyz.hub.rest.ApiParam.Query.Incremental.DEACTIVATED;
 import static com.here.xyz.hub.rest.ApiParam.Query.Incremental.FULL;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
-import static io.netty.handler.codec.http.HttpResponseStatus.NOT_IMPLEMENTED;
 import static io.netty.handler.codec.http.HttpResponseStatus.PRECONDITION_FAILED;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -280,12 +279,8 @@ public class Export extends Job<Export> {
             .compose(job -> {
                 Incremental incremental = Incremental.of((String) getParam("incremental"));
                 if (incremental != null && incremental != DEACTIVATED) {
-
-	            switch( getCsvFormat() )
-        	    { case TILEID_FC_B64: case PARTITIONID_FC_B64 : break;
-	              default :  return Future.failedFuture(new HttpException(BAD_REQUEST, "CSV format is not supported!"));
-        	    }
-
+                    if (getCsvFormat() != TILEID_FC_B64 && getCsvFormat() != PARTITIONID_FC_B64)
+                        return Future.failedFuture(new HttpException(BAD_REQUEST, "CSV format is not supported!"));
                     if (getExportTarget().getType() == DOWNLOAD)
                         return Future.failedFuture(new HttpException(HttpResponseStatus.BAD_REQUEST,
                             "Incremental Export is not available for Type Download!"));

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/task/FeatureTaskHandler.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/task/FeatureTaskHandler.java
@@ -811,7 +811,7 @@ public class FeatureTaskHandler {
           .compose(
               space -> {
                 if (space != null) {
-                  if (space.getExtension() != null && task.getEvent() instanceof ContextAwareEvent && SUPER.equals(((ContextAwareEvent<?>) task.getEvent()).getContext()))
+                  if (space.getExtension() != null && task.getEvent() instanceof ContextAwareEvent && SUPER == ((ContextAwareEvent<?>) task.getEvent()).getContext())
                     return switchToSuperSpace(task, space);
                   task.space = space;
                   //Inject the extension-map
@@ -848,6 +848,7 @@ public class FeatureTaskHandler {
     }
   }
 
+  //TODO: Remove the following hack and perform the switch to super within connector (GetFeatures QR) instead
   private static <X extends FeatureTask> Future<Space> switchToSuperSpace(X task, Space space) {
     //Overwrite the event's space ID to be the ID of the extended (super) space ...
     task.getEvent().setSpace(space.getExtension().getSpaceId());

--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/jobs/JobApiExportIT.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/jobs/JobApiExportIT.java
@@ -18,7 +18,13 @@
  */
 package com.here.xyz.hub.rest.jobs;
 
-import com.here.xyz.events.ContextAwareEvent;
+import static com.here.xyz.events.ContextAwareEvent.SpaceContext.EXTENSION;
+import static com.here.xyz.events.ContextAwareEvent.SpaceContext.SUPER;
+import static com.here.xyz.httpconnector.util.jobs.Export.ExportTarget.Type.DOWNLOAD;
+import static com.here.xyz.httpconnector.util.jobs.Job.CSVFormat.GEOJSON;
+import static com.here.xyz.httpconnector.util.jobs.Job.Status.failed;
+import static com.here.xyz.httpconnector.util.jobs.Job.Status.finalized;
+
 import com.here.xyz.httpconnector.util.jobs.Export;
 import com.here.xyz.httpconnector.util.jobs.Job;
 import com.here.xyz.models.geojson.coordinates.PointCoordinates;
@@ -53,8 +59,8 @@ public class JobApiExportIT extends JobApiIT {
     @Test
     public void testFullWKBExport() throws Exception {
         /** Create job */
-        Export job = buildTestJob(testExportJobId, null, new Export.ExportTarget().withType(Export.ExportTarget.Type.DOWNLOAD), Job.CSVFormat.JSON_WKB);
-        List<URL> urls = performExport(job, getScopedSpaceId(testSpaceId2, scope), Job.Status.finalized, Job.Status.failed);
+        Export job = buildTestJob(testExportJobId, null, new Export.ExportTarget().withType(DOWNLOAD), Job.CSVFormat.JSON_WKB);
+        List<URL> urls = performExport(job, getScopedSpaceId(testSpaceId2, scope), finalized, failed);
 
         List<String> mustContain = Arrays.asList(
             "01020000A0E61000000300000041C17BFDFF662140E08442041C14494000000000000000006BDE27FD732F21406C5CFFAECF0A49400000000000000000A9B7ABFCD7162140A96A82A8FB0E49400000000000000000",
@@ -78,10 +84,10 @@ public class JobApiExportIT extends JobApiIT {
                 .withRadius(5500);
 
         Export.Filters filters = new Export.Filters().withSpatialFilter(spatialFilter);
-        Export.ExportTarget exportTarget = new Export.ExportTarget().withType(Export.ExportTarget.Type.DOWNLOAD);
+        Export.ExportTarget exportTarget = new Export.ExportTarget().withType(DOWNLOAD);
 
         Export job = buildTestJob(testExportJobId, filters, exportTarget, Job.CSVFormat.JSON_WKB);
-        List<URL> urls = performExport(job, getScopedSpaceId(testSpaceId2, scope), Job.Status.finalized, Job.Status.failed);
+        List<URL> urls = performExport(job, getScopedSpaceId(testSpaceId2, scope), finalized, failed);
 
         List<String> mustContain = Arrays.asList(
             "foo_polygon",
@@ -99,10 +105,10 @@ public class JobApiExportIT extends JobApiIT {
                 .withRadius(5500);
 
         Export.Filters filters = new Export.Filters().withSpatialFilter(spatialFilter);
-        Export.ExportTarget exportTarget = new Export.ExportTarget().withType(Export.ExportTarget.Type.DOWNLOAD);
+        Export.ExportTarget exportTarget = new Export.ExportTarget().withType(DOWNLOAD);
 
         Export job = buildTestJob(testExportJobId, filters, exportTarget, Job.CSVFormat.JSON_WKB);
-        List<URL> urls = performExport(job, getScopedSpaceId(testSpaceId2, scope), Job.Status.finalized, Job.Status.failed);
+        List<URL> urls = performExport(job, getScopedSpaceId(testSpaceId2, scope), finalized, failed);
 
         List<String> mustContain = Arrays.asList(
             "foo_polygon",
@@ -118,10 +124,10 @@ public class JobApiExportIT extends JobApiIT {
 
         Export.Filters filters = new Export.Filters()
                 .withPropertyFilter(propertyFilter);
-        Export.ExportTarget exportTarget = new Export.ExportTarget().withType(Export.ExportTarget.Type.DOWNLOAD);
+        Export.ExportTarget exportTarget = new Export.ExportTarget().withType(DOWNLOAD);
 
         Export job = buildTestJob(testExportJobId, filters, exportTarget, Job.CSVFormat.JSON_WKB);
-        List<URL> urls = performExport(job, getScopedSpaceId(testSpaceId2, scope), Job.Status.finalized, Job.Status.failed);
+        List<URL> urls = performExport(job, getScopedSpaceId(testSpaceId2, scope), finalized, failed);
 
         List<String> mustContain = Arrays.asList(
             "onPropertyLevel",
@@ -142,10 +148,10 @@ public class JobApiExportIT extends JobApiIT {
         Export.Filters filters = new Export.Filters()
                 .withSpatialFilter(spatialFilter)
                 .withPropertyFilter(propertyFilter);
-        Export.ExportTarget exportTarget = new Export.ExportTarget().withType(Export.ExportTarget.Type.DOWNLOAD);
+        Export.ExportTarget exportTarget = new Export.ExportTarget().withType(DOWNLOAD);
 
         Export job = buildTestJob(testExportJobId, filters, exportTarget, Job.CSVFormat.JSON_WKB);
-        List<URL> urls = performExport(job, getScopedSpaceId(testSpaceId2, scope), Job.Status.finalized, Job.Status.failed);
+        List<URL> urls = performExport(job, getScopedSpaceId(testSpaceId2, scope), finalized, failed);
 
         List<String> mustContain = Arrays.asList(
             "Point",
@@ -163,8 +169,8 @@ public class JobApiExportIT extends JobApiIT {
     @Test
     public void testFullGEOJSONExport() throws Exception {
         /** Create job */
-        Export job = buildTestJob(testExportJobId, null, new Export.ExportTarget().withType(Export.ExportTarget.Type.DOWNLOAD), Job.CSVFormat.GEOJSON);
-        List<URL> urls = performExport(job, getScopedSpaceId(testSpaceId2, scope), Job.Status.finalized, Job.Status.failed);
+        Export job = buildTestJob(testExportJobId, null, new Export.ExportTarget().withType(DOWNLOAD), GEOJSON);
+        List<URL> urls = performExport(job, getScopedSpaceId(testSpaceId2, scope), finalized, failed);
 
         List<String> mustContain = Arrays.asList(
             "MultiPolygon",
@@ -185,8 +191,8 @@ public class JobApiExportIT extends JobApiIT {
     @Test
     public void testFullGEOJSONCompositeL1Export() throws Exception {
         /** Create job */
-        Export job = buildTestJob(testExportJobId, null, new Export.ExportTarget().withType(Export.ExportTarget.Type.DOWNLOAD), Job.CSVFormat.GEOJSON);
-        List<URL> urls = performExport(job, getScopedSpaceId(testSpaceId2Ext, scope), Job.Status.finalized, Job.Status.failed);
+        Export job = buildTestJob(testExportJobId, null, new Export.ExportTarget().withType(DOWNLOAD), GEOJSON);
+        List<URL> urls = performExport(job, getScopedSpaceId(testSpaceId2Ext, scope), finalized, failed);
 
         List<String> mustContain = Arrays.asList(
             "MultiPolygon",
@@ -209,9 +215,8 @@ public class JobApiExportIT extends JobApiIT {
      * */
     @Test
     public void testFullGEOJSONCompositeL1SuperExport() throws Exception {
-        /** Create job */
-        Export job = buildTestJob(testExportJobId, null, new Export.ExportTarget().withType(Export.ExportTarget.Type.DOWNLOAD), Job.CSVFormat.GEOJSON);
-        List<URL> urls = performExport(job, getScopedSpaceId(testSpaceId2Ext, scope), Job.Status.finalized, Job.Status.failed, ContextAwareEvent.SpaceContext.SUPER, null);
+        Export job = buildTestJob(testExportJobId, null, new Export.ExportTarget().withType(DOWNLOAD), GEOJSON);
+        List<URL> urls = performExport(job, getScopedSpaceId(testSpaceId2Ext, scope), finalized, failed, SUPER);
 
         List<String> mustContain = Arrays.asList(
             "MultiPolygon",
@@ -232,9 +237,8 @@ public class JobApiExportIT extends JobApiIT {
      * */
     @Test
     public void testFullGEOJSONCompositeL1ExtensionExport() throws Exception {
-        /** Create job */
-        Export job = buildTestJob(testExportJobId, null, new Export.ExportTarget().withType(Export.ExportTarget.Type.DOWNLOAD), Job.CSVFormat.GEOJSON);
-        List<URL> urls = performExport(job, getScopedSpaceId(testSpaceId2Ext, scope), Job.Status.finalized, Job.Status.failed, ContextAwareEvent.SpaceContext.EXTENSION, null);
+        Export job = buildTestJob(testExportJobId, null, new Export.ExportTarget().withType(DOWNLOAD), GEOJSON);
+        List<URL> urls = performExport(job, getScopedSpaceId(testSpaceId2Ext, scope), finalized, failed, EXTENSION);
 
         List<String> mustContain = Arrays.asList(
             "Point",
@@ -254,8 +258,8 @@ public class JobApiExportIT extends JobApiIT {
                 .withRadius(550000);
         Export.Filters filters = new Export.Filters().withSpatialFilter(spatialFilter);
 
-        Export job = buildTestJob(testExportJobId, filters, new Export.ExportTarget().withType(Export.ExportTarget.Type.DOWNLOAD), Job.CSVFormat.GEOJSON);
-        List<URL> urls = performExport(job, getScopedSpaceId(testSpaceId2Ext, scope), Job.Status.finalized, Job.Status.failed);
+        Export job = buildTestJob(testExportJobId, filters, new Export.ExportTarget().withType(DOWNLOAD), GEOJSON);
+        List<URL> urls = performExport(job, getScopedSpaceId(testSpaceId2Ext, scope), finalized, failed);
 
         List<String> mustContain = Arrays.asList(
             "MultiPolygon",
@@ -278,8 +282,8 @@ public class JobApiExportIT extends JobApiIT {
                 .withSpatialFilter(spatialFilter)
                 .withPropertyFilter(propertyFilter);
 
-        Export job = buildTestJob(testExportJobId, filters, new Export.ExportTarget().withType(Export.ExportTarget.Type.DOWNLOAD), Job.CSVFormat.GEOJSON);
-        List<URL> urls= performExport(job, getScopedSpaceId(testSpaceId2Ext, scope), Job.Status.finalized, Job.Status.failed);
+        Export job = buildTestJob(testExportJobId, filters, new Export.ExportTarget().withType(DOWNLOAD), GEOJSON);
+        List<URL> urls= performExport(job, getScopedSpaceId(testSpaceId2Ext, scope), finalized, failed);
 
         List<String> mustContain = Arrays.asList(
             getScopedSpaceId(testSpaceId2Ext, scope),
@@ -300,8 +304,8 @@ public class JobApiExportIT extends JobApiIT {
                 .withSpatialFilter(spatialFilter);
 
         /** Create job */
-        Export job = buildTestJob(testExportJobId, filters, new Export.ExportTarget().withType(Export.ExportTarget.Type.DOWNLOAD), Job.CSVFormat.GEOJSON);
-        List<URL> urls = performExport(job, getScopedSpaceId(testSpaceId2ExtExt, scope), Job.Status.finalized, Job.Status.failed);
+        Export job = buildTestJob(testExportJobId, filters, new Export.ExportTarget().withType(DOWNLOAD), GEOJSON);
+        List<URL> urls = performExport(job, getScopedSpaceId(testSpaceId2ExtExt, scope), finalized, failed);
 
         List<String> mustContain = Arrays.asList(
             "MultiPolygon",
@@ -316,8 +320,8 @@ public class JobApiExportIT extends JobApiIT {
     @Test
     public void testFullGEOJSONCompositeL2Export() throws Exception {
         /** Create job */
-        Export job = buildTestJob(testExportJobId, null, new Export.ExportTarget().withType(Export.ExportTarget.Type.DOWNLOAD), Job.CSVFormat.GEOJSON);
-        List<URL> urls = performExport(job, getScopedSpaceId(testSpaceId2ExtExt, scope), Job.Status.finalized, Job.Status.failed);
+        Export job = buildTestJob(testExportJobId, null, new Export.ExportTarget().withType(DOWNLOAD), GEOJSON);
+        List<URL> urls = performExport(job, getScopedSpaceId(testSpaceId2ExtExt, scope), finalized, failed);
 
         List<String> mustContain = Arrays.asList(
             "MultiPolygon",
@@ -335,9 +339,8 @@ public class JobApiExportIT extends JobApiIT {
 
     @Test
     public void testFullGEOJSONCompositeL2SuperExport() throws Exception {
-        /** Create job */
-        Export job = buildTestJob(testExportJobId, null, new Export.ExportTarget().withType(Export.ExportTarget.Type.DOWNLOAD), Job.CSVFormat.GEOJSON);
-        List<URL> urls = performExport(job, getScopedSpaceId(testSpaceId2ExtExt, scope), Job.Status.finalized, Job.Status.failed, ContextAwareEvent.SpaceContext.SUPER, null);
+        Export job = buildTestJob(testExportJobId, null, new Export.ExportTarget().withType(DOWNLOAD), GEOJSON);
+        List<URL> urls = performExport(job, getScopedSpaceId(testSpaceId2ExtExt, scope), finalized, failed, SUPER);
 
         List<String> mustContain = Arrays.asList(
             "MultiPolygon",
@@ -369,7 +372,7 @@ public class JobApiExportIT extends JobApiIT {
 
         Export job =  buildVMTestJob(testExportJobId, null, exportTarget, Job.CSVFormat.TILEID_FC_B64, targetLevel, maxTilesPerFile);
         /** VML Trigger cant get tested here - so its okay that the job will fail in Triggerstate */
-        List<URL> urls = performExport(job, getScopedSpaceId(testSpaceId2, scope), Job.Status.failed, Job.Status.finalized);
+        List<URL> urls = performExport(job, getScopedSpaceId(testSpaceId2, scope), failed, finalized);
 
         List<String> mustContain = Arrays.asList("360", "eyJ0eXBlIjogIkZl");
 
@@ -393,7 +396,7 @@ public class JobApiExportIT extends JobApiIT {
 
         Export job =  buildVMTestJob(testExportJobId, null, exportTarget, Job.CSVFormat.TILEID_FC_B64, targetLevel, maxTilesPerFile);
         /** VML Trigger cant get tested here - so its okay that the job will fail in Triggerstate */
-        List<URL> urls = performExport(job, getScopedSpaceId(testSpaceId2, scope), Job.Status.failed, Job.Status.finalized);
+        List<URL> urls = performExport(job, getScopedSpaceId(testSpaceId2, scope), failed, finalized);
 
         List<String> mustContain = Arrays.asList("23600780", "23600794", "W9uIiwgImZlYXR1cmV");
 
@@ -423,7 +426,7 @@ public class JobApiExportIT extends JobApiIT {
 
         Export.Filters filters = new Export.Filters().withSpatialFilter(spatialFilter);
         Export job =  buildVMTestJob(testExportJobId, filters, exportTarget, Job.CSVFormat.TILEID_FC_B64, targetLevel, maxTilesPerFile);
-        List<URL> urls = performExport(job, getScopedSpaceId(testSpaceId2,scope), Job.Status.failed, Job.Status.finalized);
+        List<URL> urls = performExport(job, getScopedSpaceId(testSpaceId2,scope), failed, finalized);
 
         List<String> mustContain = Arrays.asList("360", "eyJ0eXBlIjogIkZlYXR1cmVDb2xsZWN0aW9uIiwg");
 
@@ -446,7 +449,7 @@ public class JobApiExportIT extends JobApiIT {
 
         Export.Filters filters = new Export.Filters().withSpatialFilter(spatialFilter);
         Export job =  buildVMTestJob(testExportJobId, filters, exportTarget, Job.CSVFormat.TILEID_FC_B64, targetLevel, maxTilesPerFile);
-        List<URL> urls = performExport(job, getScopedSpaceId(testSpaceId2, scope), Job.Status.failed, Job.Status.finalized);
+        List<URL> urls = performExport(job, getScopedSpaceId(testSpaceId2, scope), failed, finalized);
 
         List<String> mustContain = Arrays.asList("360", "VzIjpbeyJpZC");
 
@@ -466,7 +469,7 @@ public class JobApiExportIT extends JobApiIT {
                 .withPropertyFilter(propertyFilter);
 
         Export job =  buildVMTestJob(testExportJobId, filters, exportTarget, Job.CSVFormat.TILEID_FC_B64, targetLevel, maxTilesPerFile);
-        List<URL> urls = performExport(job, getScopedSpaceId(testSpaceId2, scope), Job.Status.failed, Job.Status.finalized);
+        List<URL> urls = performExport(job, getScopedSpaceId(testSpaceId2, scope), failed, finalized);
 
         List<String> mustContain = Arrays.asList("360", "Onh5eiI6IHsidGFncyI6IF");
 
@@ -492,7 +495,7 @@ public class JobApiExportIT extends JobApiIT {
                 .withPropertyFilter(propertyFilter);
 
         Export job =  buildVMTestJob(testExportJobId, filters, exportTarget, Job.CSVFormat.TILEID_FC_B64, targetLevel, maxTilesPerFile);
-        List<URL> urls = performExport(job, getScopedSpaceId(testSpaceId2,scope), Job.Status.failed, Job.Status.finalized);
+        List<URL> urls = performExport(job, getScopedSpaceId(testSpaceId2,scope), failed, finalized);
 
         List<String> mustContain = Arrays.asList("360", "aW9uIiwgImZlYXR");
 
@@ -514,7 +517,7 @@ public class JobApiExportIT extends JobApiIT {
 
         /** Create job */
         Export job =  buildVMTestJob(testExportJobId, null, exportTarget, Job.CSVFormat.TILEID_FC_B64, targetLevel, maxTilesPerFile);
-        List<URL> urls = performExport(job, getScopedSpaceId(testSpaceId2Ext, scope), Job.Status.failed, Job.Status.finalized);
+        List<URL> urls = performExport(job, getScopedSpaceId(testSpaceId2Ext, scope), failed, finalized);
 
         List<String> mustContain = Arrays.asList("280", "306", "IkZlYXR1cmU");
 
@@ -532,7 +535,7 @@ public class JobApiExportIT extends JobApiIT {
 
         /** Create job */
         Export job =  buildVMTestJob(testExportJobId, null, exportTarget, Job.CSVFormat.TILEID_FC_B64, targetLevel, maxTilesPerFile);
-        List<URL> urls = performExport(job, getScopedSpaceId(testSpaceId2ExtExt, scope), Job.Status.failed, Job.Status.finalized);
+        List<URL> urls = performExport(job, getScopedSpaceId(testSpaceId2ExtExt, scope), failed, finalized);
 
         List<String> mustContain = Arrays.asList("374", "352", "HVyZSIsICJnZW9", "374");
 
@@ -555,7 +558,7 @@ public class JobApiExportIT extends JobApiIT {
         Export.Filters filters = new Export.Filters().withSpatialFilter(spatialFilter);
 
         Export job =  buildVMTestJob(testExportJobId, filters, exportTarget, Job.CSVFormat.TILEID_FC_B64, targetLevel, maxTilesPerFile);
-        List<URL> urls = performExport(job, getScopedSpaceId(testSpaceId2Ext,scope), Job.Status.failed, Job.Status.finalized);
+        List<URL> urls = performExport(job, getScopedSpaceId(testSpaceId2Ext,scope), failed, finalized);
 
         List<String> mustContain = Arrays.asList("360", "RyeSI6IHsidHlwZSI6I");
 
@@ -581,7 +584,7 @@ public class JobApiExportIT extends JobApiIT {
                 .withPropertyFilter(propertyFilter);
 
         Export job =  buildVMTestJob(testExportJobId, filters, exportTarget, Job.CSVFormat.TILEID_FC_B64, targetLevel, maxTilesPerFile);
-        List<URL> urls = performExport(job, getScopedSpaceId(testSpaceId2Ext, scope), Job.Status.failed, Job.Status.finalized);
+        List<URL> urls = performExport(job, getScopedSpaceId(testSpaceId2Ext, scope), failed, finalized);
 
         List<String> mustContain = Arrays.asList("360", "ZXMiOiBbOC42MTk5NjE1");
 
@@ -606,7 +609,7 @@ public class JobApiExportIT extends JobApiIT {
 
         /** Create job */
         Export job =  buildVMTestJob(testExportJobId, filters, exportTarget, Job.CSVFormat.TILEID_FC_B64, targetLevel, maxTilesPerFile);
-        List<URL> urls = performExport(job, getScopedSpaceId(testSpaceId2ExtExt, scope), Job.Status.failed, Job.Status.finalized);
+        List<URL> urls = performExport(job, getScopedSpaceId(testSpaceId2ExtExt, scope), failed, finalized);
 
         List<String> mustContain = Arrays.asList(
             "360",
@@ -623,8 +626,8 @@ public class JobApiExportIT extends JobApiIT {
         String spaceId = "test-space";
         deleteAllJobsOnSpace(spaceId);
 
-        Export job = buildTestJob(testExportJobId, null, new Export.ExportTarget().withType(Export.ExportTarget.Type.DOWNLOAD), Job.CSVFormat.JSON_WKB);
-        List<URL> urls =  performExport(job, spaceId, Job.Status.finalized, Job.Status.failed);
+        Export job = buildTestJob(testExportJobId, null, new Export.ExportTarget().withType(DOWNLOAD), Job.CSVFormat.JSON_WKB);
+        List<URL> urls =  performExport(job, spaceId, finalized, failed);
         System.out.println(urls.size());
     }
 
@@ -644,7 +647,7 @@ public class JobApiExportIT extends JobApiIT {
         deleteAllJobsOnSpace(spaceId);
         Export job =  buildVMTestJob(testExportJobId, null, exportTarget, Job.CSVFormat.TILEID_FC_B64, targetLevel, maxTilesPerFile);
 
-        List<URL> urls =  performExport(job, spaceId, Job.Status.failed, Job.Status.finalized);
+        List<URL> urls =  performExport(job, spaceId, failed, finalized);
         System.out.println(urls.size());
     }
 }

--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/jobs/JobApiIT.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/jobs/JobApiIT.java
@@ -402,6 +402,16 @@ public class JobApiIT extends TestSpaceWithFeature {
         return performExport(job, spaceId, expectedStatus, failStatus, null, null);
     }
 
+    protected List<URL> performExport(Export job, String spaceId, Status expectedStatus, Status failStatus, Incremental incremental)
+        throws Exception {
+        return performExport(job, spaceId, expectedStatus, failStatus, null, incremental);
+    }
+
+    protected List<URL> performExport(Export job, String spaceId, Status expectedStatus, Status failStatus, SpaceContext context)
+        throws Exception {
+        return performExport(job, spaceId, expectedStatus, failStatus, context, null);
+    }
+
     protected List<URL> performExport(Export job, String spaceId, Status expectedStatus, Status failStatus, SpaceContext context,
         Incremental incremental) throws Exception {
         if (incremental != null)

--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/jobs/JobApiIncrementalCompositeExportIT.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/jobs/JobApiIncrementalCompositeExportIT.java
@@ -18,12 +18,12 @@
  */
 package com.here.xyz.hub.rest.jobs;
 
-import static com.here.xyz.events.ContextAwareEvent.SpaceContext.DEFAULT;
 import static com.here.xyz.httpconnector.util.jobs.Export.ExportTarget.Type.DOWNLOAD;
 import static com.here.xyz.httpconnector.util.jobs.Job.CSVFormat.GEOJSON;
 import static com.here.xyz.httpconnector.util.jobs.Job.Status.failed;
 import static com.here.xyz.httpconnector.util.jobs.Job.Status.finalized;
 import static com.here.xyz.hub.rest.ApiParam.Query.Incremental.CHANGES;
+import static com.here.xyz.hub.rest.ApiParam.Query.Incremental.DEACTIVATED;
 import static com.here.xyz.hub.rest.ApiParam.Query.Incremental.FULL;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.PRECONDITION_FAILED;
@@ -31,7 +31,6 @@ import static org.junit.Assert.assertEquals;
 
 import com.here.xyz.httpconnector.util.jobs.Export;
 import com.here.xyz.httpconnector.util.jobs.Job;
-import com.here.xyz.hub.rest.ApiParam;
 import com.here.xyz.hub.rest.HttpException;
 import com.here.xyz.hub.rest.TestSpaceWithFeature;
 import com.here.xyz.hub.rest.TestWithSpaceCleanup;
@@ -122,7 +121,7 @@ public class JobApiIncrementalCompositeExportIT extends JobApiIT{
         Export job = buildTestJob(testExportJobId, null, new Export.ExportTarget().withType(DOWNLOAD), GEOJSON);
         try {
             /** Invalid Type - creation fails */
-            performExport(job, testSpaceId1Ext, failed, finalized, DEFAULT, FULL);
+            performExport(job, testSpaceId1Ext, failed, finalized, FULL);
         }
         catch (HttpException e){
             assertEquals(BAD_REQUEST, e.status);
@@ -133,7 +132,7 @@ public class JobApiIncrementalCompositeExportIT extends JobApiIT{
         job = buildTestJob(testExportJobId, null, new Export.ExportTarget().withType(DOWNLOAD), GEOJSON);
         try {
             /** No extended layer - creation fails */
-            performExport(job, testSpaceId1, failed, finalized, DEFAULT, CHANGES);
+            performExport(job, testSpaceId1, failed, finalized, CHANGES);
         }catch (HttpException e){
             assertEquals(BAD_REQUEST, e.status);
             exceptionCnt++;
@@ -147,16 +146,18 @@ public class JobApiIncrementalCompositeExportIT extends JobApiIT{
     public void missingPersistentBaseExport() throws Exception{
         Export job =  generateExportJob(testExportJobId, 4);
         try {
-            performExport(job, testSpaceId1Ext, failed, finalized, DEFAULT, FULL);
-        }catch (HttpException e){
+            performExport(job, testSpaceId1Ext, failed, finalized, FULL);
+        }
+        catch (HttpException e){
             assertEquals(PRECONDITION_FAILED, e.status);
         }
 
         deleteJob(job.getId(), testSpaceId1Ext, true);
         job =  generateExportJob(testExportJobId, 4);
         try {
-            performExport(job, testSpaceId1ExtExt, failed, finalized, DEFAULT, FULL);
-        }catch (HttpException e){
+            performExport(job, testSpaceId1ExtExt, failed, finalized, FULL);
+        }
+        catch (HttpException e){
             assertEquals(PRECONDITION_FAILED, e.status);
         }
     }
@@ -166,14 +167,15 @@ public class JobApiIncrementalCompositeExportIT extends JobApiIT{
         Export job =  generateExportJob(testExportJobId, 4);
 
         /** Initial Base Export on testSpaceId1 */
-        performExport(job, testSpaceId1, failed, finalized, DEFAULT, ApiParam.Query.Incremental.DEACTIVATED);
+        performExport(job, testSpaceId1, failed, finalized, DEACTIVATED);
         deleteAllJobsOnSpace(testSpaceId1);
 
         job =  generateExportJob(testExportJobId, 8);
         /** Incremental Export on testSpaceId1Ext - Base layer got exported on level 4 now we want an incremental export on another level */
         try {
-            performExport(job, testSpaceId1Ext, failed, finalized, DEFAULT, FULL);
-        }catch (HttpException e){
+            performExport(job, testSpaceId1Ext, failed, finalized, FULL);
+        }
+        catch (HttpException e){
             assertEquals(PRECONDITION_FAILED, e.status);
         }
     }
@@ -183,12 +185,12 @@ public class JobApiIncrementalCompositeExportIT extends JobApiIT{
         Export job =  generateExportJob(testExportJobId, 6);
 
         /** Initial Base Export */
-        List<URL> urls = performExport(job, testSpaceId1, failed, finalized, DEFAULT, ApiParam.Query.Incremental.DEACTIVATED);
+        List<URL> urls = performExport(job, testSpaceId1, failed, finalized, DEACTIVATED);
         assertEquals(1, urls.size());
 
         /** Incremental Export */
         job =  generateExportJob(testExportJobId+"_2", 6);
-        urls = performExport(job, testSpaceId1Ext, failed, finalized, DEFAULT, FULL);
+        urls = performExport(job, testSpaceId1Ext, failed, finalized, FULL);
         /** Expect 3 files from persistent super layer + 3 files from composite compound */
         assertEquals(2, urls.size());
 
@@ -212,7 +214,7 @@ public class JobApiIncrementalCompositeExportIT extends JobApiIT{
         Export job =  generateExportJob(testExportJobId, 6);
 
         /** Initial Base Export */
-        List<URL> urls = performExport(job, testSpaceId1, failed, finalized, DEFAULT, ApiParam.Query.Incremental.DEACTIVATED);
+        List<URL> urls = performExport(job, testSpaceId1, failed, finalized, DEACTIVATED);
         assertEquals(1, urls.size());
 
         List<String> mustContain = Arrays.asList(
@@ -230,7 +232,7 @@ public class JobApiIncrementalCompositeExportIT extends JobApiIT{
 
         /** Incremental Export */
         job =  generateExportJob(testExportJobId+"_2", 6);
-        urls = performExport(job, testSpaceId1Ext, failed, finalized, DEFAULT, CHANGES);
+        urls = performExport(job, testSpaceId1Ext, failed, finalized, CHANGES);
         /** Expect 1 file with base+delta */
         assertEquals(1, urls.size());
 
@@ -252,12 +254,12 @@ public class JobApiIncrementalCompositeExportIT extends JobApiIT{
         Export job =  generateExportJob(testExportJobId, 6);
 
         /** Initial Base Export */
-        List<URL> urls = performExport(job, testSpaceId1, failed, finalized, DEFAULT, ApiParam.Query.Incremental.DEACTIVATED);
+        List<URL> urls = performExport(job, testSpaceId1, failed, finalized, DEACTIVATED);
         assertEquals(1, urls.size());
 
         /** Incremental Export */
         job =  generateExportJob(testExportJobId+"_2", 6);
-        urls = performExport(job, testSpaceId1ExtExt, failed, finalized, DEFAULT, FULL);
+        urls = performExport(job, testSpaceId1ExtExt, failed, finalized, FULL);
         /** Expect 1 files from persistent super layer + 1 files from composite compound */
         assertEquals(2, urls.size());
 
@@ -281,13 +283,13 @@ public class JobApiIncrementalCompositeExportIT extends JobApiIT{
         Export job =  generateExportJob(testExportJobId, 6);
 
         /** Initial Base Export */
-        List<URL> urls = performExport(job, testSpaceId1, failed, finalized, DEFAULT, ApiParam.Query.Incremental.DEACTIVATED);
+        List<URL> urls = performExport(job, testSpaceId1, failed, finalized, DEACTIVATED);
         assertEquals(1, urls.size());
 
         /** Incremental Export */
         job =  generateExportJob(testExportJobId+"_2", 6);
 
-        urls = performExport(job, testSpaceId1ExtExt, failed, finalized, DEFAULT, CHANGES);
+        urls = performExport(job, testSpaceId1ExtExt, failed, finalized, CHANGES);
 
         assertEquals(1, urls.size());
 

--- a/xyz-models/src/main/java/com/here/xyz/events/ContextAwareEvent.java
+++ b/xyz-models/src/main/java/com/here/xyz/events/ContextAwareEvent.java
@@ -34,7 +34,8 @@ public abstract class ContextAwareEvent<T extends ContextAwareEvent> extends Eve
   public enum SpaceContext {
     EXTENSION,
     SUPER,
-    DEFAULT;
+    DEFAULT,
+    COMPOSITE_EXTENSION;
 
     public static SpaceContext of(String value) {
       if (value == null) {


### PR DESCRIPTION
NOTE: This is a follow up PR on https://github.com/heremaps/xyz-hub/pull/1035

- Introduce new space context COMPOSITE_EXTENSION which results in returning all features which have been added to the extension (changes) but in a composite way. That means the features will be merged with the state of the super space.
- Remove redundant implementation for ViewMode from GetFeatures QR as the Context can be used instead