### PR TITLE
Enable proper (de-)serialization and error handling for REST tier

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/httpconnector/task/JobHandler.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/httpconnector/task/JobHandler.java
@@ -24,7 +24,7 @@ import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.PRECONDITION_FAILED;
 
 import com.google.common.collect.ImmutableMap;
-import com.here.xyz.XyzSerializable.Mappers;
+import com.here.xyz.XyzSerializable;
 import com.here.xyz.httpconnector.CService;
 import com.here.xyz.httpconnector.config.JobConfigClient;
 import com.here.xyz.httpconnector.rest.HApiParam.HQuery.Command;
@@ -140,16 +140,16 @@ public class JobHandler {
 
   private static Map asMap(Object object) {
         try {
-            return Mappers.DEFAULT_MAPPER.get().convertValue(object, Map.class);
+            return XyzSerializable.toMap(object);
         }
         catch (Exception e) {
             return Collections.emptyMap();
         }
     }
 
-    private static Job asJob(Marker marker, Map object) throws HttpException {
+    private static Job asJob(Marker marker, Map map) throws HttpException {
         try {
-            return Mappers.DEFAULT_MAPPER.get().convertValue(object, Job.class);
+            return (Job) XyzSerializable.fromMap(map);
         }
         catch (Exception e) {
             logger.error(marker, "Could not convert resource.", e.getCause());

--- a/xyz-hub-service/src/main/java/com/here/xyz/httpconnector/util/jobs/Job.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/httpconnector/util/jobs/Job.java
@@ -32,12 +32,12 @@ import static io.netty.handler.codec.http.HttpResponseStatus.NOT_IMPLEMENTED;
 import static io.netty.handler.codec.http.HttpResponseStatus.PRECONDITION_FAILED;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonView;
+import com.here.xyz.Payload;
+import com.here.xyz.XyzSerializable;
 import com.here.xyz.httpconnector.CService;
 import com.here.xyz.httpconnector.config.JDBCClients;
 import com.here.xyz.httpconnector.config.JDBCImporter;
@@ -57,16 +57,13 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.MarkerManager.Log4jMarker;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
-        property = "type")
 @JsonSubTypes({
         @JsonSubTypes.Type(value = Import.class, name = "Import"),
         @JsonSubTypes.Type(value = Export.class, name = "Export"),
         @JsonSubTypes.Type(value = CombinedJob.class, name = "CombinedJob")
 })
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-public abstract class Job<T extends Job> {
+public abstract class Job<T extends Job> extends Payload {
     public static String ERROR_TYPE_VALIDATION_FAILED = "validation_failed";
     public static String ERROR_TYPE_PREPARATION_FAILED = "preparation_failed";
     public static String ERROR_TYPE_EXECUTION_FAILED = "execution_failed";
@@ -879,5 +876,9 @@ public abstract class Job<T extends Job> {
         ProcessingNotPossibleException() {
             super(PROCESSING_NOT_POSSIBLE);
         }
+    }
+
+    static {
+        XyzSerializable.registerSubtypes(Job.class);
     }
 }

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/auth/SpaceAuthorization.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/auth/SpaceAuthorization.java
@@ -31,6 +31,7 @@ import static com.here.xyz.hub.auth.XyzHubAttributeMap.SPACE;
 import static com.here.xyz.hub.auth.XyzHubAttributeMap.STORAGE;
 import static io.netty.handler.codec.http.HttpResponseStatus.FORBIDDEN;
 
+import com.here.xyz.XyzSerializable.Static;
 import com.here.xyz.hub.Service;
 import com.here.xyz.hub.connectors.models.Connector;
 import com.here.xyz.hub.connectors.models.Space;
@@ -44,7 +45,6 @@ import com.here.xyz.hub.task.TaskPipeline.Callback;
 import com.here.xyz.hub.util.diff.Difference;
 import com.here.xyz.hub.util.diff.Difference.DiffMap;
 import com.here.xyz.hub.util.diff.Patcher;
-import com.here.xyz.models.hub.Space.Static;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.jackson.DatabindCodec;

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/config/dynamo/DynamoSpaceConfigClient.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/config/dynamo/DynamoSpaceConfigClient.java
@@ -19,8 +19,6 @@
 
 package com.here.xyz.hub.config.dynamo;
 
-import static com.here.xyz.XyzSerializable.Mappers.STATIC_MAPPER;
-
 import com.amazonaws.handlers.AsyncHandler;
 import com.amazonaws.services.dynamodbv2.document.BatchGetItemOutcome;
 import com.amazonaws.services.dynamodbv2.document.Item;
@@ -37,7 +35,8 @@ import com.amazonaws.services.dynamodbv2.model.GetItemResult;
 import com.amazonaws.services.dynamodbv2.model.PutItemRequest;
 import com.amazonaws.services.dynamodbv2.model.PutItemResult;
 import com.amazonaws.util.CollectionUtils;
-import com.fasterxml.jackson.core.type.TypeReference;
+import com.here.xyz.XyzSerializable;
+import com.here.xyz.XyzSerializable.Static;
 import com.here.xyz.events.PropertiesQuery;
 import com.here.xyz.hub.Service;
 import com.here.xyz.hub.config.SpaceConfigClient;
@@ -164,7 +163,7 @@ public class DynamoSpaceConfigClient extends SpaceConfigClient {
   }
 
   private void storeSpaceSync(Space space, Promise<Void> p) {
-    final Map<String, Object> itemData = STATIC_MAPPER.get().convertValue(space, new TypeReference<Map<String, Object>>() {});
+    final Map<String, Object> itemData = XyzSerializable.toMap(space, Static.class);
     itemData.put("shared", space.isShared() ? 1 : 0); //Shared value must be a number because it's also used as index
     sanitize(itemData);
     spaces.putItem(Item.fromMap(itemData));

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/RpcClient.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/RpcClient.java
@@ -19,7 +19,6 @@
 
 package com.here.xyz.hub.connectors;
 
-import static com.here.xyz.XyzSerializable.Mappers.DEFAULT_MAPPER;
 import static com.here.xyz.events.GetFeaturesByTileEvent.ResponseType.MVT;
 import static com.here.xyz.events.GetFeaturesByTileEvent.ResponseType.MVT_FLATTENED;
 import static io.netty.handler.codec.http.HttpHeaderValues.APPLICATION_JSON;
@@ -34,7 +33,6 @@ import static io.netty.handler.codec.rtsp.RtspResponseStatuses.REQUEST_ENTITY_TO
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.exc.InvalidTypeIdException;
 import com.google.common.io.ByteStreams;
 import com.here.xyz.Payload;
@@ -551,12 +549,11 @@ public class RpcClient {
    */
   private HttpException getJsonMappingErrorMessage(final String stringResponse) {
     try {
-      final JsonNode node = DEFAULT_MAPPER.get().readTree(stringResponse);
-      if (node.has("errorMessage")) {
-        final String errorMessage = node.get("errorMessage").asText();
-        if (errorMessage.contains("Task timed out after ")) {
+      Map<String, Object> response = XyzSerializable.deserialize(stringResponse, Map.class);
+      if (response.containsKey("errorMessage")) {
+        final String errorMessage = response.get("errorMessage").toString();
+        if (errorMessage.contains("timed out"))
           return new HttpException(GATEWAY_TIMEOUT, "Connector timeout error.");
-        }
       }
     }
     catch (Exception e) {

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/models/Space.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/models/Space.java
@@ -26,6 +26,8 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonView;
 import com.google.common.primitives.Longs;
+import com.here.xyz.XyzSerializable.Public;
+import com.here.xyz.XyzSerializable.Static;
 import com.here.xyz.hub.Core;
 import com.here.xyz.hub.Service;
 import io.vertx.core.AsyncResult;
@@ -136,7 +138,7 @@ public class Space extends com.here.xyz.models.hub.Space implements Cloneable {
     if (getExtension() == null)
       return Collections.emptyMap();
     //Storage params are taken from the input and then resolved based on the extensions
-    final Map<String, Object> extendsMap = getExtension().asMap();
+    final Map<String, Object> extendsMap = getExtension().toMap();
 
     //TODO: Remove this once Job-API was fixed to configure that on job-level
     if (extendedSpace.isPersistExport())
@@ -145,7 +147,7 @@ public class Space extends com.here.xyz.models.hub.Space implements Cloneable {
     //Check if the extended space itself is extending some other space (2-level extension)
     if (extendedSpace != null && extendedSpace.getExtension() != null)
       //Get the extension definition from the extended space and add it to this one additionally
-      extendsMap.put("extends", extendedSpace.getExtension().asMap());
+      extendsMap.put("extends", extendedSpace.getExtension().toMap());
     return Collections.singletonMap("extends", extendsMap);
   }
 

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/task/ModifyFeatureOp.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/task/ModifyFeatureOp.java
@@ -19,7 +19,6 @@
 
 package com.here.xyz.hub.task;
 
-import static com.here.xyz.XyzSerializable.Mappers.DEFAULT_MAPPER;
 import static com.here.xyz.hub.task.FeatureTask.FeatureKey.AUTHOR;
 import static com.here.xyz.hub.task.FeatureTask.FeatureKey.CREATED_AT;
 import static com.here.xyz.hub.task.FeatureTask.FeatureKey.PROPERTIES;
@@ -27,7 +26,6 @@ import static com.here.xyz.hub.task.FeatureTask.FeatureKey.SPACE;
 import static com.here.xyz.hub.task.FeatureTask.FeatureKey.UPDATED_AT;
 import static com.here.xyz.hub.task.FeatureTask.FeatureKey.VERSION;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.here.xyz.XyzSerializable;
 import com.here.xyz.hub.rest.HttpException;
 import com.here.xyz.hub.task.ModifyFeatureOp.FeatureEntry;
@@ -125,17 +123,18 @@ public class ModifyFeatureOp extends ModifyOp<Feature, FeatureEntry> {
       } catch (Exception e) {
         try {
           throw new HttpException(HttpResponseStatus.BAD_REQUEST,
-              "Unable to create a Feature from the provided input: " + DEFAULT_MAPPER.get().writeValueAsString(map));
-        } catch (JsonProcessingException jsonProcessingException) {
+              "Unable to create a Feature from the provided input: " + XyzSerializable.serialize(map));
+        }
+        catch (Exception jsonProcessingException) {
           throw new HttpException(HttpResponseStatus.BAD_REQUEST,
-              "Unable to create a Feature from the provided input. id: " + map.get("id") + ",type: " + map.get("type"));
+              "Unable to create a Feature from the provided input. id: " + map.get("id") + ", type: " + map.get("type"));
         }
       }
     }
 
     @Override
     public Map<String, Object> toMap(Feature record) throws ModifyOpError, HttpException {
-      return filterMetadata(record.asMap());
+      return filterMetadata(record.toMap());
     }
 
     @Override

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/util/geo/MapBoxVectorTileBuilder.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/util/geo/MapBoxVectorTileBuilder.java
@@ -95,7 +95,7 @@ public class MapBoxVectorTileBuilder extends MvtTileBuilder {
 
     addProperty("", "id", currentFeature().getId());
     if (currentFeature().getProperties() != null) {
-      addProperties("", currentFeature().getProperties().asMap());
+      addProperties("", currentFeature().getProperties().toMap());
     }
   }
 

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/util/geo/MapBoxVectorTileFlattenedBuilder.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/util/geo/MapBoxVectorTileFlattenedBuilder.java
@@ -96,7 +96,7 @@ public class MapBoxVectorTileFlattenedBuilder extends MvtTileBuilder {
     this.layerProps = layerProps;
     this.featureBuilder = featureBuilder;
 
-    addMap("", currentFeature().asMap());
+    addMap("", currentFeature().toMap());
   }
 
 }

--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/UpdateFeatureApiIT.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/UpdateFeatureApiIT.java
@@ -363,7 +363,7 @@ public class UpdateFeatureApiIT extends TestSpaceWithFeature {
         accept(APPLICATION_GEO_JSON).
         contentType(APPLICATION_GEO_JSON).
         headers(getAuthHeaders(AuthProfile.ACCESS_OWNER_1_ADMIN)).
-        body(XyzSerializable.serialize(featureCollection)).
+        body(featureCollection.serialize()).
         when().
         post(getSpacesPath() + "/x-psql-test/features").
         then().
@@ -379,7 +379,7 @@ public class UpdateFeatureApiIT extends TestSpaceWithFeature {
         accept(APPLICATION_GEO_JSON).
         contentType(APPLICATION_GEO_JSON).
         headers(getAuthHeaders(AuthProfile.ACCESS_OWNER_1_ADMIN)).
-        body(XyzSerializable.serialize(feature)).
+        body(feature.serialize()).
         when().
         patch(getSpacesPath() + "/x-psql-test/features/Q2838923").
         then().

--- a/xyz-models/src/main/java/com/here/xyz/models/hub/Space.java
+++ b/xyz-models/src/main/java/com/here/xyz/models/hub/Space.java
@@ -29,6 +29,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.here.xyz.XyzSerializable;
+import com.here.xyz.XyzSerializable.Public;
+import com.here.xyz.XyzSerializable.Static;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -549,26 +551,18 @@ public class Space {
     return this;
   }
 
+  /**
+   * Used as a JsonView on a {@link Space} to indicate that a property should be part of a response which was requested to contain
+   * connector information.
+   */
   @SuppressWarnings("WeakerAccess")
-  public static class Public {
-
-  }
-
-  @SuppressWarnings("WeakerAccess")
-  public static class WithConnectors extends Public {
-
-  }
-
-  public static class Internal extends WithConnectors {
-
-  }
+  public static class WithConnectors extends Public {}
 
   /**
-   * Used for properties which are intended to be persisted.
+   * Used as a JsonView on models to indicate that a property should be only serialized in internal JSON representations.
+   * (e.g. when it comes RPC calls between inner software components)
    */
-  public static class Static {
-
-  }
+  public static class Internal extends WithConnectors {}
 
   /**
    * The reference to a connector configuration.

--- a/xyz-models/src/test/java/com/here/xyz/JsonMappingTest.java
+++ b/xyz-models/src/test/java/com/here/xyz/JsonMappingTest.java
@@ -31,9 +31,9 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.here.xyz.events.EventNotification;
 import com.here.xyz.events.ModifyFeaturesEvent;
 import com.here.xyz.models.geojson.implementation.Feature;
-import com.here.xyz.responses.XyzError;
 import com.here.xyz.models.hub.Space;
 import com.here.xyz.responses.ErrorResponse;
+import com.here.xyz.responses.XyzError;
 import java.io.IOException;
 import org.junit.Test;
 
@@ -78,18 +78,6 @@ public class JsonMappingTest {
     assertNotNull(obj);
     assertSame(XyzError.NOT_IMPLEMENTED, obj.getError());
     assertEquals("Hello World!", obj.getErrorMessage());
-  }
-
-  @Test
-  public void testNativeAWSLambdaErrorMessage() throws Exception {
-    final String json = "{\"errorMessage\":\"2018-09-15T07:12:25.013Z a368c0ea-b8b6-11e8-b894-eb5a7755e998 Task timed out after 25.01 seconds\"}";
-    ErrorResponse obj = new ErrorResponse();
-    obj = new ObjectMapper().readerForUpdating(obj).readValue(json);
-    assertNotNull(obj);
-    obj = XyzSerializable.fixAWSLambdaResponse(obj);
-    assertSame(XyzError.TIMEOUT, obj.getError());
-    assertEquals("2018-09-15T07:12:25.013Z a368c0ea-b8b6-11e8-b894-eb5a7755e998 Task timed out after 25.01 seconds",
-        obj.getErrorMessage());
   }
 
   //@Test

--- a/xyz-models/src/test/java/com/here/xyz/events/EventTest.java
+++ b/xyz-models/src/test/java/com/here/xyz/events/EventTest.java
@@ -52,7 +52,7 @@ public class EventTest {
   @Test
   public void testClone() throws Exception {
     final Event<?> event = new ObjectMapper().readValue(eventJson, Event.class);
-    final Event<?> clone = XyzSerializable.copy(event);
+    final Event<?> clone = event.copy();
 
     assertNotSame(event, clone);
     assertTrue(event instanceof IterateFeaturesEvent);
@@ -108,7 +108,7 @@ public class EventTest {
     assertEquals("customValue", event.getTrustedParams().get("customKey"));
     assertFalse(event.getTrustedParams().isEmpty());
 
-    String json = XyzSerializable.serialize(event);
+    String json = event.serialize();
     event = om.readValue(json, IterateFeaturesEvent.class);
 
     assertNotNull(event.getTrustedParams());

--- a/xyz-models/src/test/java/com/here/xyz/models/geojson/implementation/TestClone.java
+++ b/xyz-models/src/test/java/com/here/xyz/models/geojson/implementation/TestClone.java
@@ -57,7 +57,7 @@ public class TestClone {
   public void testAsMap() throws JsonProcessingException {
     FeatureCollection collection = generateRandomFeatures(1, 1);
     Feature feature = collection.getFeatures().get(0);
-    feature.asMap();
+    feature.toMap();
   }
 
   @Test

--- a/xyz-psql-connector/src/test/java/com/here/xyz/psql/PSQLWriteIT.java
+++ b/xyz-psql-connector/src/test/java/com/here/xyz/psql/PSQLWriteIT.java
@@ -22,7 +22,6 @@ import static io.restassured.path.json.JsonPath.with;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import com.amazonaws.util.IOUtils;
@@ -171,7 +170,7 @@ public class PSQLWriteIT extends PSQLAbstractIT {
 
         // =========== UPDATE ==========
         FeatureCollection featureCollection = XyzSerializable.deserialize(insertResponse);
-        String featuresList = XyzSerializable.serialize(featureCollection.getFeatures(), new TypeReference<List<Feature>>() {});
+        XyzSerializable.serialize(featureCollection.getFeatures(), new TypeReference<List<Feature>>() {});
 
         ModifyFeaturesEvent mfevent = new ModifyFeaturesEvent()
                 .withConnectorParams(defaultTestConnectorParams)


### PR DESCRIPTION
- Pull JsonView classes into XyzSerializable to make it broadly usable
- Enhance XyzSerializable utility with new methods to enable all existing use-cases of other components
- Remove direct usage of ObjectMappers from XyzSerializable (apart from some exceptions) and make Mappers reduce accessibility where possible
- Add functional interface "ThrowingHandler" in API class to enable a generic & central way of error handling in the REST API tier