### PR TITLE
Simplify & streamline validation of version ref

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/httpconnector/config/JDBCExporter.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/httpconnector/config/JDBCExporter.java
@@ -38,12 +38,12 @@ import com.here.xyz.httpconnector.util.jobs.Export;
 import com.here.xyz.httpconnector.util.jobs.Export.ExportStatistic;
 import com.here.xyz.httpconnector.util.jobs.Export.Filters;
 import com.here.xyz.httpconnector.util.jobs.Job.CSVFormat;
-import com.here.xyz.httpconnector.util.jobs.datasets.DatasetDescription;
 import com.here.xyz.httpconnector.util.jobs.datasets.DatasetDescription.Space;
 import com.here.xyz.httpconnector.util.web.HubWebClient;
 import com.here.xyz.hub.connectors.models.Connector;
 import com.here.xyz.hub.rest.ApiParam;
 import com.here.xyz.models.geojson.coordinates.WKTHelper;
+import com.here.xyz.models.hub.Ref;
 import com.here.xyz.psql.query.GetFeatures;
 import com.here.xyz.psql.query.GetFeaturesByGeometry;
 import com.here.xyz.psql.query.SearchForFeatures;
@@ -185,7 +185,7 @@ public class JDBCExporter extends JdbcBasedHandler {
       throw new SQLException(e);
     }
 
-    if (spatialFilter != null && spatialFilter.isClipped()) 
+    if (spatialFilter != null && spatialFilter.isClipped())
     { SQLQuery geoFragment = new SQLQuery("ST_Intersection(ST_MakeValid(geo), ST_Buffer(ST_GeomFromText(#{wktGeometry})::geography, #{radius})::geometry) as geo");
                geoFragment.setNamedParameter("wktGeometry", WKTHelper.geometryToWKB(spatialFilter.getGeometry()));
                geoFragment.setNamedParameter("radius", spatialFilter.getRadius());
@@ -604,7 +604,7 @@ public class JDBCExporter extends JdbcBasedHandler {
         }
 
         if (targetVersion != null)
-            event.setRef(targetVersion);
+            event.setRef(new Ref(targetVersion));
 
         if (propertyFilter != null) {
             PropertiesQuery propertyQueryLists = HApiParam.Query.parsePropertiesQuery(propertyFilter, "", false);

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/FeatureApi.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/FeatureApi.java
@@ -104,14 +104,13 @@ public class FeatureApi extends SpaceBasedApi {
       final boolean skipCache = Query.getBoolean(context, SKIP_CACHE, false);
       final boolean force2D = Query.getBoolean(context, FORCE_2D, false);
       final SpaceContext spaceContext = getSpaceContext(context);
-      final String version = Query.getString(context, Query.VERSION, null);
       final String author = Query.getString(context, Query.AUTHOR, null);
 
       final GetFeaturesByIdEvent event = new GetFeaturesByIdEvent()
               .withIds(ids)
               .withSelection(Query.getSelection(context))
               .withForce2D(force2D)
-              .withRef(version)
+              .withRef(getRef(context))
               .withContext(spaceContext)
               .withAuthor(author);
 

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/FeatureQueryApi.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/FeatureQueryApi.java
@@ -56,6 +56,7 @@ import com.here.xyz.models.geojson.coordinates.BBox;
 import com.here.xyz.models.geojson.exceptions.InvalidGeometryException;
 import com.here.xyz.models.geojson.implementation.Geometry;
 import com.here.xyz.models.geojson.implementation.Point;
+import com.here.xyz.models.hub.Ref;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.ParsedHeaderValue;
 import io.vertx.ext.web.RoutingContext;
@@ -97,14 +98,13 @@ public class FeatureQueryApi extends SpaceBasedApi {
       final boolean force2D = Query.getBoolean(context, FORCE_2D, false);
       final PropertiesQuery propertiesQuery = getPropertiesQuery(context);
       final SpaceContext spaceContext = getSpaceContext(context);
-      final String version = Query.getString(context, Query.VERSION, null);
       final String author = Query.getString(context, Query.AUTHOR, null);
 
       final SearchForFeaturesEvent event = new SearchForFeaturesEvent();
       event.withTags(Query.getTags(context))
           .withPropertiesQuery(propertiesQuery)
           .withLimit(getLimit(context))
-          .withRef(version)
+          .withRef(getRef(context))
           .withAuthor(author)
           .withForce2D(force2D)
           .withSelection(Query.getSelection(context))
@@ -135,13 +135,14 @@ public class FeatureQueryApi extends SpaceBasedApi {
       final boolean force2D = Query.getBoolean(context, FORCE_2D, false);
       final SpaceContext spaceContext = getSpaceContext(context);
       final Integer v = Query.getInteger(context, Query.VERSION, null);
-      final String version = Query.getString(context, Query.VERSION, null);
+      final Ref ref = getRef(context);
 
       List<String> sort = Query.getSort(context);
       PropertiesQuery propertiesQuery = Query.getPropertiesQuery(context);
       String handle = Query.getString(context, Query.HANDLE, null);
       Integer[] part = Query.getPart(context);
 
+      //TODO: Streamline the following IterateFeaturesEvent creation
       if (sort != null || propertiesQuery != null || part != null || ( handle != null && handle.startsWith("h07~"))) {
         IterateFeaturesEvent event = new IterateFeaturesEvent();
         event.withLimit(getLimit(context))
@@ -151,7 +152,7 @@ public class FeatureQueryApi extends SpaceBasedApi {
             .withPart(part)
             .withHandle(handle)
             .withContext(spaceContext)
-            .withRef(version)
+            .withRef(ref)
             .withV(v);
 
         final SearchQuery task = new SearchQuery(event, context, ApiResponseType.FEATURE_COLLECTION, skipCache);
@@ -163,7 +164,7 @@ public class FeatureQueryApi extends SpaceBasedApi {
           .withLimit(getLimit(context))
           .withForce2D(force2D)
           .withSelection(Query.getSelection(context))
-          .withRef(version)
+          .withRef(ref)
           .withV(v)
           .withHandle(Query.getString(context, Query.HANDLE, null))
           .withContext(spaceContext);
@@ -212,7 +213,6 @@ public class FeatureQueryApi extends SpaceBasedApi {
       final boolean skipCache = Query.getBoolean(context, SKIP_CACHE, false);
       final boolean force2D = Query.getBoolean(context, FORCE_2D, false);
       final SpaceContext spaceContext = getSpaceContext(context);
-      final String version = Query.getString(context, Query.VERSION, null);
 
       GetFeaturesByGeometryEvent event = new GetFeaturesByGeometryEvent()
           .withGeometry(geometry)
@@ -225,7 +225,7 @@ public class FeatureQueryApi extends SpaceBasedApi {
           .withSelection(Query.getSelection(context))
           .withForce2D(force2D)
           .withContext(spaceContext)
-          .withRef(version);
+          .withRef(getRef(context));
 
 
        if( event.getGeometry() != null && !( (event.getGeometry() instanceof Point) && event.getRadius() == 0 ) )
@@ -255,7 +255,6 @@ public class FeatureQueryApi extends SpaceBasedApi {
       final boolean clip = Query.getBoolean(context, Query.CLIP, false);
       final boolean force2D = Query.getBoolean(context, FORCE_2D, false);
       final SpaceContext spaceContext = getSpaceContext(context);
-      final String version = Query.getString(context, Query.VERSION, null);
 
       GetFeaturesByBBoxEvent event = (GetFeaturesByBBoxEvent) new GetFeaturesByBBoxEvent<>()
           .withForce2D(force2D)
@@ -271,7 +270,7 @@ public class FeatureQueryApi extends SpaceBasedApi {
             .withPropertiesQuery(Query.getPropertiesQuery(context))
             .withLimit(getLimit(context))
             .withSelection(Query.getSelection(context))
-            .withRef(version)
+            .withRef(getRef(context))
             .withContext(spaceContext);
       } catch (Exception e) {
         throw new HttpException(BAD_REQUEST,e.getMessage());
@@ -296,7 +295,6 @@ public class FeatureQueryApi extends SpaceBasedApi {
       final boolean skipCache = Query.getBoolean(context, SKIP_CACHE, false);
       final boolean force2D = Query.getBoolean(context, FORCE_2D, false);
       final SpaceContext spaceContext = getSpaceContext(context);
-      final String version = Query.getString(context, Query.VERSION, null);
 
       final int indexOfPoint = tileId.indexOf('.');
       if (indexOfPoint >= 0) {
@@ -338,7 +336,7 @@ public class FeatureQueryApi extends SpaceBasedApi {
             .withResponseType(responseType == ApiResponseType.MVT ? MVT : responseType == ApiResponseType.MVT_FLATTENED ? MVT_FLATTENED : GEO_JSON)
             .withHereTileFlag("here".equals(tileType))
             .withContext(spaceContext)
-            .withRef(version);
+            .withRef(getRef(context));
       } catch (Exception e) {
         throw new HttpException(BAD_REQUEST,e.getMessage());
       }

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/SpaceBasedApi.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/SpaceBasedApi.java
@@ -9,6 +9,8 @@ import com.here.xyz.hub.rest.ApiParam.Path;
 import com.here.xyz.hub.rest.ApiParam.Query;
 import com.here.xyz.hub.task.FeatureTaskHandler.InvalidStorageException;
 import com.here.xyz.hub.task.Task;
+import com.here.xyz.models.hub.Ref;
+import com.here.xyz.models.hub.Ref.InvalidRef;
 import com.here.xyz.responses.ErrorResponse;
 import io.vertx.ext.web.RoutingContext;
 
@@ -22,9 +24,8 @@ public abstract class SpaceBasedApi extends Api {
 
   protected static SpaceContext getSpaceContext(RoutingContext context) throws HttpException {
     SpaceContext spaceContext = SpaceContext.of(Query.getString(context, Query.CONTEXT, SpaceContext.DEFAULT.toString()).toUpperCase());
-    if (spaceContext == null) {
+    if (spaceContext == null)
       throw new HttpException(BAD_REQUEST, "Invalid space context.");
-    }
     return spaceContext;
   }
 
@@ -66,5 +67,16 @@ public abstract class SpaceBasedApi extends Api {
 
   protected final String getSpaceId(RoutingContext context) {
     return context.pathParam(Path.SPACE_ID);
+  }
+
+  protected Ref getRef(RoutingContext context) throws HttpException {
+    final String version = Query.getString(context, Query.VERSION, null);
+    try {
+
+      return new Ref(version);
+    }
+    catch (InvalidRef e) {
+      throw new HttpException(BAD_REQUEST, "Invalid value for version: " + version, e);
+    }
   }
 }

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/task/FeatureTask.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/task/FeatureTask.java
@@ -452,7 +452,6 @@ public abstract class FeatureTask<T extends Event<?>, X extends FeatureTask<T, ?
 
     public TaskPipeline<IdsQuery> createPipeline() {
       return TaskPipeline.create(this)
-          .then(FeatureTaskHandler::validateReadFeaturesParams)
           .then(FeatureTaskHandler::resolveSpace)
           .then(FeatureTaskHandler::checkSpaceIsActive)
           .then(Authorization::authorizeComposite)

--- a/xyz-models/src/main/java/com/here/xyz/events/SelectiveEvent.java
+++ b/xyz-models/src/main/java/com/here/xyz/events/SelectiveEvent.java
@@ -19,19 +19,15 @@
 
 package com.here.xyz.events;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.here.xyz.models.hub.Ref;
 import java.util.List;
 
 public class SelectiveEvent<T extends SelectiveEvent> extends ContextAwareEvent<T> {
-
   private List<String> selection;
   private boolean force2D;
-  private String ref;
+  private Ref ref = new Ref("HEAD");
   private long minVersion;
   private String author;
-  @JsonIgnore
-  private Ref parsedRef;
 
   @SuppressWarnings("unused")
   public List<String> getSelection() {
@@ -49,24 +45,17 @@ public class SelectiveEvent<T extends SelectiveEvent> extends ContextAwareEvent<
     return (T) this;
   }
 
-  public String getRef() {
+  public Ref getRef() {
     return ref;
   }
 
-  public void setRef(String ref) {
+  public void setRef(Ref ref) {
     this.ref = ref;
   }
 
-  public T withRef(String ref) {
+  public T withRef(Ref ref) {
     setRef(ref);
     return (T) this;
-  }
-
-  public Ref getParsedRef() {
-    if (parsedRef == null)
-      parsedRef = new Ref(getRef());
-
-    return parsedRef;
   }
 
   public long getMinVersion() {

--- a/xyz-models/src/main/java/com/here/xyz/models/hub/Ref.java
+++ b/xyz-models/src/main/java/com/here/xyz/models/hub/Ref.java
@@ -21,8 +21,9 @@ package com.here.xyz.models.hub;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.here.xyz.XyzSerializable;
 
-public class Ref {
+public class Ref implements XyzSerializable {
 
   public static final String HEAD = "HEAD";
   public static final String ALL_VERSIONS = "*";
@@ -38,13 +39,21 @@ public class Ref {
       allVersions = true;
     else
       try {
-        version = Long.parseLong(ref);
-        if (version < 0)
-          throw new InvalidRef("Invalid ref: The provided version number may not be lower than 0");
+        setVersion(Long.parseLong(ref));
       }
       catch (NumberFormatException e) {
         throw new InvalidRef("Invalid ref: the provided ref is not a valid ref or version: \"" + ref + "\"");
       }
+  }
+
+  public Ref(long version) {
+    setVersion(version);
+  }
+
+  private void setVersion(long version) {
+    this.version = version;
+    if (version < 0)
+      throw new InvalidRef("Invalid ref: The provided version number may not be lower than 0");
   }
 
   @JsonValue

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeatures.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeatures.java
@@ -37,7 +37,6 @@ import com.here.xyz.psql.DatabaseWriter.ModificationType;
 import com.here.xyz.psql.query.helpers.FeatureResultSetHandler;
 import com.here.xyz.responses.XyzResponse;
 import com.here.xyz.util.db.SQLQuery;
-import com.here.xyz.util.db.pg.XyzSpaceTableHelper;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -119,7 +118,7 @@ public abstract class GetFeatures<E extends ContextAwareEvent, R extends XyzResp
   }
 
   private SQLQuery buildVersionComparison(SelectiveEvent event) {
-    Ref ref = event.getParsedRef();
+    Ref ref = event.getRef();
     if (event.getVersionsToKeep() == 1 || ref.isAllVersions() || ref.isHead())
       return new SQLQuery("");
 
@@ -128,7 +127,7 @@ public abstract class GetFeatures<E extends ContextAwareEvent, R extends XyzResp
   }
 
   private SQLQuery buildNextVersionFragment(SelectiveEvent event) {
-    return buildNextVersionFragment(event.getParsedRef(), event.getVersionsToKeep() > 1,
+    return buildNextVersionFragment(event.getRef(), event.getVersionsToKeep() > 1,
         "requestedVersion");
   }
 
@@ -150,7 +149,7 @@ public abstract class GetFeatures<E extends ContextAwareEvent, R extends XyzResp
   }
 
   private SQLQuery buildMinVersionFragment(SelectiveEvent event) {
-    Ref ref = event.getParsedRef();
+    Ref ref = event.getRef();
     boolean isHeadOrStar = ref.isHead() || ref.isAllVersions();
     long version = isHeadOrStar ? Long.MAX_VALUE : ref.getVersion();
     if (event.getVersionsToKeep() > 1)
@@ -245,7 +244,7 @@ public abstract class GetFeatures<E extends ContextAwareEvent, R extends XyzResp
   private static String buildOrderByFragment(ContextAwareEvent event) {
     if (!(event instanceof SelectiveEvent selectiveEvent))
       return "";
-    return selectiveEvent.getParsedRef().isAllVersions() ? "ORDER BY version" : "";
+    return selectiveEvent.getRef().isAllVersions() ? "ORDER BY version" : "";
   }
 
   protected SQLQuery buildGeoFragment(E event) {


### PR DESCRIPTION
- Do validation of a user provided version ref in REST tier directly when reading the REST parameter
- Introduce method SpaceBasedApi#getRef() which reads the param and validates it and does proper error handling
- Re-use that method in subclasses where necessary to pass it to the events directly
- Remove obsolete method FeatureTaskHandler#validateReadFeaturesParams()