### PR TITLE
Fix OAS to always use as target host the host from which it was loaded

### DIFF
--- a/xyz-hub-service/src/main/resources/openapi.yaml
+++ b/xyz-hub-service/src/main/resources/openapi.yaml
@@ -6,7 +6,7 @@ info:
   contact: {}
   version: 1.0.0
 servers:
-  - url: http://localhost:8080/hub
+  - url: /hub
 security:
   - AccessToken: []
   - Bearer: []


### PR DESCRIPTION
Fixes issue which was introduced in earlier PR.
Reference in case later reasoning might be needed: https://github.com/heremaps/xyz-hub/pull/987/files#diff-5bf3b82600e687f243d4144d1ce793f5dc4d4e172da36bae6076444412c1e0db