### PR TITLE
Streamline space table creations to be reusable from multiple places

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/httpconnector/config/JDBCMaintainer.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/httpconnector/config/JDBCMaintainer.java
@@ -19,7 +19,7 @@
 
 package com.here.xyz.httpconnector.config;
 
-import static com.here.xyz.psql.DatabaseHandler.PARTITION_SIZE;
+import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.PARTITION_SIZE;
 import static com.here.xyz.psql.query.ModifySpace.IDX_STATUS_TABLE_FQN;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/xyz-models/src/main/java/com/here/xyz/models/hub/Space.java
+++ b/xyz-models/src/main/java/com/here/xyz/models/hub/Space.java
@@ -428,6 +428,7 @@ public class Space {
     return (T) this;
   }
 
+  //TODO: Change to primitive type
   public Boolean isEnableAutoSearchableProperties() {
     return enableAutoSearchableProperties;
   }

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseHandler.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseHandler.java
@@ -20,14 +20,10 @@
 package com.here.xyz.psql;
 
 import static com.here.xyz.events.ContextAwareEvent.SpaceContext.DEFAULT;
-import static com.here.xyz.events.ModifySpaceEvent.Operation.CREATE;
 import static com.here.xyz.models.hub.Space.DEFAULT_VERSIONS_TO_KEEP;
 import static com.here.xyz.psql.DatabaseWriter.ModificationType.DELETE;
 import static com.here.xyz.psql.DatabaseWriter.ModificationType.INSERT;
 import static com.here.xyz.psql.DatabaseWriter.ModificationType.UPDATE;
-import static com.here.xyz.psql.QueryRunner.SCHEMA;
-import static com.here.xyz.psql.QueryRunner.TABLE;
-import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.buildSpaceTableIndexQueries;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.here.xyz.connectors.ErrorResponseException;
@@ -36,7 +32,6 @@ import com.here.xyz.connectors.runtime.ConnectorRuntime;
 import com.here.xyz.events.Event;
 import com.here.xyz.events.GetFeaturesByIdEvent;
 import com.here.xyz.events.ModifyFeaturesEvent;
-import com.here.xyz.events.ModifySpaceEvent;
 import com.here.xyz.models.geojson.implementation.Feature;
 import com.here.xyz.models.geojson.implementation.FeatureCollection;
 import com.here.xyz.models.geojson.implementation.Properties;
@@ -44,26 +39,20 @@ import com.here.xyz.models.geojson.implementation.XyzNamespace;
 import com.here.xyz.psql.config.ConnectorParameters;
 import com.here.xyz.psql.query.ExtendedSpace;
 import com.here.xyz.psql.query.GetFeaturesById;
-import com.here.xyz.psql.query.ModifySpace;
 import com.here.xyz.psql.query.XyzEventBasedQueryRunner;
 import com.here.xyz.psql.query.helpers.FetchExistingIds;
 import com.here.xyz.psql.query.helpers.FetchExistingIds.FetchIdsInput;
-import com.here.xyz.psql.query.helpers.TableExists;
-import com.here.xyz.psql.query.helpers.TableExists.Table;
 import com.here.xyz.psql.query.helpers.versioning.GetNextVersion;
 import com.here.xyz.psql.tools.ECPSTool;
 import com.here.xyz.responses.ErrorResponse;
 import com.here.xyz.responses.XyzError;
 import com.here.xyz.responses.XyzResponse;
 import com.here.xyz.util.db.DatabaseSettings;
-import com.here.xyz.util.db.SQLQuery;
 import com.here.xyz.util.db.datasource.CachedPooledDataSources;
 import com.here.xyz.util.db.datasource.DataSourceProvider;
 import java.sql.BatchUpdateException;
 import java.sql.Connection;
-import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -83,7 +72,6 @@ public abstract class DatabaseHandler extends StorageConnector {
     private static final Logger logger = LogManager.getLogger();
     private static final String MAINTENANCE_ENDPOINT = "MAINTENANCE_SERVICE_ENDPOINT";
 
-    public static final String HEAD_TABLE_SUFFIX = "_head";
     /**
      * Lambda Execution Time = 25s. We are actively canceling queries after STATEMENT_TIMEOUT_SECONDS
      * So if we receive a timeout prior 25s-STATEMENT_TIMEOUT_SECONDS the cancellation comes from
@@ -92,13 +80,6 @@ public abstract class DatabaseHandler extends StorageConnector {
     static final int MIN_REMAINING_TIME_FOR_RETRY_SECONDS = 3;
 
     private static String INCLUDE_OLD_STATES = "includeOldStates"; // read from event params
-
-    public static final long PARTITION_SIZE = 100_000;
-
-    /**
-     * Current event.
-     */
-    private Event event;
 
     /**
      * The dbMaintainer for the current event.
@@ -117,7 +98,6 @@ public abstract class DatabaseHandler extends StorageConnector {
 
     @Override
     protected void initialize(Event event) {
-        this.event = event;
         String connectorId = traceItem.getConnectorId();
         ConnectorParameters connectorParams = ConnectorParameters.fromEvent(event);
 
@@ -174,14 +154,6 @@ public abstract class DatabaseHandler extends StorageConnector {
             }
         }
         return false;
-    }
-
-    protected XyzResponse executeModifySpace(ModifySpaceEvent event) throws SQLException, ErrorResponseException {
-        if (event.getSpaceDefinition() != null && event.getOperation() == CREATE)
-            //Create Space Table
-            ensureSpace();
-
-        return write(new ModifySpace(event).withDbMaintainer(dbMaintainer));
     }
 
     protected XyzResponse executeModifyFeatures(ModifyFeaturesEvent event) throws Exception {
@@ -427,162 +399,14 @@ public abstract class DatabaseHandler extends StorageConnector {
       return ids;
     }
 
-    private static boolean _advisory(String key, Connection connection, boolean lock, boolean block) throws SQLException
-    {
-     boolean cStateFlag = connection.getAutoCommit();
-     connection.setAutoCommit(true);
-     try (Statement stmt = connection.createStatement()) {
-         ResultSet rs = stmt.executeQuery("SELECT pg_" + (lock && !block ? "try_" : "") + "advisory_" + (lock ? "" : "un") + "lock(('x' || left(md5('" + key + "'), 15))::bit(60)::bigint)");
-         if (!block && rs.next())
-             return rs.getBoolean(1);
-         return false;
-     }
-     finally {
-         connection.setAutoCommit(cStateFlag);
-     }
-    }
-
-    private static void advisoryLock(String key, Connection connection ) throws SQLException { _advisory(key,connection,true, true); }
-
-    private static void advisoryUnlock(String key, Connection connection ) throws SQLException { _advisory(key,connection,false, true); }
-
     private static boolean isForExtendingSpace(Event event) {
         return event.getParams() != null && event.getParams().containsKey("extends");
-    }
-
-    //TODO: Move the following into ModifySpace QR
-    private void ensureSpace() throws SQLException, ErrorResponseException {
-        // Note: We can assume that when the table exists, the postgis extensions are installed.
-        final String tableName = XyzEventBasedQueryRunner.readTableFromEvent(event);
-
-        try (final Connection connection = dataSourceProvider.getWriter().getConnection()) {
-            advisoryLock( tableName, connection );
-            boolean cStateFlag = connection.getAutoCommit();
-            try {
-
-                if (cStateFlag)
-                  connection.setAutoCommit(false);
-
-                try (Statement stmt = connection.createStatement()) {
-                    createSpaceStatement(stmt, event);
-
-                    stmt.setQueryTimeout(calculateTimeout());
-                    stmt.executeBatch();
-                    connection.commit();
-                    logger.debug("{} Successfully created table '{}' for space id '{}'", traceItem, tableName, event.getSpace());
-                }
-            } catch (Exception e) {
-                logger.error("{} Failed to create table '{}' for space id: '{}': {}", traceItem, tableName, event.getSpace(), e);
-                connection.rollback();
-                //Check if the table was created in the meantime, by another instance.
-                boolean tableExists = run(new TableExists(new Table(getDatabaseSettings().getSchema(),
-                    XyzEventBasedQueryRunner.readTableFromEvent(event))));
-                if (tableExists)
-                    return;
-                throw new SQLException("Missing table \"" + tableName + "\" and creation failed: " + e.getMessage(), e);
-            } finally {
-                advisoryUnlock( tableName, connection );
-                if (cStateFlag)
-                 connection.setAutoCommit(true);
-            }
-        }
     }
 
     public static int readVersionsToKeep(Event event) {
         if (event.getParams() == null || !event.getParams().containsKey("versionsToKeep"))
             return DEFAULT_VERSIONS_TO_KEEP;
         return (int) event.getParams().get("versionsToKeep");
-    }
-
-    private void alterColumnStorage(Statement stmt, String schema, String tableName) throws SQLException {
-        stmt.addBatch(new SQLQuery("ALTER TABLE ${schema}.${table} "
-            + "ALTER COLUMN id SET STORAGE MAIN, "
-            + "ALTER COLUMN jsondata SET STORAGE MAIN, "
-            + "ALTER COLUMN geo SET STORAGE MAIN, "
-            + "ALTER COLUMN operation SET STORAGE PLAIN, "
-            + "ALTER COLUMN next_version SET STORAGE PLAIN, "
-            + "ALTER COLUMN version SET STORAGE PLAIN, "
-            + "ALTER COLUMN i SET STORAGE PLAIN, "
-            + "ALTER COLUMN author SET STORAGE MAIN, "
-
-            + "ALTER COLUMN id SET COMPRESSION lz4, "
-            + "ALTER COLUMN jsondata SET COMPRESSION lz4, "
-            + "ALTER COLUMN geo SET COMPRESSION lz4, "
-            + "ALTER COLUMN author SET COMPRESSION lz4;")
-            .withVariable(SCHEMA, schema)
-            .withVariable(TABLE, tableName)
-            .substitute()
-            .text());
-    }
-
-    private void createHeadPartition(Statement stmt, String schema, String rootTable) throws SQLException {
-        SQLQuery q = new SQLQuery("CREATE TABLE IF NOT EXISTS ${schema}.${partitionTable} "
-            + "PARTITION OF ${schema}.${rootTable} FOR VALUES FROM (max_bigint()) TO (MAXVALUE)")
-            .withVariable(SCHEMA, schema)
-            .withVariable("rootTable", rootTable)
-            .withVariable("partitionTable", rootTable + HEAD_TABLE_SUFFIX);
-
-        stmt.addBatch(q.substitute().text());
-    }
-
-    private void createHistoryPartition(Statement stmt, String schema, String rootTable, long partitionNo) throws SQLException {
-        SQLQuery q = new SQLQuery("SELECT xyz_create_history_partition('" + schema + "', '" + rootTable + "', " + partitionNo + ", " + PARTITION_SIZE + ")");
-        stmt.addBatch(q.substitute().text());
-    }
-
-    private void createSpaceTableStatement(Statement stmt, String schema, String table, boolean withIndices, String existingSerial) throws SQLException {
-        String tableFields = "id TEXT NOT NULL, "
-                + "version BIGINT NOT NULL, "
-                + "next_version BIGINT NOT NULL DEFAULT 9223372036854775807::BIGINT, "
-                + "operation CHAR NOT NULL, "
-                + "author TEXT, "
-                + "jsondata JSONB, "
-                + "geo geometry(GeometryZ, 4326), "
-                + "i " + (existingSerial == null ? "BIGSERIAL" : "BIGINT NOT NULL DEFAULT nextval('${schema}.${existingSerial}')")
-                + ", CONSTRAINT ${constraintName} PRIMARY KEY (id, version, next_version)";
-
-        SQLQuery createTable = new SQLQuery("CREATE TABLE IF NOT EXISTS ${schema}.${table} (${{tableFields}}) PARTITION BY RANGE (next_version)")
-            .withQueryFragment("tableFields", tableFields)
-            .withVariable(SCHEMA, schema)
-            .withVariable(TABLE, table)
-            .withVariable("constraintName", table + "_primKey");
-
-        if (existingSerial != null)
-            createTable.setVariable("existingSerial", existingSerial);
-
-        stmt.addBatch(createTable.substitute().text());
-
-        //Add new way of using different storage-type for columns
-        alterColumnStorage(stmt, schema, table);
-
-        if (withIndices)
-            createIndices(stmt, schema, table);
-    }
-
-    private void createSpaceStatement(Statement stmt, Event event) throws SQLException {
-        String schema = getDatabaseSettings().getSchema();
-        String table = XyzEventBasedQueryRunner.readTableFromEvent(event);
-
-        createSpaceTableStatement(stmt, schema, table, true, null);
-        createHeadPartition(stmt, schema, table);
-        createHistoryPartition(stmt, schema, table, 0L);
-
-        stmt.addBatch(buildCreateSequenceQuery(schema, table, "version").substitute().text());
-
-        stmt.setQueryTimeout(calculateTimeout());
-    }
-
-    private static SQLQuery buildCreateSequenceQuery(String schema, String table, String columnName) {
-        return new SQLQuery("CREATE SEQUENCE IF NOT EXISTS ${schema}.${sequence} MINVALUE 0 OWNED BY ${schema}.${table}.${columnName}")
-            .withVariable(SCHEMA, schema)
-            .withVariable(TABLE, table)
-            .withVariable("sequence", table + "_" + columnName + "_seq")
-            .withVariable("columnName", columnName);
-    }
-
-    private static void createIndices(Statement stmt, String schema, String table) throws SQLException {
-        for (SQLQuery indexCreationQuery : buildSpaceTableIndexQueries(schema, table))
-            stmt.addBatch(indexCreationQuery.substitute().text());
     }
 
     static int calculateTimeout() throws SQLException{

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseWriter.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseWriter.java
@@ -19,14 +19,14 @@
 
 package com.here.xyz.psql;
 
-import static com.here.xyz.psql.DatabaseHandler.PARTITION_SIZE;
+import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.PARTITION_SIZE;
 import static com.here.xyz.psql.DatabaseWriter.ModificationType.DELETE;
 import static com.here.xyz.psql.DatabaseWriter.ModificationType.INSERT;
 import static com.here.xyz.psql.DatabaseWriter.ModificationType.INSERT_HIDE_COMPOSITE;
 import static com.here.xyz.psql.DatabaseWriter.ModificationType.UPDATE;
 import static com.here.xyz.psql.DatabaseWriter.ModificationType.UPDATE_HIDE_COMPOSITE;
-import static com.here.xyz.psql.QueryRunner.SCHEMA;
-import static com.here.xyz.psql.QueryRunner.TABLE;
+import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.SCHEMA;
+import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.TABLE;
 import static com.here.xyz.util.db.SQLQuery.XyzSqlErrors.XYZ_CONFLICT;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -273,7 +273,7 @@ public class DatabaseWriter {
             }
 
             if (transactional) {
-                executeBatchesAndCheckOnFailures(dbh, idList, modificationQuery.prepareStatement(connection), fails, event, action);
+                executeBatchesAndCheckOnFailures(idList, modificationQuery.prepareStatement(connection), fails, event, action);
 
                 if (fails.size() > 0) {
                     logException(null, action, event);
@@ -383,10 +383,9 @@ public class DatabaseWriter {
         return ConnectorRuntime.getInstance().getStreamId();
     }
 
-    private static void executeBatchesAndCheckOnFailures(DatabaseHandler dbh, List<String> idList, PreparedStatement batchStmt,
+    private static void executeBatchesAndCheckOnFailures(List<String> idList, PreparedStatement batchStmt,
         List<FeatureCollection.ModificationFailure> fails,
         ModifyFeaturesEvent event, ModificationType type) throws SQLException {
-        int[] batchStmtResult;
 
         try {
             if (idList.size() > 0) {

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/PSQLXyzConnector.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/PSQLXyzConnector.java
@@ -58,6 +58,7 @@ import com.here.xyz.psql.query.IterateChangesets;
 import com.here.xyz.psql.query.IterateFeatures;
 import com.here.xyz.psql.query.IterateFeaturesSorted;
 import com.here.xyz.psql.query.LoadFeatures;
+import com.here.xyz.psql.query.ModifySpace;
 import com.here.xyz.psql.query.ModifySubscription;
 import com.here.xyz.psql.query.SearchForFeatures;
 import com.here.xyz.psql.query.XyzEventBasedQueryRunner;
@@ -287,18 +288,23 @@ public class PSQLXyzConnector extends DatabaseHandler {
 
   @Override
   protected XyzResponse processModifySpaceEvent(ModifySpaceEvent event) throws Exception {
-    try{
+    try {
       logger.info("{} Received ModifySpaceEvent", traceItem);
 
       if (event.isDryRun())
         return new SuccessResponse().withStatus("OK");
 
-      this.validateModifySpaceEvent(event);
+      validateModifySpaceEvent(event);
 
-      return executeModifySpace(event);
-    }catch (SQLException e){
+      XyzResponse response = write(new ModifySpace(event).withDbMaintainer(dbMaintainer));
+      logger.debug("{} Successfully created table for space id '{}'", traceItem, event.getSpace());
+      return response;
+    }
+    catch (SQLException e) {
+      logger.error("{} Failed to create table for space id: '{}': {}", traceItem, event.getSpace(), e);
       return checkSQLException(e, XyzEventBasedQueryRunner.readTableFromEvent(event));
-    }finally {
+    }
+    finally {
       logger.info("{} Finished ModifySpaceEvent", traceItem);
     }
   }

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/QueryRunner.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/QueryRunner.java
@@ -42,8 +42,6 @@ import org.apache.logging.log4j.Logger;
 public abstract class QueryRunner<E extends Object, R extends Object> implements ResultSetHandler<R> {
 
   private static final Logger logger = LogManager.getLogger();
-  protected static final String SCHEMA = "schema";
-  protected static final String TABLE = "table";
   private static final int MIN_REMAINING_TIME_FOR_RESULT_HANDLING = 2;
   private SQLQuery query;
   private boolean useReadReplica;
@@ -83,7 +81,8 @@ public abstract class QueryRunner<E extends Object, R extends Object> implements
   }
 
   protected R write(DataSourceProvider dataSourceProvider) throws SQLException, ErrorResponseException {
-    return handleWrite(prepareQuery().write(dataSourceProvider));
+    SQLQuery query = prepareQuery();
+    return handleWrite(query.isBatch() ? query.writeBatch(dataSourceProvider) : new int[]{query.write(dataSourceProvider)});
   }
 
   public final R write() throws SQLException, ErrorResponseException {
@@ -104,7 +103,7 @@ public abstract class QueryRunner<E extends Object, R extends Object> implements
   @Override
   public abstract R handle(ResultSet rs) throws SQLException;
 
-  protected R handleWrite(int rowCount) throws ErrorResponseException {
+  protected R handleWrite(int[] rowCounts) throws ErrorResponseException {
     return null;
   }
 

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/DeleteChangesets.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/DeleteChangesets.java
@@ -53,8 +53,8 @@ public class DeleteChangesets extends XyzQueryRunner<DeleteChangesetsEvent, Succ
   }
 
   @Override
-  protected SuccessResponse handleWrite(int rowCount) throws ErrorResponseException {
-    if (rowCount == 0)
+  protected SuccessResponse handleWrite(int[] rowCounts) throws ErrorResponseException {
+    if (rowCounts[0] == 0)
       throw new ErrorResponseException(ILLEGAL_ARGUMENT, "Version < '"+event.getRequestedMinVersion()+"' is already deleted!");
     return new SuccessResponse();
   }

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetChangesetStatistics.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetChangesetStatistics.java
@@ -19,10 +19,14 @@
 
 package com.here.xyz.psql.query;
 
+import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.SCHEMA;
+import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.TABLE;
+
 import com.here.xyz.connectors.ErrorResponseException;
 import com.here.xyz.events.GetChangesetStatisticsEvent;
 import com.here.xyz.responses.ChangesetsStatisticsResponse;
 import com.here.xyz.util.db.SQLQuery;
+import com.here.xyz.util.db.pg.XyzSpaceTableHelper;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeatures.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeatures.java
@@ -25,6 +25,8 @@ import static com.here.xyz.models.hub.Ref.HEAD;
 import static com.here.xyz.psql.DatabaseWriter.ModificationType.DELETE;
 import static com.here.xyz.psql.DatabaseWriter.ModificationType.INSERT_HIDE_COMPOSITE;
 import static com.here.xyz.psql.DatabaseWriter.ModificationType.UPDATE_HIDE_COMPOSITE;
+import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.SCHEMA;
+import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.TABLE;
 
 import com.here.xyz.connectors.ErrorResponseException;
 import com.here.xyz.events.ContextAwareEvent;
@@ -35,6 +37,7 @@ import com.here.xyz.psql.DatabaseWriter.ModificationType;
 import com.here.xyz.psql.query.helpers.FeatureResultSetHandler;
 import com.here.xyz.responses.XyzResponse;
 import com.here.xyz.util.db.SQLQuery;
+import com.here.xyz.util.db.pg.XyzSpaceTableHelper;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeaturesByBBox.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeaturesByBBox.java
@@ -22,7 +22,9 @@ package com.here.xyz.psql.query;
 import static com.here.xyz.events.GetFeaturesByTileEvent.ResponseType.GEO_JSON;
 import static com.here.xyz.events.GetFeaturesByTileEvent.ResponseType.MVT;
 import static com.here.xyz.events.GetFeaturesByTileEvent.ResponseType.MVT_FLATTENED;
-import static com.here.xyz.psql.DatabaseHandler.HEAD_TABLE_SUFFIX;
+import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.HEAD_TABLE_SUFFIX;
+import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.SCHEMA;
+import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.TABLE;
 
 import com.here.xyz.connectors.ErrorResponseException;
 import com.here.xyz.events.GetFeaturesByBBoxEvent;
@@ -37,6 +39,7 @@ import com.here.xyz.psql.tools.DhString;
 import com.here.xyz.responses.BinaryResponse;
 import com.here.xyz.responses.XyzResponse;
 import com.here.xyz.util.db.SQLQuery;
+import com.here.xyz.util.db.pg.XyzSpaceTableHelper;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Map;

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeaturesByBBoxClustered.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeaturesByBBoxClustered.java
@@ -20,8 +20,9 @@
 package com.here.xyz.psql.query;
 
 import static com.here.xyz.events.GetFeaturesByTileEvent.ResponseType.GEO_JSON;
-import static com.here.xyz.psql.DatabaseHandler.HEAD_TABLE_SUFFIX;
+import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.HEAD_TABLE_SUFFIX;
 import static com.here.xyz.responses.XyzError.ILLEGAL_ARGUMENT;
+import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.SCHEMA;
 
 import com.google.common.collect.Streams;
 import com.here.xyz.connectors.ErrorResponseException;
@@ -33,6 +34,7 @@ import com.here.xyz.psql.factory.TweaksSQL;
 import com.here.xyz.psql.tools.DhString;
 import com.here.xyz.responses.XyzResponse;
 import com.here.xyz.util.db.SQLQuery;
+import com.here.xyz.util.db.pg.XyzSpaceTableHelper;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Arrays;

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetStatistics.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetStatistics.java
@@ -19,6 +19,9 @@
 
 package com.here.xyz.psql.query;
 
+import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.SCHEMA;
+import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.TABLE;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.here.xyz.XyzSerializable;
@@ -32,6 +35,7 @@ import com.here.xyz.responses.StatisticsResponse;
 import com.here.xyz.responses.StatisticsResponse.Value;
 import com.here.xyz.util.db.SQLQuery;
 import com.here.xyz.util.db.datasource.DataSourceProvider;
+import com.here.xyz.util.db.pg.XyzSpaceTableHelper;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/IterateChangesets.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/IterateChangesets.java
@@ -19,6 +19,10 @@
 
 package com.here.xyz.psql.query;
 
+import static com.here.xyz.responses.XyzError.ILLEGAL_ARGUMENT;
+import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.SCHEMA;
+import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.TABLE;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.here.xyz.connectors.ErrorResponseException;
@@ -31,6 +35,7 @@ import com.here.xyz.responses.changesets.Changeset;
 import com.here.xyz.responses.changesets.ChangesetCollection;
 import com.here.xyz.util.db.SQLQuery;
 import com.here.xyz.util.db.datasource.DataSourceProvider;
+import com.here.xyz.util.db.pg.XyzSpaceTableHelper;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/IterateFeatures.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/IterateFeatures.java
@@ -19,6 +19,9 @@
 
 package com.here.xyz.psql.query;
 
+import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.SCHEMA;
+import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.TABLE;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.here.xyz.connectors.ErrorResponseException;
@@ -28,6 +31,7 @@ import com.here.xyz.models.geojson.implementation.FeatureCollection;
 import com.here.xyz.psql.tools.DhString;
 import com.here.xyz.psql.tools.ECPSTool;
 import com.here.xyz.util.db.SQLQuery;
+import com.here.xyz.util.db.pg.XyzSpaceTableHelper;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/IterateFeaturesSorted.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/IterateFeaturesSorted.java
@@ -19,6 +19,9 @@
 
 package com.here.xyz.psql.query;
 
+import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.SCHEMA;
+import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.TABLE;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -37,6 +40,7 @@ import com.here.xyz.psql.tools.ECPSTool;
 import com.here.xyz.responses.XyzError;
 import com.here.xyz.util.db.SQLQuery;
 import com.here.xyz.util.db.datasource.DataSourceProvider;
+import com.here.xyz.util.db.pg.XyzSpaceTableHelper;
 import java.security.GeneralSecurityException;
 import java.sql.ResultSet;
 import java.sql.SQLException;

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/ModifySubscription.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/ModifySubscription.java
@@ -24,6 +24,8 @@ import static com.here.xyz.events.ModifySubscriptionEvent.Operation.DELETE;
 import static com.here.xyz.events.ModifySubscriptionEvent.Operation.UPDATE;
 import static com.here.xyz.psql.query.ModifySpace.SPACE_META_TABLE_FQN;
 import static com.here.xyz.responses.XyzError.EXCEPTION;
+import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.SCHEMA;
+import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.TABLE;
 
 import com.here.xyz.connectors.ErrorResponseException;
 import com.here.xyz.events.ModifySubscriptionEvent;
@@ -61,7 +63,7 @@ public class ModifySubscription extends XyzQueryRunner<ModifySubscriptionEvent, 
   }
 
   @Override
-  protected FeatureCollection handleWrite(int rowCount) {
+  protected FeatureCollection handleWrite(int[] rowCounts) {
     //TODO: Fix return type of this operation should not be a FeatureCollection but simply a SuccessResponse
     return new FeatureCollection().withCount(1L);
   }

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/bbox/GetSamplingStrengthEstimation.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/bbox/GetSamplingStrengthEstimation.java
@@ -20,6 +20,7 @@
 package com.here.xyz.psql.query.bbox;
 
 import static com.here.xyz.psql.query.GetFeaturesByBBox.getTileFromBbox;
+import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.SCHEMA;
 
 import com.here.xyz.connectors.ErrorResponseException;
 import com.here.xyz.events.GetFeaturesByBBoxEvent;
@@ -30,6 +31,7 @@ import com.here.xyz.psql.query.XyzEventBasedQueryRunner;
 import com.here.xyz.psql.query.bbox.GetSamplingStrengthEstimation.SamplingStrengthEstimation;
 import com.here.xyz.psql.tools.DhString;
 import com.here.xyz.util.db.SQLQuery;
+import com.here.xyz.util.db.pg.XyzSpaceTableHelper;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/helpers/FetchExistingIds.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/helpers/FetchExistingIds.java
@@ -19,10 +19,14 @@
 
 package com.here.xyz.psql.query.helpers;
 
+import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.SCHEMA;
+import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.TABLE;
+
 import com.here.xyz.connectors.ErrorResponseException;
 import com.here.xyz.psql.QueryRunner;
 import com.here.xyz.psql.query.helpers.FetchExistingIds.FetchIdsInput;
 import com.here.xyz.util.db.SQLQuery;
+import com.here.xyz.util.db.pg.XyzSpaceTableHelper;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/helpers/GetIndexList.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/helpers/GetIndexList.java
@@ -19,6 +19,9 @@
 
 package com.here.xyz.psql.query.helpers;
 
+import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.SCHEMA;
+import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.TABLE;
+
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.here.xyz.XyzSerializable;
 import com.here.xyz.connectors.ErrorResponseException;
@@ -26,6 +29,7 @@ import com.here.xyz.psql.QueryRunner;
 import com.here.xyz.psql.query.ModifySpace;
 import com.here.xyz.util.db.SQLQuery;
 import com.here.xyz.util.db.datasource.DataSourceProvider;
+import com.here.xyz.util.db.pg.XyzSpaceTableHelper;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/helpers/GetTablesWithColumn.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/helpers/GetTablesWithColumn.java
@@ -19,6 +19,8 @@
 
 package com.here.xyz.psql.query.helpers;
 
+import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.SCHEMA;
+
 import com.here.xyz.connectors.ErrorResponseException;
 import com.here.xyz.psql.QueryRunner;
 import com.here.xyz.psql.query.helpers.GetTablesWithColumn.GetTablesWithColumnInput;
@@ -46,7 +48,7 @@ public class GetTablesWithColumn extends QueryRunner<GetTablesWithColumnInput, L
         + "t.table_name != 'spatial_ref_sys' AND "
         + "LIMIT #{limit}")
         .withNamedParameter("column", input.columnName)
-        .withNamedParameter("schema", getSchema())
+        .withNamedParameter(SCHEMA, getSchema())
         .withNamedParameter("limit", input.limit);
   }
 

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/helpers/TableExists.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/helpers/TableExists.java
@@ -19,6 +19,9 @@
 
 package com.here.xyz.psql.query.helpers;
 
+import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.SCHEMA;
+import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.TABLE;
+
 import com.here.xyz.connectors.ErrorResponseException;
 import com.here.xyz.psql.QueryRunner;
 import com.here.xyz.psql.query.helpers.TableExists.Table;
@@ -37,9 +40,9 @@ public class TableExists extends QueryRunner<Table, Boolean> {
 
   @Override
   protected SQLQuery buildQuery(Table table) throws SQLException, ErrorResponseException {
-    return new SQLQuery("SELECT FROM pg_tables WHERE schemaname = #{schema} AND tablename = #{tableName}")
-        .withNamedParameter("schema", table.schema)
-        .withNamedParameter("tableName", table.tableName);
+    return new SQLQuery("SELECT FROM pg_tables WHERE schemaname = #{schema} AND tablename = #{table}")
+        .withNamedParameter(SCHEMA, table.schema)
+        .withNamedParameter(TABLE, table.tableName);
   }
 
   @Override

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/helpers/versioning/GetHeadVersion.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/helpers/versioning/GetHeadVersion.java
@@ -19,6 +19,9 @@
 
 package com.here.xyz.psql.query.helpers.versioning;
 
+import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.SCHEMA;
+import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.TABLE;
+
 import com.here.xyz.connectors.ErrorResponseException;
 import com.here.xyz.events.Event;
 import com.here.xyz.psql.query.XyzEventBasedQueryRunner;

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/helpers/versioning/GetMinAvailableVersion.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/helpers/versioning/GetMinAvailableVersion.java
@@ -20,11 +20,14 @@
 package com.here.xyz.psql.query.helpers.versioning;
 
 import static com.here.xyz.psql.query.ModifySpace.SPACE_META_TABLE_FQN;
+import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.SCHEMA;
+import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.TABLE;
 
 import com.here.xyz.connectors.ErrorResponseException;
 import com.here.xyz.events.Event;
 import com.here.xyz.psql.query.XyzEventBasedQueryRunner;
 import com.here.xyz.util.db.SQLQuery;
+import com.here.xyz.util.db.pg.XyzSpaceTableHelper;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/helpers/versioning/GetNextVersion.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/helpers/versioning/GetNextVersion.java
@@ -19,10 +19,13 @@
 
 package com.here.xyz.psql.query.helpers.versioning;
 
+import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.SCHEMA;
+
 import com.here.xyz.connectors.ErrorResponseException;
 import com.here.xyz.events.Event;
 import com.here.xyz.psql.query.XyzEventBasedQueryRunner;
 import com.here.xyz.util.db.SQLQuery;
+import com.here.xyz.util.db.pg.XyzSpaceTableHelper;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/helpers/versioning/SetVersion.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/helpers/versioning/SetVersion.java
@@ -20,6 +20,7 @@
 package com.here.xyz.psql.query.helpers.versioning;
 
 import static com.here.xyz.psql.query.helpers.versioning.GetNextVersion.VERSION_SEQUENCE_SUFFIX;
+import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.SCHEMA;
 
 import com.here.xyz.connectors.ErrorResponseException;
 import com.here.xyz.events.ModifyFeaturesEvent;

--- a/xyz-util/src/main/java/com/here/xyz/util/db/SQLQuery.java
+++ b/xyz-util/src/main/java/com/here/xyz/util/db/SQLQuery.java
@@ -21,6 +21,8 @@ package com.here.xyz.util.db;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_DEFAULT;
 import static com.here.xyz.util.db.SQLQuery.XyzSqlErrors.XYZ_FAILED_ATTEMPT;
+import static com.here.xyz.util.db.pg.LockHelper.advisoryLock;
+import static com.here.xyz.util.db.pg.LockHelper.advisoryUnlock;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -31,6 +33,7 @@ import com.mchange.v2.c3p0.ComboPooledDataSource;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -71,6 +74,7 @@ public class SQLQuery {
   private Map<String, String> variables;
   private Map<String, SQLQuery> queryFragments;
   private boolean async = false;
+  private String lock;
   private int timeout = Integer.MAX_VALUE;
   private int maximumRetries;
   private HashMap<String, List<Integer>> namedParams2Positions = new HashMap<>();
@@ -79,6 +83,7 @@ public class SQLQuery {
   private Map<String, String> labels = new HashMap<>();
   private static List<ExecutionContext> executions = new CopyOnWriteArrayList<>();
   private boolean labelsEnabled = true;
+  private List<SQLQuery> queryBatch;
 
   public SQLQuery(String text) {
     if (text != null)
@@ -124,6 +129,64 @@ public class SQLQuery {
   }
 
   /**
+   * Returns whether this query is a batch of queries which can be executed
+   * all at once by calling {@link #writeBatch(DataSourceProvider)}.
+   *
+   * @return True, if this query is a query batch
+   */
+  public boolean isBatch() {
+    return queryBatch != null && !queryBatch.isEmpty();
+  }
+
+  /**
+   * Adds another query to the collection of queries which form this query batch.
+   * Calling the method {@link #writeBatch(DataSourceProvider)} will cause all queries of this query batch to be executed.
+   * Whether an SQLQuery object is a batch or not, can be checked by calling the method {@link #isBatch()}.
+   *
+   * @param query The query to be added to this query batch
+   */
+  public void addBatch(SQLQuery query) {
+    if (queryBatch == null)
+      queryBatch = new ArrayList<>();
+    queryBatch.add(query);
+  }
+
+  /**
+   * Creates a new SQLQuery, which is a query batch of all the provided SQL queries.
+   * All contained queries can be executed all at once by calling {@link #writeBatch(DataSourceProvider)}.
+   * Whether an SQLQuery object is a batch or not, can be checked by calling the method {@link #isBatch()}.
+   *
+   * @param queries The queries to be added to the batch
+   * @return An SQLQuery object which contains all the provided queries as batch
+   */
+  public static SQLQuery batchOf(List<SQLQuery> queries) {
+    if (queries.size() == 0)
+      throw new IllegalArgumentException("A batch of queries cannot be empty.");
+
+    SQLQuery result = null;
+    for (SQLQuery query : queries) {
+      if (result == null)
+        result = query;
+      else
+        result.addBatch(query);
+    }
+
+    return result;
+  }
+
+  /**
+   * Creates a new SQLQuery, which is a query batch of all the provided SQL queries.
+   * All contained queries can be executed all at once by calling {@link #writeBatch(DataSourceProvider)}.
+   * Whether an SQLQuery object is a batch or not, can be checked by calling the method {@link #isBatch()}.
+   *
+   * @param queries The queries to be added to the batch
+   * @return An SQLQuery object which contains all the provided queries as batch
+   */
+  public static SQLQuery batchOf(SQLQuery... queries) {
+    return batchOf(Arrays.asList(queries));
+  }
+
+  /**
    * Returns the query text as it has been defined for this SQLQuery.
    * Use method {@link #substitute()} prior to this method to retrieve to substitute all placeholders of this query.
    * @return
@@ -133,14 +196,23 @@ public class SQLQuery {
     return statement;
   }
 
+  private List<String> batchTexts() {
+    if (queryBatch == null || queryBatch.isEmpty())
+      throw new IllegalStateException("This SQLQuery is not a query batch.");
+    List<String> batchTexts = new ArrayList<>();
+    batchTexts.add(text());
+    batchTexts.addAll(queryBatch.stream().map(query -> query.text()).collect(Collectors.toList()));
+    return batchTexts;
+  }
+
   @Override
   public String toString() {
     return serializeForLogging();
   }
 
   /**
-   * NOTE: This implementation does not always produce an actually executable SQL query.
-   *  It's only used for logging purposes.
+   * NOTE: This implementation does not produce an actually executable SQL query for all cases.
+   *  So handle the usage of this method with care.
    * @return A representation of the query text with all parameters being replaced by
    *  their string-representation.
    */
@@ -150,12 +222,12 @@ public class SQLQuery {
     String text = text();
     for (Object paramValue : parameters()) {
       Pattern p = Pattern.compile("\\?");
-      text = text.replaceFirst(p.pattern(), paramValueToLoggingRepresentation(paramValue));
+      text = text.replaceFirst(p.pattern(), paramValueToString(paramValue));
     }
     return text;
   }
 
-  private String paramValueToLoggingRepresentation(Object paramValue) {
+  private String paramValueToString(Object paramValue) {
     if (paramValue == null)
       return "NULL";
     if (paramValue instanceof String)
@@ -168,7 +240,7 @@ public class SQLQuery {
       return paramValue + "::BOOLEAN";
     if (paramValue instanceof Object[] arrayValue)
       return "{" + Arrays.stream(arrayValue)
-          .map(elementValue -> paramValueToLoggingRepresentation(elementValue))
+          .map(elementValue -> paramValueToString(elementValue))
           .collect(Collectors.joining(",")) + "}";
     return paramValue.toString();
   }
@@ -211,12 +283,30 @@ public class SQLQuery {
     return parameters;
   }
 
-  public synchronized SQLQuery substitute() {
+  private List<List<Object>> batchParameters() {
+    if (queryBatch == null || queryBatch.isEmpty())
+      throw new IllegalStateException("This SQLQuery is not a query batch.");
+    List<List<Object>> batchParameters = new ArrayList<>();
+    batchParameters.add(parameters());
+    batchParameters.addAll(queryBatch.stream().map(query -> query.parameters()).collect(Collectors.toList()));
+    return batchParameters;
+  }
+
+  public SQLQuery substitute() {
+    substitute(!isBatch());
+    if (isBatch())
+      queryBatch.forEach(query -> query.substitute(false));
+
+    return this;
+  }
+
+  private synchronized SQLQuery substitute(boolean usePlaceholders) {
     initQueryId();
     replaceVars();
     replaceFragments();
-    replaceNamedParameters(!isAsync());
+    replaceNamedParameters(usePlaceholders && !isAsync());
     injectLabels();
+
     return this;
   }
 
@@ -268,7 +358,7 @@ public class SQLQuery {
     Pattern p = Pattern.compile("#\\{\\s*([^\\s\\}]+)\\s*\\}");
     Matcher m = p.matcher(text());
 
-    while(m.find()) {
+    while (m.find()) {
       String nParam = m.group(1);
       if (!namedParameters.containsKey(nParam))
         throw new IllegalArgumentException("sql: named Parameter ["+ nParam +"] missing");
@@ -284,15 +374,6 @@ public class SQLQuery {
 
     if (usePlaceholders)
       statement = m.replaceAll("?");
-  }
-
-  private String paramValueToString(Object paramValue) {
-    if (paramValue instanceof String)
-      return "'" + paramValue + "'";
-    if (paramValue instanceof Number)
-      return paramValue.toString();
-    throw new RuntimeException("Only strings or numeric values are allowed for parameters of async queries. Provided: "
-        + paramValue.getClass().getSimpleName());
   }
 
   private void replaceVars() {
@@ -516,14 +597,42 @@ public class SQLQuery {
     this.async = async;
   }
 
-  private String serializeForLogging() {
-    initQueryId();
-    return XyzSerializable.serialize(this);
-  }
-
   public SQLQuery withAsync(boolean async) {
     setAsync(async);
     return this;
+  }
+
+  /**
+   * The advisory lock key which was provided to be applied during the runtime of this query.
+   *
+   * @return The advisory lock key
+   */
+  public String getLock() {
+    return lock;
+  }
+
+  /**
+   * Can be used to apply an advisory lock on the provided lock key during the runtime of this query.
+   *
+   * @param lock The advisory lock key on which to apply the lock
+   */
+  public void setLock(String lock) {
+    this.lock = lock;
+  }
+
+  /**
+   * Can be used to apply an advisory lock on the provided lock key during the runtime of this query.
+   *
+   * @param lock The advisory lock key on which to apply the lock
+   */
+  public SQLQuery withLock(String lock) {
+    setLock(lock);
+    return this;
+  }
+
+  private String serializeForLogging() {
+    initQueryId();
+    return XyzSerializable.serialize(this);
   }
 
   public int getTimeout() {
@@ -646,72 +755,117 @@ public class SQLQuery {
     return null;
   }
 
+  /**
+   * If this query is a reading query, use this method to execute it on the database writer.
+   *
+   * @param dataSourceProvider The data source provider depicting the target database to execute the query
+   * @return Nothing, this method is just used for queries that do not produce a result or no result is needed
+   * @throws SQLException
+   */
   public void run(DataSourceProvider dataSourceProvider) throws SQLException {
     run(dataSourceProvider, false);
   }
 
+  /**
+   * If this query is a reading query, use this method to execute it on the database writer.
+   *
+   * @param dataSourceProvider The data source provider depicting the target database to execute the query
+   * @param handler The handler to process the ResultSet of the query execution
+   * @return The value which has been processed by the specified ResultSetHandler
+   * @param <R> The type of the return value being produced by the ResultSetHandler
+   * @throws SQLException
+   */
   public <R> R run(DataSourceProvider dataSourceProvider, ResultSetHandler<R> handler) throws SQLException {
     return run(dataSourceProvider, handler, false);
   }
 
+  /**
+   * If this query is a reading query, use this method to execute it on the database reader or writer.
+   *
+   * @param dataSourceProvider The data source provider depicting the target database to execute the query
+   * @param useReplica Whether to run on the reader of the data source provider
+   * @return Nothing, this method is just used for queries that do not produce a result or no result is needed
+   * @throws SQLException
+   */
   public void run(DataSourceProvider dataSourceProvider, boolean useReplica) throws SQLException {
     run(dataSourceProvider, rs -> null, useReplica);
   }
 
+  /**
+   * If this query is a reading query, use this method to execute it on the database reader or writer.
+   *
+   * @param dataSourceProvider The data source provider depicting the target database to execute the query
+   * @param handler The handler to process the ResultSet of the query execution
+   * @param useReplica Whether to run on the reader of the data source provider
+   * @return The value which has been processed by the specified ResultSetHandler
+   * @param <R> The type of the return value being produced by the ResultSetHandler
+   * @throws SQLException
+   */
   public <R> R run(DataSourceProvider dataSourceProvider, ResultSetHandler<R> handler, boolean useReplica) throws SQLException {
-    return (R) execute(dataSourceProvider, useReplica, handler, ExecutionOperation.QUERY,
+    return (R) execute(dataSourceProvider, handler, ExecutionOperation.QUERY,
         new ExecutionContext(getTimeout(), getMaximumRetries(), dataSourceProvider, useReplica));
   }
 
+  /**
+   * If this query is an updating query, use this method to execute it on the database writer.
+   *
+   * @param dataSourceProvider The data source provider depicting the target database to execute the query
+   * @return The update result (e.g. row counts)
+   * @throws SQLException
+   */
   public int write(DataSourceProvider dataSourceProvider) throws SQLException {
-    return (int) execute(dataSourceProvider, false, null, ExecutionOperation.UPDATE,
+    return (int) execute(dataSourceProvider, null, ExecutionOperation.UPDATE,
+        new ExecutionContext(getTimeout(), getMaximumRetries(), dataSourceProvider, false));
+  }
+
+  /**
+   * Executes all queries of a query batch at once on the database writer.
+   * Batches of queries can be created by using the methods {@link #addBatch(SQLQuery)},
+   * {@link #batchOf(SQLQuery...)} or {@link #batchOf(List)}.
+   *
+   * NOTE: This method will throw a {@link RuntimeException} if it is executed on a query which is not a batch.
+   * If a query is actually a batch of queries can be checked using the {@link #isBatch()} method.
+   *
+   * @param dataSourceProvider The data source provider depicting the target database to execute the query
+   * @return An array of update results (e.g. row counts)
+   * @throws SQLException
+   */
+  public int[] writeBatch(DataSourceProvider dataSourceProvider) throws SQLException {
+    return (int[]) execute(dataSourceProvider, null, ExecutionOperation.UPDATE_BATCH,
         new ExecutionContext(getTimeout(), getMaximumRetries(), dataSourceProvider, false));
   }
 
   private enum ExecutionOperation {
     QUERY,
-    UPDATE
+    UPDATE,
+    UPDATE_BATCH
   }
 
-  private Object execute(DataSourceProvider dataSourceProvider, boolean useReplica, ResultSetHandler<?> handler,
-      ExecutionOperation operation, ExecutionContext executionContext) throws SQLException {
+  private Object execute(DataSourceProvider dataSourceProvider, ResultSetHandler<?> handler, ExecutionOperation operation,
+      ExecutionContext executionContext) throws SQLException {
     logger.info("Executing SQLQuery {}", this);
-    String queryText = substitute().text();
-    List<Object> queryParameters = parameters();
+    substitute();
 
-    if (isAsync()) {
-      if (dataSourceProvider instanceof PooledDataSources pooledDataSources) {
-        SQLQuery asyncQuery = new SQLQuery("SELECT asyncify(#{query}, #{password})")
-            .withNamedParameter("query", queryText)
-            .withNamedParameter("password", pooledDataSources.getDatabaseSettings().getPassword());
-        queryText = asyncQuery.substitute().text();
-      }
-      else
-        throw new RuntimeException("Async SQLQueries must be performed using an instance of PooledDataSources as DataSourceProvider");
-    }
-
-    final DataSource dataSource = useReplica ? dataSourceProvider.getReader() : dataSourceProvider.getWriter();
-    StatementConfiguration statementConfig = executionContext.remainingQueryTimeout > 0
-        ? new StatementConfiguration.Builder().queryTimeout(executionContext.remainingQueryTimeout).build()
-        : null;
+    final DataSource dataSource = executionContext.useReplica ? dataSourceProvider.getReader() : dataSourceProvider.getWriter();
     executionContext.attemptExecution();
-    final QueryRunner runner = new QueryRunner(dataSource, statementConfig);
     try {
       logger.info("Sending query to database {} {}, substituted query-text: {}",
-          useReplica ? "reader" : "writer",
+          executionContext.useReplica ? "reader" : "writer",
           dataSourceProvider instanceof PooledDataSources pooledDataSources
               ? pooledDataSources.getDatabaseSettings().getId() : "unknown",
           replaceUnnamedParametersForLogging());
+
       return switch (operation) {
-        case QUERY -> runner.query(queryText, handler, queryParameters.toArray());
-        case UPDATE -> runner.update(queryText, queryParameters.toArray());
+        case QUERY -> executeQuery(dataSource, executionContext, handler);
+        case UPDATE -> executeUpdate(dataSource, executionContext);
+        case UPDATE_BATCH -> executeBatchUpdate(dataSource, executionContext);
       };
     }
     catch (SQLException e) {
       if (executionContext.mayRetry(e)) {
         logger.info("{} Retry Query permitted.", getQueryId());
         executionContext.addRetriedException(e);
-        return execute(dataSourceProvider, useReplica, handler, operation, executionContext);
+        return execute(dataSourceProvider, handler, operation, executionContext);
       }
       else
         throw e;
@@ -730,6 +884,75 @@ public class SQLQuery {
       logger.info("{} query time: {}ms, {}dataSource: {}", getQueryId(), overallTime, usedTimeMsg,
           dataSource instanceof ComboPooledDataSource comboPooledDataSource ? comboPooledDataSource.getJdbcUrl() : "n/a");
     }
+  }
+
+  private String prepareQueryText(ExecutionContext executionContext) {
+    String queryText = text();
+    if (isAsync()) {
+      if (executionContext.dataSourceProvider instanceof PooledDataSources pooledDataSources) {
+        SQLQuery asyncQuery = new SQLQuery("SELECT asyncify(#{query}, #{password})")
+            .withNamedParameter("query", queryText)
+            .withNamedParameter("password", pooledDataSources.getDatabaseSettings().getPassword());
+        queryText = asyncQuery.substitute().text();
+      }
+      else
+        throw new RuntimeException("Async SQLQueries must be performed using an instance of PooledDataSources as DataSourceProvider");
+    }
+    return queryText;
+  }
+
+  private int executeUpdate(DataSource dataSource, ExecutionContext executionContext) throws SQLException {
+    return getRunner(dataSource, executionContext).update(prepareQueryText(executionContext), parameters().toArray());
+  }
+
+  private Object executeQuery(DataSource dataSource, ExecutionContext executionContext, ResultSetHandler<?> handler) throws SQLException {
+    return getRunner(dataSource, executionContext).query(prepareQueryText(executionContext), handler, parameters().toArray());
+  }
+
+  private static QueryRunner getRunner(DataSource dataSource, ExecutionContext executionContext) {
+    StatementConfiguration statementConfig = executionContext.remainingQueryTimeout > 0
+        ? new StatementConfiguration.Builder().queryTimeout(executionContext.remainingQueryTimeout).build()
+        : null;
+    return new QueryRunner(dataSource, statementConfig);
+  }
+
+  private int[] executeBatchUpdate(DataSource dataSource, ExecutionContext executionContext) throws SQLException {
+    int[] batchResult;
+    try (final Connection connection = dataSource.getConnection()) {
+      if (getLock() != null)
+        advisoryLock(getLock(), connection);
+
+      boolean previousCommitState = connection.getAutoCommit();
+      try {
+        if (previousCommitState)
+          connection.setAutoCommit(false);
+
+        List<String> queryTexts = batchTexts();
+        List<List<Object>> params = batchParameters();
+        try (Statement stmt = connection.createStatement()) {
+          for (String queryText : queryTexts)
+            stmt.addBatch(queryText); //TODO: Use parameters
+
+          if (executionContext.remainingQueryTimeout > 0)
+            stmt.setQueryTimeout(executionContext.remainingQueryTimeout);
+
+          batchResult = stmt.executeBatch();
+          connection.commit();
+        }
+      }
+      catch (SQLException e) {
+        connection.rollback();
+        throw e;
+      }
+      finally {
+        if (getLock() != null)
+          advisoryUnlock(getLock(), connection);
+
+        if (previousCommitState)
+          connection.setAutoCommit(true);
+      }
+    }
+    return batchResult;
   }
 
   protected class ExecutionContext {
@@ -784,7 +1007,7 @@ public class SQLQuery {
     private boolean isRecoverable(Exception e) {
       if (e instanceof SQLException sqlEx && sqlEx.getSQLState() != null && (
           /*
-          If a timeout occurs right after the invocation it could be caused
+          If a timeout occurs right after the invocation, it could be caused
           by a serverless aurora scaling. Then we should retry again.
           57014 - query_canceled
           57P01 - admin_shutdown

--- a/xyz-util/src/main/java/com/here/xyz/util/db/pg/LockHelper.java
+++ b/xyz-util/src/main/java/com/here/xyz/util/db/pg/LockHelper.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2017-2024 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.xyz.util.db.pg;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+public class LockHelper {
+
+  private static boolean advisory(String key, Connection connection, boolean lock, boolean block) throws SQLException {
+    boolean previousCommitState = connection.getAutoCommit();
+    connection.setAutoCommit(true);
+    try (Statement stmt = connection.createStatement()) {
+      ResultSet rs = stmt.executeQuery("SELECT pg_" + (lock && !block ? "try_" : "") + "advisory_"
+          + (lock ? "" : "un") + "lock(('x' || left(md5('" + key + "'), 15))::bit(60)::bigint)");
+      if (!block && rs.next())
+        return rs.getBoolean(1);
+      return false;
+    }
+    finally {
+      connection.setAutoCommit(previousCommitState);
+    }
+  }
+
+  public static void advisoryLock(String key, Connection connection) throws SQLException {
+    advisory(key, connection, true, true);
+  }
+
+  public static void advisoryUnlock(String key, Connection connection) throws SQLException {
+    advisory(key, connection, false, true);
+  }
+}

--- a/xyz-util/src/main/java/com/here/xyz/util/db/pg/XyzSpaceTableHelper.java
+++ b/xyz-util/src/main/java/com/here/xyz/util/db/pg/XyzSpaceTableHelper.java
@@ -22,11 +22,17 @@ package com.here.xyz.util.db.pg;
 import static com.here.xyz.util.db.pg.IndexHelper.buildCreateIndexQuery;
 
 import com.here.xyz.util.db.SQLQuery;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
 public class XyzSpaceTableHelper {
+
+  public static final String SCHEMA = "schema";
+  public static final String TABLE = "table";
+  public static final String HEAD_TABLE_SUFFIX = "_head";
+  public static final long PARTITION_SIZE = 100_000;
 
   public static List<SQLQuery> buildSpaceTableIndexQueries(String schema, String table, SQLQuery queryComment) {
     return Arrays.asList(
@@ -45,11 +51,83 @@ public class XyzSpaceTableHelper {
     ).stream().map(q -> addQueryComment(q, queryComment)).collect(Collectors.toList());
   }
 
+  public static List<SQLQuery> buildCreateSpaceTableQueries(String schema, String table) {
+    List<SQLQuery> queries = new ArrayList<>();
+
+    queries.add(buildCreateSpaceTableQuery(schema, table));
+    queries.add(buildColumnStoragAttributesQuery(schema, table));
+    queries.addAll(buildSpaceTableIndexQueries(schema, table));
+    queries.add(buildCreateHeadPartitionQuery(schema, table));
+    queries.add(buildCreateHistoryPartitionQuery(schema, table, 0L));
+    queries.add(buildCreateSequenceQuery(schema, table, "version"));
+
+    return queries;
+  }
+
   public static List<SQLQuery> buildSpaceTableIndexQueries(String schema, String table) {
     return buildSpaceTableIndexQueries(schema, table, null);
   }
 
   private static SQLQuery addQueryComment(SQLQuery indexCreationQuery, SQLQuery queryComment) {
     return queryComment != null ? indexCreationQuery.withQueryFragment("queryComment", queryComment) : indexCreationQuery;
+  }
+
+  public static SQLQuery buildColumnStoragAttributesQuery(String schema, String tableName) {
+      return new SQLQuery("ALTER TABLE ${schema}.${table} "
+          + "ALTER COLUMN id SET STORAGE MAIN, "
+          + "ALTER COLUMN jsondata SET STORAGE MAIN, "
+          + "ALTER COLUMN geo SET STORAGE MAIN, "
+          + "ALTER COLUMN operation SET STORAGE PLAIN, "
+          + "ALTER COLUMN next_version SET STORAGE PLAIN, "
+          + "ALTER COLUMN version SET STORAGE PLAIN, "
+          + "ALTER COLUMN i SET STORAGE PLAIN, "
+          + "ALTER COLUMN author SET STORAGE MAIN, "
+
+          + "ALTER COLUMN id SET COMPRESSION lz4, "
+          + "ALTER COLUMN jsondata SET COMPRESSION lz4, "
+          + "ALTER COLUMN geo SET COMPRESSION lz4, "
+          + "ALTER COLUMN author SET COMPRESSION lz4;")
+          .withVariable(SCHEMA, schema)
+          .withVariable(TABLE, tableName);
+  }
+
+  public static SQLQuery buildCreateHeadPartitionQuery(String schema, String rootTable) {
+      return new SQLQuery("CREATE TABLE IF NOT EXISTS ${schema}.${partitionTable} "
+          + "PARTITION OF ${schema}.${rootTable} FOR VALUES FROM (max_bigint()) TO (MAXVALUE)")
+          .withVariable(SCHEMA, schema)
+          .withVariable("rootTable", rootTable)
+          .withVariable("partitionTable", rootTable + HEAD_TABLE_SUFFIX);
+  }
+
+  public static SQLQuery buildCreateHistoryPartitionQuery(String schema, String rootTable, long partitionNo) {
+      return new SQLQuery(
+          "SELECT xyz_create_history_partition('" + schema + "', '" + rootTable + "', " + partitionNo + ", " + PARTITION_SIZE + ")");
+  }
+
+  public static SQLQuery buildCreateSpaceTableQuery(String schema, String table) {
+      String tableFields = "id TEXT NOT NULL, "
+              + "version BIGINT NOT NULL, "
+              + "next_version BIGINT NOT NULL DEFAULT 9223372036854775807::BIGINT, "
+              + "operation CHAR NOT NULL, "
+              + "author TEXT, "
+              + "jsondata JSONB, "
+              + "geo geometry(GeometryZ, 4326), "
+              + "i BIGSERIAL"
+              + ", CONSTRAINT ${constraintName} PRIMARY KEY (id, version, next_version)";
+
+      SQLQuery createTable = new SQLQuery("CREATE TABLE IF NOT EXISTS ${schema}.${table} (${{tableFields}}) PARTITION BY RANGE (next_version)")
+          .withQueryFragment("tableFields", tableFields)
+          .withVariable(SCHEMA, schema)
+          .withVariable(TABLE, table)
+          .withVariable("constraintName", table + "_primKey");
+      return createTable;
+  }
+
+  public static SQLQuery buildCreateSequenceQuery(String schema, String table, String columnName) {
+      return new SQLQuery("CREATE SEQUENCE IF NOT EXISTS ${schema}.${sequence} MINVALUE 0 OWNED BY ${schema}.${table}.${columnName}")
+          .withVariable(SCHEMA, schema)
+          .withVariable(TABLE, table)
+          .withVariable("sequence", table + "_" + columnName + "_seq")
+          .withVariable("columnName", columnName);
   }
 }


### PR DESCRIPTION
- Introduce new methods in SQLQuery class to enable batch query executions: #addBatch(), #isBatch(), #batchOf(), #writeBatch()
- Move advisory lock helper methods into new class LockHelper in the util module so it can be re-used from multiple places
- Introduce advisory lock support for SQLQuery, by setting an arbitrary key to gather a lock from the database during the execution time of the query
- Move all XYZ space table creation related query builder methods into XyzSpaceTableHelper
- Move the execution of the table creation queries into the ModifySpace QR and use the new batch & lock support of the SQLQuery class for all involved queries
- Move some XYZ space table related constants into XyzSpaceTableHelper (SCHEMA, TABLE, PARTITION_SIZE, HEAD_TABLE_SUFFIX), so that all modules can access it