### PR TITLE
Fix for requesting features of a composite & versioned space after "recovering" of SUPER state

### DIFF
--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/ModifyFeatureCompositeSpaceIT.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/ModifyFeatureCompositeSpaceIT.java
@@ -396,7 +396,7 @@ public class ModifyFeatureCompositeSpaceIT extends TestCompositeSpace {
     postFeature("x-psql-test-ext", f1.withProperties(new Properties().with("name", "b")));
 
     // modify x-psql-test-ext-ext to point to x-psql-test
-    modifyComposite("x-psql-test-ext-ext", "x-psql-test");
+    makeComposite("x-psql-test-ext-ext", "x-psql-test");
 
     // get F1 from x-psql-test-ext-ext -> assert F1(p.name="a")
     getFeature("x-psql-test-ext-ext", f1.getId(), OK.code(), "properties.name", "a");
@@ -416,13 +416,13 @@ public class ModifyFeatureCompositeSpaceIT extends TestCompositeSpace {
     deleteFeature("x-psql-test-ext", f1.getId());
 
     // modify x-psql-test-ext-ext to point to x-psql-test
-    modifyComposite("x-psql-test-ext-ext", "x-psql-test");
+    makeComposite("x-psql-test-ext-ext", "x-psql-test");
 
     // get F1 from x-psql-test-ext-ext -> assert F1(p.name="a")
     getFeature("x-psql-test-ext-ext", f1.getId(), OK.code(), "properties.name", "a");
 
     // modify x-psql-test-ext-ext to point to x-psql-test-ext
-    modifyComposite("x-psql-test-ext-ext", "x-psql-test-ext");
+    makeComposite("x-psql-test-ext-ext", "x-psql-test-ext");
 
     // get F1 from x-psql-test-ext-ext -> assert 404
     getFeature("x-psql-test-ext-ext", f1.getId(), NOT_FOUND.code());
@@ -439,13 +439,13 @@ public class ModifyFeatureCompositeSpaceIT extends TestCompositeSpace {
     postFeature("x-psql-test-2", f1.withProperties(new Properties().with("name", "b")));
 
     // modify x-psql-test-ext to point to x-psql-test-2
-    modifyComposite("x-psql-test-ext", "x-psql-test-2");
+    makeComposite("x-psql-test-ext", "x-psql-test-2");
 
     // get F1 from x-psql-test-ext-ext -> assert F1(p.name="b")
     getFeature("x-psql-test-ext-ext", f1.getId(), OK.code(), "properties.name", "b");
 
     // modify x-psql-test-ext to point to x-psql-test
-    modifyComposite("x-psql-test-ext", "x-psql-test");
+    makeComposite("x-psql-test-ext", "x-psql-test");
 
     // get F1 from x-psql-test-ext-ext -> assert F1(p.name="a")
     getFeature("x-psql-test-ext-ext", f1.getId(), OK.code(), "properties.name", "a");

--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/VersioningCompositeGetFeaturesIT.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/VersioningCompositeGetFeaturesIT.java
@@ -25,6 +25,7 @@ import com.here.xyz.models.geojson.implementation.Properties;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.FixMethodOrder;
+import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runners.MethodSorters;
 
@@ -42,7 +43,7 @@ public class VersioningCompositeGetFeaturesIT extends VersioningGetFeaturesIT {
 
     createSpaceWithId(BASE);
     createSpaceWithVersionsToKeep(DELTA, 1000);
-    modifyComposite(DELTA, BASE);
+    makeComposite(DELTA, BASE);
 
     postFeature(BASE, newFeature(), AuthProfile.ACCESS_OWNER_1_ADMIN);
 
@@ -59,5 +60,56 @@ public class VersioningCompositeGetFeaturesIT extends VersioningGetFeaturesIT {
   public void after() {
     removeSpace(BASE);
     removeSpace(DELTA);
+  }
+
+  @Test
+  public void testFeatureDeletion() {
+    deleteFeature(DELTA, "f1");
+    getFeature(DELTA, "f1", "SUPER", 200);
+    getFeature(DELTA, "f1", "EXTENSION", 200);
+    getFeature(DELTA, "f1", "DEFAULT", 404);
+    getFeature(DELTA, "f1", 404);
+  }
+
+  @Test
+  public void testGetFeatureByIdAfterDeletionAndRecovery() {
+    //Delete the feature in the composite space
+    deleteFeature(DELTA, "f1");
+    //"Recover" the feature in the composite space (by hardly deleting it from the EXTENSION)
+    deleteFeature(DELTA, "f1", "EXTENSION");
+    getFeature(DELTA, "f1", "EXTENSION", 404);
+    getFeature(DELTA, "f1", "DEFAULT", 200);
+    getFeature(DELTA, "f1", 200);
+  }
+
+  @Test
+  public void testGetFeaturesByIdAfterDeletionAndRecoveryWithSpecificVersion() {
+    //Delete the feature in the composite space (Creates version 2, see #before() above)
+    deleteFeature(DELTA, "f1");
+    //Check that versions 0 & 1 are still accessible correctly
+    getFeature(DELTA, "f1", 0, "EXTENSION", 200);
+    getFeature(DELTA, "f1", 0, "DEFAULT", 200);
+    getFeature(DELTA, "f1", 1, "EXTENSION", 200);
+    getFeature(DELTA, "f1", 1, "DEFAULT", 200);
+    //Check that version 2 (the deletion marker) is only accessible in context EXTENSION
+    getFeature(DELTA, "f1", 2, "EXTENSION", 200);
+    getFeature(DELTA, "f1", 2, "DEFAULT", 404);
+    //"Recover" the feature in the composite space (by hardly deleting it from the EXTENSION, creates version 3)
+    deleteFeature(DELTA, "f1", "EXTENSION");
+    //Check that version 3 is only accessible through context DEFAULT
+    getFeature(DELTA, "f1", 3, "EXTENSION", 404);
+    getFeature(DELTA, "f1", 3, "DEFAULT", 200);
+    getFeature(DELTA, "f1", 3, 200);
+    //Write another new version of the feature (creates version 4)
+    postFeature(DELTA, newFeature().withProperties(new Properties().with("key3", "value3")), AuthProfile.ACCESS_OWNER_1_ADMIN,
+        true);
+    //Check that version 3 is still only accessible through context DEFAULT
+    getFeature(DELTA, "f1", 3, "EXTENSION", 404);
+    getFeature(DELTA, "f1", 3, "DEFAULT", 200);
+    getFeature(DELTA, "f1", 3, 200);
+    //Check that version 4 is accessible through both contexts
+    getFeature(DELTA, "f1", 4, "EXTENSION", 200);
+    getFeature(DELTA, "f1", 4, "DEFAULT", 200);
+    getFeature(DELTA, "f1", 4, 200);
   }
 }

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeatures.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeatures.java
@@ -52,6 +52,7 @@ public abstract class GetFeatures<E extends ContextAwareEvent, R extends XyzResp
   protected SQLQuery buildQuery(E event) throws SQLException, ErrorResponseException {
     int versionsToKeep = DatabaseHandler.readVersionsToKeep(event);
     boolean useExtensionQuery = isExtendedSpace(event) && (event.getContext() == DEFAULT || event.getContext() == COMPOSITE_EXTENSION);
+    SQLQuery versionCheckFragment = buildVersionCheckFragment(event);
     SQLQuery query;
     if (useExtensionQuery) {
       query = new SQLQuery(
@@ -65,7 +66,7 @@ public abstract class GetFeatures<E extends ContextAwareEvent, R extends XyzResp
           + "                ${{baseQuery}}"
           + "            ) a WHERE ${{exists}} exists(SELECT 1 FROM ${schema}.${table} b WHERE ${{notExistsIdComparison}})"
           + ") limitQuery ${{limit}}")
-          .withQueryFragment("notExistsIdComparison", buildIdComparisonFragment(event, "a."))
+          .withQueryFragment("notExistsIdComparison", buildIdComparisonFragment(event, "a.", versionCheckFragment))
           .withQueryFragment("unionAll", event.getContext() == COMPOSITE_EXTENSION ? "UNION DISTINCT" : "UNION ALL")
           .withQueryFragment("exists", event.getContext() == COMPOSITE_EXTENSION ? "" : "NOT");
     }
@@ -77,7 +78,7 @@ public abstract class GetFeatures<E extends ContextAwareEvent, R extends XyzResp
     }
 
     query.setQueryFragment("deletedCheck", buildDeletionCheckFragment(versionsToKeep, useExtensionQuery));
-    query.withQueryFragment("versionCheck", buildVersionCheckFragment(event));
+    query.withQueryFragment("versionCheck", versionCheckFragment);
     query.withQueryFragment("authorCheck", buildAuthorCheckFragment(event));
     query.setQueryFragment("selection", buildSelectionFragment(event));
     query.setQueryFragment("geo", buildGeoFragment(event));
@@ -114,23 +115,26 @@ public abstract class GetFeatures<E extends ContextAwareEvent, R extends XyzResp
   }
 
   private SQLQuery buildVersionCheckFragment(E event) {
-    if (!(event instanceof SelectiveEvent)) return new SQLQuery("");
+    if (!(event instanceof SelectiveEvent))
+      return new SQLQuery("");
 
     SelectiveEvent selectiveEvent = (SelectiveEvent) event;
     int versionsToKeep = DatabaseHandler.readVersionsToKeep(event);
     boolean versionIsStar = "*".equals(selectiveEvent.getRef());
     boolean versionIsNotPresent = selectiveEvent.getRef() == null;
+    final SQLQuery minVersionFragment = buildMinVersionFragment(selectiveEvent);
 
     final SQLQuery defaultClause = new SQLQuery(" ${{minVersion}} ${{nextVersion}} ")
         .withQueryFragment("nextVersion", versionIsStar || versionsToKeep <= 1 ? "" : " AND next_version = #{MAX_BIGINT} ")
-        .withNamedParameter("MAX_BIGINT", MAX_BIGINT);
-    defaultClause.withQueryFragment("minVersion", buildMinVersionFragment(selectiveEvent));
+        .withNamedParameter("MAX_BIGINT", MAX_BIGINT)
+        .withQueryFragment("minVersion", minVersionFragment);
 
-    if (versionsToKeep == 1 || versionIsNotPresent || versionIsStar) return defaultClause;
+    if (versionsToKeep == 1 || versionIsNotPresent || versionIsStar)
+      return defaultClause;
 
-    // versionsToKeep > 1 AND contains a reference to a version or version is a valid version
+    //versionsToKeep > 1 AND contains a reference to a version or version is a valid version
     return new SQLQuery(" AND version <= #{version} AND next_version > #{version} ${{minVersion}} ")
-        .withQueryFragment("minVersion", buildMinVersionFragment(selectiveEvent))
+        .withQueryFragment("minVersion", minVersionFragment)
         .withNamedParameter("version", getVersionFromRef(selectiveEvent));
   }
 
@@ -143,7 +147,7 @@ public abstract class GetFeatures<E extends ContextAwareEvent, R extends XyzResp
     long version = getVersionFromRef(event);
     boolean isHead = version == MAX_BIGINT;
     if (event.getVersionsToKeep() > 1)
-      return new SQLQuery("AND greatest(#{minVersion}, (select max(version) - #{versionsToKeep} from ${schema}.${table})) <= #{version}")
+      return new SQLQuery("AND greatest(#{minVersion}, (SELECT max(version) - #{versionsToKeep} FROM ${schema}.${table})) <= #{version}")
           .withNamedParameter("versionsToKeep", event.getVersionsToKeep())
           .withNamedParameter("minVersion", event.getMinVersion())
           .withNamedParameter("version", version);
@@ -152,13 +156,15 @@ public abstract class GetFeatures<E extends ContextAwareEvent, R extends XyzResp
   }
 
   private SQLQuery buildAuthorCheckFragment(E event) {
-    if (!(event instanceof SelectiveEvent)) return new SQLQuery("");
+    if (!(event instanceof SelectiveEvent))
+      return new SQLQuery("");
 
     SelectiveEvent selectiveEvent = (SelectiveEvent) event;
     long v2k = DatabaseHandler.readVersionsToKeep(event);
     boolean emptyAuthor = selectiveEvent.getAuthor() == null;
 
-    if (v2k < 1 || emptyAuthor) return new SQLQuery("");
+    if (v2k < 1 || emptyAuthor)
+      return new SQLQuery("");
 
     return new SQLQuery(" AND author = #{author}")
         .withNamedParameter("author", selectiveEvent.getAuthor());
@@ -187,6 +193,7 @@ public abstract class GetFeatures<E extends ContextAwareEvent, R extends XyzResp
   private SQLQuery build2LevelBaseQuery(E event) {
     int versionsToKeep = DatabaseHandler.readVersionsToKeep(event);
 
+    SQLQuery versionCheckFragment = buildBaseVersionCheckFragment();
     return new SQLQuery("(SELECT id, version, operation, jsondata, geo${{iColumnIntermediate}}"
         + "    FROM ${schema}.${intermediateExtensionTable}"
         + "    WHERE ${{filterWhereClause}} ${{deletedCheck}} ${{versionCheck}} ${{iOffsetIntermediate}} ${{limit}})"
@@ -197,13 +204,15 @@ public abstract class GetFeatures<E extends ContextAwareEvent, R extends XyzResp
         + "        ) b WHERE NOT exists(SELECT 1 FROM ${schema}.${intermediateExtensionTable} WHERE ${{idComparison}})")
         .withVariable("intermediateExtensionTable", getIntermediateTable(event))
         .withQueryFragment("deletedCheck", buildDeletionCheckFragment(versionsToKeep, true)) //NOTE: We know that the intermediate space is an extended one
-        .withQueryFragment("versionCheck", buildBaseVersionCheckFragment())
+        .withQueryFragment("versionCheck", versionCheckFragment)
         .withQueryFragment("innerBaseQuery", build1LevelBaseQuery(event))
-        .withQueryFragment("idComparison", buildIdComparisonFragment(event, "b."));
+        .withQueryFragment("idComparison", buildIdComparisonFragment(event, "b.", versionCheckFragment));
   }
 
-  private String buildIdComparisonFragment(E event, String prefix) {
-    return  "id = " + prefix + "id";
+  private SQLQuery buildIdComparisonFragment(E event, String prefix, SQLQuery versionCheckFragment) {
+    return new SQLQuery("id = " + prefix + "id"
+        + (event instanceof SelectiveEvent ? " ${{versionCheck}} AND operation != 'D'" : ""))
+        .withQueryFragment("versionCheck", versionCheckFragment);
   }
 
   private SQLQuery buildDeletionCheckFragment(int v2k, boolean isExtended) {


### PR DESCRIPTION
Following scenario was failing / buggy and is fixed now:
- Having a composite space B extending space A with feature F
- Add feature F to space B
- Delete feature F from space B (through context DEFAULT)
- "Recover" SUPER-state of F in B by deleting F through context EXTENSION
- Trying to access F in B through context DEFAULT results in not found / 404 but it should be there

Added test #testGetFeatureByIdAfterDeletionAndRecovery() and #testGetFeaturesByIdAfterDeletionAndRecoveryWithSpecificVersion() to make sure to keep testing that complex scenario in the future