### PR TITLE
Improve Dynamo Job Config client

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/httpconnector/config/AwsS3Client.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/httpconnector/config/AwsS3Client.java
@@ -29,8 +29,6 @@ import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.here.xyz.httpconnector.CService;
-
-import java.io.IOException;
 import java.net.URL;
 import java.util.Date;
 
@@ -47,38 +45,38 @@ public class AwsS3Client {
     public AwsS3Client() {
         final AmazonS3ClientBuilder builder = AmazonS3ClientBuilder.standard();
 
-        if(isLocal()){
+        if (isLocal()) {
             builder.withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(
                     CService.configuration.LOCALSTACK_ENDPOINT, CService.configuration.JOBS_REGION))
                     .withCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials("localstack", "localstack")))
                     .withPathStyleAccessEnabled(true);
-        }else{
+        }
+        else {
             final String region = CService.configuration != null ? CService.configuration.JOBS_REGION : "eu-west-1";
             builder.setRegion(region);
         }
 
         if (CService.configuration != null && CService.configuration.JOB_BOT_SECRET_ARN != null) {
-            synchronized(AwsS3Client.class) {
+            synchronized (AwsS3Client.class) {
                 builder.setCredentials(new SecretManagerCredentialsProvider(CService.configuration.JOB_BOT_SECRET_ARN));
             }
         }
         client = builder.build();
     }
 
-    public URL generateDownloadURL(String bucketName, String key) throws IOException {
+    public URL generateDownloadURL(String bucketName, String key) {
         return generatePresignedUrl(bucketName, key, HttpMethod.GET);
     }
 
-    public URL generateUploadURL(String bucketName, String key) throws IOException {
+    public URL generateUploadURL(String bucketName, String key) {
         return generatePresignedUrl(bucketName, key, HttpMethod.PUT);
     }
 
-    public URL generatePresignedUrl(String bucketName, String key, HttpMethod method) throws IOException {
-
+    public URL generatePresignedUrl(String bucketName, String key, HttpMethod method) {
         GeneratePresignedUrlRequest generatePresignedUrlRequest =
                 new GeneratePresignedUrlRequest(bucketName, key)
-                        .withMethod(method)
-                        .withExpiration(new Date(System.currentTimeMillis() + PRESIGNED_URL_EXPIRATION_SECONDS * 1000));
+                    .withMethod(method)
+                    .withExpiration(new Date(System.currentTimeMillis() + PRESIGNED_URL_EXPIRATION_SECONDS * 1000));
 
         return client.generatePresignedUrl(generatePresignedUrlRequest);
     }

--- a/xyz-hub-service/src/main/java/com/here/xyz/httpconnector/config/DynamoJobConfigClient.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/httpconnector/config/DynamoJobConfigClient.java
@@ -36,7 +36,6 @@ import com.here.xyz.hub.config.dynamo.DynamoClient;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.json.DecodeException;
-import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -264,8 +263,6 @@ public class DynamoJobConfigClient extends JobConfigClient {
         //TODO: Remove the following hacks from the persistence layer!
         if( json.containsKey(IO_IMPORT_ATTR_NAME) )
             return convertJobToItem(json, IO_IMPORT_ATTR_NAME);
-        if( json.containsKey(IO_EXPORT_ATTR_NAME) )
-            return convertJobToItem(json, IO_EXPORT_ATTR_NAME);
         return Item.fromJSON(json.toString());
     }
 

--- a/xyz-hub-service/src/main/java/com/here/xyz/httpconnector/config/JobS3Client.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/httpconnector/config/JobS3Client.java
@@ -254,7 +254,7 @@ public class JobS3Client extends AwsS3Client{
         return exportObjectMap;
     }
 
-    public Map<String,ExportObject> scanExportPath(String prefix, String bucketName, boolean createDownloadUrl){
+    public Map<String,ExportObject> scanExportPath(String prefix, String bucketName, boolean createDownloadUrl) {
         Map<String, ExportObject> exportObjectList = new HashMap<>();
         ListObjectsRequest listObjects = new ListObjectsRequest()
                 .withPrefix(prefix)
@@ -268,17 +268,18 @@ public class JobS3Client extends AwsS3Client{
                 continue;
 
             ExportObject eo = new ExportObject(objectSummary.getKey(), objectSummary.getSize());
-            if(eo.getFilename().equalsIgnoreCase("manifest.json"))
+            if (eo.getFilename().equalsIgnoreCase("manifest.json"))
                 continue;;
 
             exportObjectList.put(eo.getFilename(prefix), eo);
-            if(createDownloadUrl){
-                try {
-                    eo.setDownloadUrl(generateDownloadURL(bucketName, eo.getS3Key()));
-                }catch (IOException e){
-                    logger.error("[{}] Cant create download-url! ", prefix, e);
-                }
-            }
+            //if (createDownloadUrl) {
+            //    try {
+            //        eo.setDownloadUrl(generateDownloadURL(bucketName, eo.getS3Key()));
+            //    }
+            //    catch (Exception e) {
+            //        logger.error("[{}] Cant create download-url! ", prefix, e);
+            //    }
+            //}
         }
 
         return exportObjectList;

--- a/xyz-hub-service/src/main/java/com/here/xyz/httpconnector/util/jobs/Job.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/httpconnector/util/jobs/Job.java
@@ -831,7 +831,7 @@ public abstract class Job<T extends Job> extends Payload {
 
     public static class Public {}
 
-    public static class Static {}
+    public static class Static implements SerializationView {}
 
     public static class Internal extends Space.Internal {}
 

--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/jobs/JobApiGeneralIT.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/jobs/JobApiGeneralIT.java
@@ -205,7 +205,7 @@ public class JobApiGeneralIT extends JobApiIT {
                 .statusCode(CREATED.code());
 
 
-        job = (Import) getJob(getScopedSpaceId(testSpaceId1, scope), job.getId());
+        job = (Import) loadJob(getScopedSpaceId(testSpaceId1, scope), job.getId());
         Map<String, ImportObject> importObjects = job.getImportObjects();
 
         assertEquals(importObjects.size(), 1);

--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/jobs/JobApiIT.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/jobs/JobApiIT.java
@@ -257,7 +257,7 @@ public class JobApiIT extends TestSpaceWithFeature {
         }
     }
 
-    protected static Job getJob(String spaceId, String jobId) {
+    protected static Job loadJob(String spaceId, String jobId) {
         /** Get all jobs */
         Response response = given()
                 .accept(APPLICATION_JSON)
@@ -268,9 +268,11 @@ public class JobApiIT extends TestSpaceWithFeature {
         assertEquals(OK.code(),response.getStatusCode());
         String body = response.getBody().asString();
         try {
+            //TODO: Use XyzSerializable here!!
             Job job = DatabindCodec.mapper().readValue(body, new TypeReference<Job>() {});
             return job;
-        }catch (Exception e){
+        }
+        catch (Exception e) {
             return null;
         }
     }
@@ -290,7 +292,7 @@ public class JobApiIT extends TestSpaceWithFeature {
                 OR
              failed
             */
-            job = getJob(spaceId, jobId);
+            job = loadJob(spaceId, jobId);
             status = job.getStatus();
             assertNotEquals(status, failStatus);
 
@@ -312,7 +314,7 @@ public class JobApiIT extends TestSpaceWithFeature {
         Job job = null;
 
         while(!status.equals(Job.Status.executing)){
-            job = getJob(spaceId, jobId);
+            job = loadJob(spaceId, jobId);
             status = job.getStatus();
             System.out.println("Current Status of Job["+jobId+"]: "+status);
             Thread.sleep(150);
@@ -321,7 +323,7 @@ public class JobApiIT extends TestSpaceWithFeature {
         abortJob(job, spaceId);
 
         while(!status.equals(Job.Status.failed)){
-            job = getJob(spaceId, jobId);
+            job = loadJob(spaceId, jobId);
             status = job.getStatus();
             System.out.println("Current Status of Job["+jobId+"]: "+status);
             Thread.sleep(150);
@@ -461,18 +463,18 @@ public class JobApiIT extends TestSpaceWithFeature {
 
         //Poll status
         pollStatus(spaceId, job.getId(), expectedStatus, failStatus);
-        job = (Export) getJob(spaceId, job.getId());
+        Export responseJob = (Export) loadJob(spaceId, job.getId());
 
         List<URL> urlList = new ArrayList<>();
-        if (job.getExportObjects() != null) {
-            for (String key : job.getExportObjects().keySet()) {
-                urlList.add(job.getExportObjects().get(key).getDownloadUrl());
+        if (responseJob.getExportObjects() != null) {
+            for (String key : responseJob.getExportObjects().keySet()) {
+                urlList.add(responseJob.getExportObjects().get(key).getDownloadUrl());
             }
         }
 
-        if(job.getSuperExportObjects() != null) {
-            for (String key : job.getSuperExportObjects().keySet()) {
-                urlList.add(job.getSuperExportObjects().get(key).getDownloadUrl());
+        if(responseJob.getSuperExportObjects() != null) {
+            for (String key : responseJob.getSuperExportObjects().keySet()) {
+                urlList.add(responseJob.getSuperExportObjects().get(key).getDownloadUrl());
             }
         }
         return urlList;

--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/jobs/JobApiImportIT.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/jobs/JobApiImportIT.java
@@ -153,7 +153,7 @@ public class JobApiImportIT extends JobApiIT {
                 .then()
                 .body("features.size()", equalTo(1));
 
-        job = (Import)getJob(getScopedSpaceId(testSpaceId1, scope), job.getId());
+        job = (Import) loadJob(getScopedSpaceId(testSpaceId1, scope), job.getId());
 
         assertTrue(job.getErrorDescription().equalsIgnoreCase(Import.ERROR_DESCRIPTION_IDS_NOT_UNIQUE));
 
@@ -364,7 +364,7 @@ public class JobApiImportIT extends JobApiIT {
                 .statusCode(NO_CONTENT.code());
 
         pollStatus(getScopedSpaceId(testSpaceId1, scope), job.getId(), Job.Status.failed, Job.Status.finalized);
-        job = (Import) getJob(getScopedSpaceId(testSpaceId1, scope), job.getId());
+        job = (Import) loadJob(getScopedSpaceId(testSpaceId1, scope), job.getId());
 
         assertEquals(job.getErrorDescription(), Import.ERROR_DESCRIPTION_UPLOAD_MISSING );
         assertEquals(job.getErrorType(), Import.ERROR_TYPE_VALIDATION_FAILED);


### PR DESCRIPTION
- Add type information (Job.class) while doing conversion to POJO from item
- Use maps instead of JSON string (de-)serialization for type conversion
- Do not store pre-signed URLs anymore. Instead always generate them on-demand. That also solves size-issues (4KB limit) and reduces the necessary overall storage on the Dynamo table.