### PR TITLE
Fix issue with concurrent feature inserts

### DIFF
--- a/xyz-connectors/src/main/java/com/here/xyz/connectors/ErrorResponseException.java
+++ b/xyz-connectors/src/main/java/com/here/xyz/connectors/ErrorResponseException.java
@@ -21,8 +21,8 @@ package com.here.xyz.connectors;
 
 import static com.here.xyz.responses.XyzError.EXCEPTION;
 
-import com.here.xyz.responses.XyzError;
 import com.here.xyz.responses.ErrorResponse;
+import com.here.xyz.responses.XyzError;
 
 /**
  * An exception, which will cause the connector to respond with an ErrorResponse object.
@@ -34,6 +34,11 @@ public class ErrorResponseException extends Exception {
   public ErrorResponseException(XyzError xyzError, String errorMessage) {
     super(errorMessage);
     createErrorResponse(xyzError, errorMessage);
+  }
+
+  public ErrorResponseException(ErrorResponse errorResponse) {
+    super(errorResponse.getErrorMessage());
+    this.errorResponse = errorResponse;
   }
 
   public ErrorResponseException(Exception cause) {

--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/DecompressedSizeIT.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/DecompressedSizeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2023 HERE Europe B.V.
+ * Copyright (C) 2017-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@
 package com.here.xyz.hub.rest;
 
 import static com.here.xyz.hub.rest.Api.HeaderValues.APPLICATION_GEO_JSON;
-import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static io.restassured.RestAssured.given;
 
 import org.junit.AfterClass;
@@ -43,26 +42,26 @@ public class DecompressedSizeIT extends TestSpaceWithFeature {
 
   @Test
   public void testHeaderOutputSizeReporting() {
-    given().
-        accept(APPLICATION_GEO_JSON).
-        headers(getAuthHeaders(AuthProfile.ACCESS_OWNER_1_ADMIN)).
-        when().
-        get(getSpacesPath() + "/x-psql-test/tile/quadkey/2100300120310022").
-        then().
-        header("X-Decompressed-Input-Size", "0").
-        header("X-Decompressed-Output-Size", "493");
+    given()
+        .accept(APPLICATION_GEO_JSON)
+        .headers(getAuthHeaders(AuthProfile.ACCESS_OWNER_1_ADMIN))
+        .when()
+        .get(getSpacesPath() + "/x-psql-test/tile/quadkey/2100300120310022")
+        .then()
+        .header("X-Decompressed-Input-Size", "0")
+        .header("X-Decompressed-Output-Size", "493");
   }
 
   @Test
   public void testHeaderInputSizeReporting() {
-    given().
-        contentType(APPLICATION_GEO_JSON).
-        headers(getAuthHeaders(AuthProfile.ACCESS_OWNER_1_ADMIN)).
-        body("{\"type\": \"FeatureCollection\",\"features\": [{\"type\": \"Feature\"}]}").
-        when().
-        put(getSpacesPath() + "/x-psql-test/features").
-        then().
-        header("X-Decompressed-Input-Size", "63").
-        header("X-Decompressed-Output-Size", "310");
+    given()
+        .contentType(APPLICATION_GEO_JSON)
+        .headers(getAuthHeaders(AuthProfile.ACCESS_OWNER_1_ADMIN))
+        .body("{\"type\": \"FeatureCollection\",\"features\": [{\"type\": \"Feature\"}]}")
+        .when()
+        .put(getSpacesPath() + "/x-psql-test/features")
+        .then()
+        .header("X-Decompressed-Input-Size", "63")
+        .header("X-Decompressed-Output-Size", "310");
   }
 }

--- a/xyz-models/src/main/java/com/here/xyz/models/geojson/implementation/Geometry.java
+++ b/xyz-models/src/main/java/com/here/xyz/models/geojson/implementation/Geometry.java
@@ -19,6 +19,8 @@
 
 package com.here.xyz.models.geojson.implementation;
 
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
@@ -37,7 +39,7 @@ import java.util.List;
 })
 public abstract class Geometry implements Typed {
 
-  @JsonInclude(JsonInclude.Include.NON_EMPTY)
+  @JsonInclude(NON_EMPTY)
   private BBox bbox;
   private org.locationtech.jts.geom.Geometry geomCache;
 

--- a/xyz-models/src/main/java/com/here/xyz/responses/ErrorResponse.java
+++ b/xyz-models/src/main/java/com/here/xyz/responses/ErrorResponse.java
@@ -21,7 +21,6 @@ package com.here.xyz.responses;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-
 import java.util.Map;
 
 /**
@@ -37,11 +36,13 @@ public class ErrorResponse extends XyzResponse<ErrorResponse> {
   private Map<String, Object> errorDetails;
 
   /**
-   * Returns the errorDetails which can contains additional detail information.
+   * Returns the errorDetails which can contain additional detail information.
    *
    * @return the errorDetails map.
    */
-  public Map<String, Object>  getErrorDetails(){return this.errorDetails;}
+  public Map<String, Object>  getErrorDetails() {
+    return this.errorDetails;
+  }
 
   /**
    * Set the errorDetails map to the provided value.

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseHandler.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseHandler.java
@@ -285,8 +285,8 @@ public abstract class DatabaseHandler extends StorageConnector {
                 }
             } catch (Exception e) {
                 /** No time left for processing */
-                if(e instanceof SQLException && ((SQLException)e).getSQLState() !=null
-                        &&((SQLException)e).getSQLState().equalsIgnoreCase("54000")) {
+                if(e instanceof SQLException sqlException && sqlException.getSQLState() !=null
+                        && sqlException.getSQLState().equalsIgnoreCase("54000")) {
                     throw e;
                 }
 
@@ -307,8 +307,8 @@ public abstract class DatabaseHandler extends StorageConnector {
                 if (event.getTransaction()) {
                     connection.rollback();
 
-                    if (e instanceof SQLException && ((SQLException)e).getSQLState() != null
-                            && ((SQLException)e).getSQLState().equalsIgnoreCase("42P01"))
+                    if (e instanceof SQLException sqlException && sqlException.getSQLState() != null
+                            && sqlException.getSQLState().equalsIgnoreCase("42P01"))
                         ;//Table does not exist yet - create it!
                     else {
 
@@ -317,17 +317,18 @@ public abstract class DatabaseHandler extends StorageConnector {
 
                         Map<String, Object> errorDetails = new HashMap<>();
 
-                        if(e instanceof BatchUpdateException || fails.size() >=1 ){
+                        if (e instanceof BatchUpdateException || fails.size() >= 1) {
                             //23505 = Object already exists
-                            if(e instanceof BatchUpdateException && !((BatchUpdateException) e).getSQLState().equalsIgnoreCase("23505"))
+                            if (e instanceof BatchUpdateException bue && !bue.getSQLState().equalsIgnoreCase("23505"))
                                 throw e;
 
                             errorDetails.put("FailedList", fails);
                             return new ErrorResponse().withErrorDetails(errorDetails).withError(XyzError.CONFLICT).withErrorMessage(DatabaseWriter.TRANSACTION_ERROR_GENERAL);
-                        }else {
+                        }
+                        else {
                             errorDetails.put(DatabaseWriter.TRANSACTION_ERROR_GENERAL,
-                                    (e instanceof SQLException && ((SQLException)e).getSQLState() != null)
-                                            ? "SQL-state: "+((SQLException) e).getSQLState() : "Unexpected Error occurred");
+                                    (e instanceof SQLException sqlException && sqlException.getSQLState() != null)
+                                            ? "SQL-state: " + sqlException.getSQLState() : "Unexpected Error occurred");
                             return new ErrorResponse().withErrorDetails(errorDetails).withError(XyzError.BAD_GATEWAY).withErrorMessage(DatabaseWriter.TRANSACTION_ERROR_GENERAL);
                         }
                     }

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseMaintainer.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseMaintainer.java
@@ -49,7 +49,7 @@ public class DatabaseMaintainer {
     private static final Logger logger = LogManager.getLogger();
 
     /** Is used to check against xyz_ext_version() */
-    public static final int XYZ_EXT_VERSION = 184;
+    public static final int XYZ_EXT_VERSION = 185;
 
     public static final int H3_CORE_VERSION = 108;
 

--- a/xyz-psql-connector/src/test/java/com/here/xyz/psql/tools/Helper.java
+++ b/xyz-psql-connector/src/test/java/com/here/xyz/psql/tools/Helper.java
@@ -43,8 +43,8 @@ public class Helper {
 
     protected static <T extends XyzResponse> T deserializeResponse(String jsonResponse) throws JsonProcessingException, ErrorResponseException {
       XyzResponse response = XyzSerializable.deserialize(jsonResponse);
-      if (response instanceof ErrorResponse)
-        throw new ErrorResponseException(((ErrorResponse) response).getError(), ((ErrorResponse) response).getErrorMessage());
+      if (response instanceof ErrorResponse errorResponse)
+        throw new ErrorResponseException(errorResponse);
       return (T) response;
     }
 

--- a/xyz-util/src/main/java/com/here/xyz/util/db/pg/IndexHelper.java
+++ b/xyz-util/src/main/java/com/here/xyz/util/db/pg/IndexHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2023 HERE Europe B.V.
+ * Copyright (C) 2017-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xyz-util/src/main/java/com/here/xyz/util/db/pg/XyzSpaceTableHelper.java
+++ b/xyz-util/src/main/java/com/here/xyz/util/db/pg/XyzSpaceTableHelper.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) 2017-2024 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
 package com.here.xyz.util.db.pg;
 
 import static com.here.xyz.util.db.pg.IndexHelper.buildCreateIndexQuery;


### PR DESCRIPTION
When two features are getting created within a space (without history being activated) at (roughly) the same time under rare circumstances, it could happen, that both features were added to the underlying space table. This is now fixed in the following manner:

- If "conflictDetection" was activated for the transaction a "conflict" error is thrown
- Otherwise the later incoming feature modification is handled as an update rather than an insert
- Also reactivate concurrency tests for inserts, now with differentiation if conflict detection is active or not

- Also fix another minor bug regarding concurrent deletions: When there are two deletions happening at (roughly) the same time, now the 2nd deletion won't throw a "conflict" error to the user anymore as the result of both operations would have been the same.
- Update PSQLConcurrencyIT accordingly to not expect that kind of "conflict" error anymore for two concurrent deletions
