### PR TITLE
Fix issue with missing slashes "/" at the end of export s3-keys

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/httpconnector/util/jobs/ExportObject.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/httpconnector/util/jobs/ExportObject.java
@@ -58,7 +58,7 @@ public class ExportObject {
         if(pos == -1)
             getFilename();
 
-        return s3Key.substring(pos + prefix.length() + 1);
+        return s3Key.substring(pos + prefix.length() + (prefix.endsWith("/") ? 0 : 1));
     }
 
     public void setS3Key(String s3Key) {


### PR DESCRIPTION
- Missing slash at the end was leading to too many prefixes / "folders" being matched during S3 scanning if there were more than 10 child jobs in the CombinedJob
- Also re-activated S3 scan cache, but only cache jobs which are finalized (to not cache intermediate / non-final states of exportObjects)
- Also fix issue with existing / old jobs which still have their exportObjects being stored in the config to be deserialized properly