### PR TITLE
Fix minor issue which could lead to duplicate features in rare cases

### DIFF
--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseMaintainer.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseMaintainer.java
@@ -49,7 +49,7 @@ public class DatabaseMaintainer {
     private static final Logger logger = LogManager.getLogger();
 
     /** Is used to check against xyz_ext_version() */
-    public static final int XYZ_EXT_VERSION = 186;
+    public static final int XYZ_EXT_VERSION = 187;
 
     public static final int H3_CORE_VERSION = 108;
 

--- a/xyz-util/src/main/java/com/here/xyz/util/db/pg/XyzSpaceTableHelper.java
+++ b/xyz-util/src/main/java/com/here/xyz/util/db/pg/XyzSpaceTableHelper.java
@@ -58,7 +58,7 @@ public class XyzSpaceTableHelper {
     List<SQLQuery> queries = new ArrayList<>();
 
     queries.add(buildCreateSpaceTableQuery(schema, table));
-    queries.add(buildColumnStoragAttributesQuery(schema, table));
+    queries.add(buildColumnStorageAttributesQuery(schema, table));
     queries.addAll(buildSpaceTableIndexQueries(schema, table));
     queries.add(buildCreateHeadPartitionQuery(schema, table));
     queries.add(buildCreateHistoryPartitionQuery(schema, table, 0L));
@@ -75,7 +75,7 @@ public class XyzSpaceTableHelper {
     return queryComment != null ? indexCreationQuery.withQueryFragment("queryComment", queryComment) : indexCreationQuery;
   }
 
-  public static SQLQuery buildColumnStoragAttributesQuery(String schema, String tableName) {
+  public static SQLQuery buildColumnStorageAttributesQuery(String schema, String tableName) {
       return new SQLQuery("ALTER TABLE ${schema}.${table} "
           + "ALTER COLUMN id SET STORAGE MAIN, "
           + "ALTER COLUMN jsondata SET STORAGE MAIN, "
@@ -115,14 +115,16 @@ public class XyzSpaceTableHelper {
               + "author TEXT, "
               + "jsondata JSONB, "
               + "geo geometry(GeometryZ, 4326), "
-              + "i BIGSERIAL"
-              + ", CONSTRAINT ${constraintName} PRIMARY KEY (id, version, next_version)";
+              + "i BIGSERIAL, "
+              + "CONSTRAINT ${uniqueConstraintName} UNIQUE (id, next_version), "
+              + "CONSTRAINT ${primKeyConstraintName} PRIMARY KEY (id, version, next_version)";
 
       SQLQuery createTable = new SQLQuery("CREATE TABLE IF NOT EXISTS ${schema}.${table} (${{tableFields}}) PARTITION BY RANGE (next_version)")
           .withQueryFragment("tableFields", tableFields)
           .withVariable(SCHEMA, schema)
           .withVariable(TABLE, table)
-          .withVariable("constraintName", table + "_primKey");
+          .withVariable("uniqueConstraintName", table + "_unique")
+          .withVariable("primKeyConstraintName", table + "_primKey");
       return createTable;
   }
 


### PR DESCRIPTION
- Introduce UNIQUE constraint on columns (id, next_version)
- Change xyz_write_versioned_modification_operation() function to perform the next_version update *before* the insert of the new row to prevent violating the new constraint
- Change xyz_simple_upsert() function - Switch order of update / insert and use an ON CONFLICT clause which performs an update in case of a violation of the new unique constraint