### PR TITLE
Add workaround for an issue in Jackson to improve SQLQuery serialization

### DIFF
--- a/xyz-util/src/main/java/com/here/xyz/util/db/SQLQuery.java
+++ b/xyz-util/src/main/java/com/here/xyz/util/db/SQLQuery.java
@@ -85,6 +85,8 @@ public class SQLQuery {
   private boolean labelsEnabled = true;
   private List<SQLQuery> queryBatch;
 
+  private SQLQuery() {} //Only added as workaround for an issue with Jackson's Include.NON_DEFAULT setting
+
   public SQLQuery(String text) {
     if (text != null)
       statement = text;


### PR DESCRIPTION
When using Jackson's Include.NON_DEFAULT setting on a class, it does take into account the NON_DEFAULT setting if the empty constructor is not added explicitly.