### PR TITLE
Simplify query building in GetFeatures QR

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/httpconnector/config/JDBCExporter.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/httpconnector/config/JDBCExporter.java
@@ -170,6 +170,8 @@ public class JDBCExporter extends JdbcBasedHandler {
     try {
 
       return ((ExportSpace) getQueryRunner(client, spatialFilter, event))
+          //TODO: Why not selecting the feature id / geo here?
+          //FIXME: Do not select operation / author as part of the "property-selection"-fragment
           .withSelectionOverride(new SQLQuery("jsondata, operation, author"))
           .withGeoOverride(buildGeoFragment(spatialFilter))
           .buildQuery(event);
@@ -699,8 +701,9 @@ public class JDBCExporter extends JdbcBasedHandler {
 
             default:
             {
-                contentQuery
-                        .withQueryFragment("id", "");
+              //TODO: Why is it important here to not have the id selected?
+              contentQuery = new SQLQuery("SELECT jsondata, geo FROM (${{innerContentQuery}}) contentQuery")
+                  .withQueryFragment("innerContentQuery", contentQuery);
                 return queryToText(contentQuery);
             }
         }

--- a/xyz-hub-service/src/main/java/com/here/xyz/httpconnector/config/query/ExportSpaceByGeometry.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/httpconnector/config/query/ExportSpaceByGeometry.java
@@ -36,7 +36,29 @@ public class ExportSpaceByGeometry extends GetFeaturesByGeometry implements Expo
 
   @Override
   public SQLQuery buildQuery(GetFeaturesByGeometryEvent event) throws SQLException, ErrorResponseException {
-    return patchQuery(super.buildQuery(event), geoOverride, customWhereClause, selectionOverride);
+    return super.buildQuery(event);
+  }
+
+  @Override
+  protected SQLQuery buildSelectClause(GetFeaturesByGeometryEvent event, int dataset) {
+    return patchSelectClause(super.buildSelectClause(event, dataset), selectionOverride);
+  }
+
+  @Override
+  protected SQLQuery buildGeoFragment(GetFeaturesByGeometryEvent event) {
+    if (geoOverride == null)
+      return super.buildGeoFragment(event);
+    return geoOverride;
+  }
+
+  @Override
+  protected SQLQuery buildFilterWhereClause(GetFeaturesByGeometryEvent event) {
+    return patchWhereClause(super.buildFilterWhereClause(event), customWhereClause);
+  }
+
+  @Override
+  protected SQLQuery buildLimitFragment(GetFeaturesByGeometryEvent event) {
+    return new SQLQuery("");
   }
 
   @Override

--- a/xyz-hub-service/src/main/java/com/here/xyz/httpconnector/config/query/ExportSpaceByProperties.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/httpconnector/config/query/ExportSpaceByProperties.java
@@ -39,7 +39,29 @@ public class ExportSpaceByProperties extends SearchForFeatures<SearchForFeatures
 
   @Override
   public SQLQuery buildQuery(SearchForFeaturesEvent event) throws SQLException, ErrorResponseException {
-    return patchQuery(super.buildQuery(event), geoOverride, customWhereClause, selectionOverride);
+    return super.buildQuery(event);
+  }
+
+  @Override
+  protected SQLQuery buildSelectClause(SearchForFeaturesEvent event, int dataset) {
+    return patchSelectClause(super.buildSelectClause(event, dataset), selectionOverride);
+  }
+
+  @Override
+  protected SQLQuery buildGeoFragment(SearchForFeaturesEvent event) {
+    if (geoOverride == null)
+      return super.buildGeoFragment(event);
+    return geoOverride;
+  }
+
+  @Override
+  protected SQLQuery buildFilterWhereClause(SearchForFeaturesEvent event) {
+    return patchWhereClause(super.buildFilterWhereClause(event), customWhereClause);
+  }
+
+  @Override
+  protected SQLQuery buildLimitFragment(SearchForFeaturesEvent event) {
+    return new SQLQuery("");
   }
 
   @Override

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeaturesByBBox.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeaturesByBBox.java
@@ -22,9 +22,6 @@ package com.here.xyz.psql.query;
 import static com.here.xyz.events.GetFeaturesByTileEvent.ResponseType.GEO_JSON;
 import static com.here.xyz.events.GetFeaturesByTileEvent.ResponseType.MVT;
 import static com.here.xyz.events.GetFeaturesByTileEvent.ResponseType.MVT_FLATTENED;
-import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.HEAD_TABLE_SUFFIX;
-import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.SCHEMA;
-import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.TABLE;
 
 import com.here.xyz.connectors.ErrorResponseException;
 import com.here.xyz.events.GetFeaturesByBBoxEvent;
@@ -33,14 +30,11 @@ import com.here.xyz.events.GetFeaturesByTileEvent.ResponseType;
 import com.here.xyz.models.geojson.HQuad;
 import com.here.xyz.models.geojson.WebMercatorTile;
 import com.here.xyz.models.geojson.coordinates.BBox;
-import com.here.xyz.psql.factory.TweaksSQL;
-import com.here.xyz.psql.tools.DhString;
 import com.here.xyz.responses.BinaryResponse;
 import com.here.xyz.responses.XyzResponse;
 import com.here.xyz.util.db.SQLQuery;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Map;
 
 public class GetFeaturesByBBox<E extends GetFeaturesByBBoxEvent, R extends XyzResponse> extends Spatial<E, R> {
 
@@ -99,35 +93,6 @@ public class GetFeaturesByBBox<E extends GetFeaturesByBBoxEvent, R extends XyzRe
     return geoFilter;
   }
 
-  private SQLQuery generateCombinedQuery(GetFeaturesByBBoxEvent event, SQLQuery indexedQuery) {
-    final SQLQuery query = new SQLQuery(
-        "SELECT ${{selection}}, ${{geo}}"
-            + "    FROM ${schema}.${headTable} ${{tableSample}}"
-            + "    WHERE ${{filterWhereClause}} ${{orderBy}} ${{limit}}"
-    )
-        .withVariable(SCHEMA, getSchema())
-        .withVariable("headTable", getDefaultTable((E) event) + HEAD_TABLE_SUFFIX);
-
-    query.setQueryFragment("selection", buildSelectionFragment(event));
-    query.setQueryFragment("geo", buildClippedGeoFragment((E) event, buildGeoFilter(event)));
-    query.setQueryFragment("tableSample", ""); //Can be overridden by caller
-
-    SQLQuery filterWhereClause = new SQLQuery("${{indexedQuery}} AND ${{searchQuery}}");
-
-    filterWhereClause.setQueryFragment("indexedQuery", indexedQuery);
-    SQLQuery searchQuery = generateSearchQuery(event);
-    if (searchQuery == null)
-      filterWhereClause.setQueryFragment("searchQuery", "TRUE");
-    else
-      filterWhereClause.setQueryFragment("searchQuery", searchQuery);
-
-    query.setQueryFragment("filterWhereClause", filterWhereClause);
-    query.setQueryFragment("orderBy", ""); //Can be overridden by caller
-    query.setQueryFragment("limit", buildLimitFragment(event.getLimit()));
-
-    return query;
-  }
-
   protected SQLQuery buildMvtEncapsuledQuery(GetFeaturesByTileEvent event, SQLQuery dataQry) {
     return buildMvtEncapsuledQuery(null, event, dataQry);
   }
@@ -162,15 +127,22 @@ public class GetFeaturesByBBox<E extends GetFeaturesByBBoxEvent, R extends XyzRe
     }
 
   @Override
-  protected SQLQuery buildClippedGeoFragment(E event, SQLQuery geoFilter) {
-    boolean convertToGeoJson = getResponseType(event) == GEO_JSON;
-    if (!event.getClip())
-      return buildGeoFragment(event, convertToGeoJson);
+  protected SQLQuery buildGeoJsonExpression(E event) {
+    if (getResponseType(event) == GEO_JSON)
+      return super.buildGeoJsonExpression(event);
+    //Do not use the GeoJSON representation if the geo fragment will be transformed to MVT
+    return buildRawGeoExpression(event);
+  }
 
-    SQLQuery clippedGeo = new SQLQuery("ST_Intersection(ST_MakeValid(geo), ${{geoFilter}})")
-        .withQueryFragment("geoFilter", geoFilter);
+  public ResponseType getResponseType(GetFeaturesByBBoxEvent event) {
+    if (event instanceof GetFeaturesByTileEvent)
+      return ((GetFeaturesByTileEvent) event).getResponseType();
+    return GEO_JSON;
+  }
 
-    return super.buildGeoFragment(event, convertToGeoJson, clippedGeo);
+  protected boolean isMvtRequested(GetFeaturesByBBoxEvent event) {
+    ResponseType responseType = getResponseType(event);
+    return responseType == MVT || responseType == MVT_FLATTENED;
   }
 
   //---------------------------
@@ -184,93 +156,6 @@ public class GetFeaturesByBBox<E extends GetFeaturesByBBoxEvent, R extends XyzRe
 
      return WebMercatorTile.getTileFromLatLonLev(lat2, lon2, lev);
     }
-
-
-  /***************************************** TWEAKS **************************************************/
-
-  public static ResponseType getResponseType(GetFeaturesByBBoxEvent event) {
-    if (event instanceof GetFeaturesByTileEvent)
-      return ((GetFeaturesByTileEvent) event).getResponseType();
-    return GEO_JSON;
-  }
-
-  protected static boolean isMvtRequested(GetFeaturesByBBoxEvent event) {
-    ResponseType responseType = getResponseType(event);
-    return responseType == MVT || responseType == MVT_FLATTENED;
-  }
-
-  private static String map2MvtGeom( GetFeaturesByBBoxEvent event, BBox bbox, String tweaksGeoSql )
-  {
-   boolean bExtentTweaks = // -> 2048 only if tweaks or viz been specified explicit
-    ( "viz".equals(event.getOptimizationMode()) || (event.getTweakParams() != null && event.getTweakParams().size() > 0 ) );
-
-   int extent = ( bExtentTweaks ? 2048 : 4096 ), extentPerMargin = extent / WebMercatorTile.TileSizeInPixel, extentWithMargin = extent, level = -1, tileX = -1, tileY = -1, margin = 0;
-   boolean hereTile = false;
-
-   if( event instanceof GetFeaturesByTileEvent )
-   { GetFeaturesByTileEvent tevnt = (GetFeaturesByTileEvent) event;
-     level = tevnt.getLevel();
-     tileX = tevnt.getX();
-     tileY = tevnt.getY();
-     margin = tevnt.getMargin();
-     extentWithMargin = extent + (margin * extentPerMargin);
-     hereTile = tevnt.getHereTileFlag();
-   }
-   else
-   { final WebMercatorTile tile = getTileFromBbox(bbox);
-     level = tile.level;
-     tileX = tile.x;
-     tileY = tile.y;
-   }
-
-   double wgs3857width = 20037508.342789244d, wgs4326width = 180d,
-          wgsWidth = 2 * ( !hereTile ? wgs3857width : wgs4326width ),
-          xwidth = wgsWidth,
-          ywidth = wgsWidth,
-          gridsize = (1L << level),
-          stretchFactor = 1.0 + ( margin / ((double) WebMercatorTile.TileSizeInPixel)), // xyz-hub uses margin for tilesize of 256 pixel.
-          xProjShift = (!hereTile ? (tileX - gridsize/2 + 0.5) * (xwidth / gridsize)      : -180d + (tileX + 0.5) * (xwidth / gridsize) ) ,
-          yProjShift = (!hereTile ? (tileY - gridsize/2 + 0.5) * (ywidth / gridsize) * -1 :  -90d + (tileY + 0.5) * (ywidth / gridsize) ) ;
-
-   String
-    box2d   = DhString.format( DhString.format("ST_MakeEnvelope(%%.%1$df,%%.%1$df,%%.%1$df,%%.%1$df, 4326)", 14 /*GEOMETRY_DECIMAL_DIGITS*/), bbox.minLon(), bbox.minLat(), bbox.maxLon(), bbox.maxLat() ),
-      // 1. build mvt
-    mvtgeom = DhString.format( (!hereTile ? "st_asmvtgeom(st_force2d(st_transform(%1$s,3857)), st_transform(%2$s,3857),%3$d,0,true)"
-                                          : "st_asmvtgeom(st_force2d(%1$s), %2$s,%3$d,0,true)")
-                               , tweaksGeoSql, box2d, extentWithMargin);
-      // 2. project the mvt to tile
-    mvtgeom = DhString.format( (!hereTile ? "st_setsrid(st_translate(st_scale(st_translate(%1$s, %2$d , %2$d, 0.0), st_makepoint(%3$f,%4$f,1.0) ), %5$f , %6$f, 0.0 ), 3857)"
-                                          : "st_setsrid(st_translate(st_scale(st_translate(%1$s, %2$d , %2$d, 0.0), st_makepoint(%3$f,%4$f,1.0) ), %5$f , %6$f, 0.0 ), 4326)")
-                               ,mvtgeom
-                               ,-extentWithMargin/2 // => shift to stretch from tilecenter
-                               ,stretchFactor*(xwidth / (gridsize*extent)), stretchFactor * (ywidth / (gridsize*extent)) * -1 // stretch tile to proj. size
-                               ,xProjShift, yProjShift // shift to proj. position
-                             );
-      // 3 project tile to wgs84 and map invalid geom to null
-
-    mvtgeom = DhString.format( (!hereTile ? "(select case st_isvalid(g) when true then g else null end from st_transform(%1$s,4326) g)"
-                                          : "(select case st_isvalid(g) when true then g else null end from %1$s g)")
-                               , mvtgeom );
-
-      // 4. assure intersect with origin bbox in case of mapping errors
-    mvtgeom  = DhString.format("ST_Intersection(%1$s,st_setsrid(%2$s,4326))", mvtgeom, box2d);
-      // 5. map non-null but empty polygons to null - e.g. avoid -> "geometry": { "type": "Polygon", "coordinates": [] }
-    mvtgeom = DhString.format("(select case st_isempty(g) when false then g else null end from %1$s g)", mvtgeom );
-
-    // if geom = point | multipoint then no mvt <-> geo conversion should be done
-    mvtgeom = DhString.format("case strpos(ST_GeometryType( geo ), 'Point') > 0 when true then geo else %1$s end", mvtgeom );
-
-    return mvtgeom;
-  }
-
-  private static String clipProjGeom(BBox bbox, String tweaksGeoSql )
-  {
-   String fmt =  DhString.format(  " case st_within( %%1$s, ST_MakeEnvelope(%%2$.%1$df,%%3$.%1$df,%%4$.%1$df,%%5$.%1$df, 4326) ) "
-                               + "  when true then %%1$s "
-                               + "  else ST_Intersection(ST_MakeValid(%%1$s),ST_MakeEnvelope(%%2$.%1$df,%%3$.%1$df,%%4$.%1$df,%%5$.%1$df, 4326))"
-                               + " end " , 14 /*GEOMETRY_DECIMAL_DIGITS*/ );
-   return DhString.format( fmt, tweaksGeoSql, bbox.minLon(), bbox.minLat(), bbox.maxLon(), bbox.maxLat());
-  }
 
   protected static int samplingStrengthFromText(String sampling, boolean fiftyOnUnset)
   {
@@ -286,306 +171,5 @@ public class GetFeaturesByBBox<E extends GetFeaturesByBBoxEvent, R extends XyzRe
 
    return strength;
 
-  }
-
-  public SQLQuery buildSamplingTweaksQuery(GetFeaturesByBBoxEvent event, Map tweakParams) {
-    BBox bbox = event.getBbox();
-    boolean bSortByHashedValue = (boolean) tweakParams.get("sortByHashedValue");
-   int strength = 0;
-   boolean bDistribution  = true,
-           bDistribution2 = false,
-           bConvertGeo2Geojson = getResponseType(event) == GEO_JSON;
-
-   if( tweakParams != null )
-   {
-    if( tweakParams.get(TweaksSQL.SAMPLING_STRENGTH) instanceof Integer )
-     strength = (int) tweakParams.get(TweaksSQL.SAMPLING_STRENGTH);
-    else
-     strength = samplingStrengthFromText( (String) tweakParams.getOrDefault(TweaksSQL.SAMPLING_STRENGTH,"default"), true );
-
-     switch(((String) tweakParams.getOrDefault(TweaksSQL.SAMPLING_ALGORITHM, TweaksSQL.SAMPLING_ALGORITHM_DST)).toLowerCase() )
-     {
-       case TweaksSQL.SAMPLING_ALGORITHM_SZE  : bDistribution = false; break;
-       case TweaksSQL.SAMPLING_ALGORITHM_DST2 : bDistribution2 = true;
-       case TweaksSQL.SAMPLING_ALGORITHM_DST  :
-       default                                : bDistribution = true; break;
-     }
-   }
-
-   boolean bEnsureMode = TweaksSQL.ENSURE.equalsIgnoreCase(event.getTweakType());
-
-   float tblSampleRatio = ( (strength > 0 && bDistribution2) ? TweaksSQL.tableSampleRatio(strength) : -1f);
-
-   final String sCondition = ( ((bEnsureMode && strength == 0) || (tblSampleRatio >= 0.0)) ? "1 = 1" : TweaksSQL.strengthSql(strength,bDistribution)  ),
-                twqry = DhString.format(DhString.format("ST_Intersects(geo, ST_MakeEnvelope(%%.%1$df,%%.%1$df,%%.%1$df,%%.%1$df, 4326) ) and %%s", 14 /*GEOMETRY_DECIMAL_DIGITS*/), bbox.minLon(), bbox.minLat(), bbox.maxLon(), bbox.maxLat(), sCondition );
-
-   final SQLQuery tweakQuery = new SQLQuery(twqry);
-
-   if( !bEnsureMode || !bConvertGeo2Geojson ) {
-     SQLQuery combinedQuery = generateCombinedQuery(event, tweakQuery);
-     if (tblSampleRatio > 0.0)
-       combinedQuery.setQueryFragment("tableSample", DhString.format("tablesample system(%.6f) repeatable(499)", 100.0 * tblSampleRatio));
-     if (bSortByHashedValue)
-       combinedQuery.setQueryFragment("orderBy", "ORDER BY " + TweaksSQL.distributionFunctionIndexExpression());
-     return combinedQuery;
-   }
-
-
-   /* TweaksSQL.ENSURE and geojson requested (no mvt) */
-   boolean bTestTweaksGeoIfNull = false;
-   String tweaksGeoSql = clipProjGeom(bbox,"geo");
-   tweaksGeoSql = map2MvtGeom( event, bbox, tweaksGeoSql );
-   //convert to geojson
-   tweaksGeoSql = ( bConvertGeo2Geojson ? DhString.format("replace(ST_AsGeojson(" + getForceMode(event.isForce2D()) + "( %s ),%d),'nan','0')",tweaksGeoSql,GEOMETRY_DECIMAL_DIGITS)
-                                        : DhString.format( getForceMode(event.isForce2D()) + "( %s )",tweaksGeoSql ) );
-
-   return generateCombinedQueryTweaks(event, tweakQuery , tweaksGeoSql, bTestTweaksGeoIfNull, tblSampleRatio, bSortByHashedValue );
-}
-
-  private static double cToleranceFromStrength(int strength )
-  {
-   double tolerance = 0.0001;
-   if(  strength > 0  && strength <= 25 )      tolerance = 0.0001 + ((0.001-0.0001)/25.0) * (strength -  1);
-   else if(  strength > 25 && strength <= 50 ) tolerance = 0.001  + ((0.01 -0.001) /25.0) * (strength - 26);
-   else if(  strength > 50 && strength <= 75 ) tolerance = 0.01   + ((0.1  -0.01)  /25.0) * (strength - 51);
-   else /* [76 - 100 ] */                      tolerance = 0.1    + ((1.0  -0.1)   /25.0) * (strength - 76);
-
-   return tolerance;
-  }
-
-  public SQLQuery buildSimplificationTweaksQuery(GetFeaturesByBBoxEvent event, Map tweakParams) throws SQLException
-  {
-    BBox bbox = event.getBbox();
-   int strength = 0,
-       iMerge = 0;
-   String tweaksGeoSql = "geo";
-   boolean bStrength = true, bTestTweaksGeoIfNull = true, convertGeo2Geojson = getResponseType(event) == GEO_JSON, bMvtRequested = !convertGeo2Geojson;
-
-   if( tweakParams != null )
-   {
-    if( tweakParams.get(TweaksSQL.SIMPLIFICATION_STRENGTH) instanceof Integer )
-     strength = (int) tweakParams.get(TweaksSQL.SIMPLIFICATION_STRENGTH);
-    else
-     switch(((String) tweakParams.getOrDefault(TweaksSQL.SIMPLIFICATION_STRENGTH,"default")).toLowerCase() )
-     { case "low"     : strength =  20;  break;
-       case "lowmed"  : strength =  40;  break;
-       case "med"     : strength =  60;  break;
-       case "medhigh" : strength =  80;  break;
-       case "high"    : strength = 100; break;
-       case "default" : bStrength = false;
-       default: strength  = 50; break;
-     }
-
-     String tweaksAlgorithm = ((String) tweakParams.getOrDefault(TweaksSQL.SIMPLIFICATION_ALGORITHM,"default")).toLowerCase();
-
-     // do clip before simplification -- preventing extrem large polygon for further working steps (except for mvt with gridbytilelevel, redundancy)
-     if (event.getClip() && !( TweaksSQL.SIMPLIFICATION_ALGORITHM_A05.equals( tweaksAlgorithm ) && bMvtRequested ) )
-      tweaksGeoSql = clipProjGeom( bbox,tweaksGeoSql );
-
-     //SIMPLIFICATION_ALGORITHM
-     int hint = 0;
-     String[] pgisAlgorithm = { "ST_SnapToGrid", "ftm_SimplifyPreserveTopology", "ftm_Simplify" };
-
-     switch( tweaksAlgorithm )
-     {
-       case TweaksSQL.SIMPLIFICATION_ALGORITHM_A03 : hint++;
-       case TweaksSQL.SIMPLIFICATION_ALGORITHM_A02 : hint++;
-       case TweaksSQL.SIMPLIFICATION_ALGORITHM_A01 :
-       {
-        double tolerance = ( bStrength ? cToleranceFromStrength( strength ) : Math.abs( bbox.maxLon() - bbox.minLon() ) / 4096 );
-        tweaksGeoSql = DhString.format("%s(%s, %f)", pgisAlgorithm[hint], tweaksGeoSql, tolerance );
-       }
-       break;
-
-       case TweaksSQL.SIMPLIFICATION_ALGORITHM_A05 : // gridbytilelevel - convert to/from mvt
-       {
-        if(!bMvtRequested)
-         tweaksGeoSql = map2MvtGeom( event, bbox, tweaksGeoSql );
-        bTestTweaksGeoIfNull = false;
-       }
-       break;
-
-       case TweaksSQL.SIMPLIFICATION_ALGORITHM_A06 : iMerge++;
-       case TweaksSQL.SIMPLIFICATION_ALGORITHM_A04 : iMerge++; break;
-
-       default: break;
-     }
-
-     //convert to geojson
-     tweaksGeoSql = ( convertGeo2Geojson ? DhString.format("replace(ST_AsGeojson(" + getForceMode(event.isForce2D()) + "( %s ),%d),'nan','0')",tweaksGeoSql,GEOMETRY_DECIMAL_DIGITS)
-                                          : DhString.format( getForceMode(event.isForce2D()) + "( %s )",tweaksGeoSql) );
-   }
-
-     final String bboxqry = DhString.format( DhString.format("ST_Intersects(geo, ST_MakeEnvelope(%%.%1$df,%%.%1$df,%%.%1$df,%%.%1$df, 4326) )", 14 /*GEOMETRY_DECIMAL_DIGITS*/), bbox.minLon(), bbox.minLat(), bbox.maxLon(), bbox.maxLat() );
-
-     if (iMerge == 0)
-       return generateCombinedQueryTweaks(event, new SQLQuery(bboxqry), tweaksGeoSql, bTestTweaksGeoIfNull, -1.0f, false );
-
-     // Merge Algorithm - only using low, med, high
-
-     int minGeoHashLenToMerge = 0,
-         minGeoHashLenForLineMerge = 3;
-
-     if      ( strength <= 20 ) { minGeoHashLenToMerge = 7; minGeoHashLenForLineMerge = 7; } //low
-     else if ( strength <= 40 ) { minGeoHashLenToMerge = 6; minGeoHashLenForLineMerge = 6; } //lowmed
-     else if ( strength <= 60 ) { minGeoHashLenToMerge = 6; minGeoHashLenForLineMerge = 5; } //med
-     else if ( strength <= 80 ) {                           minGeoHashLenForLineMerge = 4; } //medhigh
-
-     if( "geo".equals(tweaksGeoSql) ) // formal, just in case
-      tweaksGeoSql = ( convertGeo2Geojson ? DhString.format("replace(ST_AsGeojson(" + getForceMode(event.isForce2D()) + "( %s ),%d),'nan','0')",tweaksGeoSql,GEOMETRY_DECIMAL_DIGITS)
-                                           : DhString.format(getForceMode(event.isForce2D()) + "( %s )",tweaksGeoSql) );
-
-     if( convertGeo2Geojson )
-      tweaksGeoSql = DhString.format("(%s)::jsonb", tweaksGeoSql);
-
-
-     SQLQuery query = buildSimplificationTweaksMergeQuery(event, iMerge, tweaksGeoSql, minGeoHashLenToMerge, minGeoHashLenForLineMerge, bboxqry, convertGeo2Geojson);
-     final SQLQuery searchQuery = generateSearchQuery(event);
-     if (searchQuery != null)
-       query.setQueryFragment("searchQuery", new SQLQuery("AND ${{sq}}").withQueryFragment("sq", searchQuery));
-     return query;
-}
-
-private SQLQuery buildSimplificationTweaksMergeQuery(GetFeaturesByBBoxEvent event, int iMerge, String tweaksGeoSql, int minGeoHashLenToMerge, int minGeoHashLenForLineMerge, String bboxQuery, boolean convertGeo2Geojson) {
-    SQLQuery query;
-    if (iMerge == 1) {
-      query = new SQLQuery("select jsondata, geo "
-          +"from "
-          +"( "
-          +" select jsonb_set('{\"type\": \"Feature\"}'::jsonb,'{properties}', jsonb_set( case when (ginfo->>1)::integer = 1 then jsonb_set( '{}'::jsonb,'{ids}', ids ) else '{}'::jsonb end , '{groupInfo}', ginfo )) as jsondata, ${{tweaksGeo}} as geo"
-          +" from "
-          +" ( "
-          +"  select jsonb_build_array(left(md5( gh || gsz ), 12), row_number() over w, count(1) over w, nrobj ) as ginfo, * "
-          +"  from "
-          +"  ( "
-          +"   select gh, case length(gh) > #{minGeoHashLenToMerge} when true then 0 else i end as gsz, count(1) as nrobj, jsonb_agg(id) as ids, (st_dump( st_union(oo.geo) )).geom as geo "
-          +"   from "
-          +"   ( "
-          +"    select ST_GeoHash(geo) as gh, i, id , geo "
-          +"    from "
-          +"    ( "
-          +"     select i, id, geo "  // fetch objects
-          +"     from ${schema}.${table} "
-          +"     where 1 = 1 "
-          +"       and ${{bboxQuery}} ${{searchQuery}} " + "    ) o "
-          +"   ) oo "
-          +"   group by gsz, gh"
-          +"  ) ooo window w as (partition by gh, gsz ) "
-          +" ) oooo "
-          +") ooooo "
-          +"where geo IS NOT NULL AND ${{geoCheck}} LIMIT #{limit}")
-          .withQueryFragment("geoCheck", convertGeo2Geojson
-              ? "geo->>'type' != 'GeometryCollection' and jsonb_array_length(geo->'coordinates') > 0 "
-              : "geometrytype(geo) != 'GEOMETRYCOLLECTION' and not st_isempty(geo) ")
-          .withNamedParameter("minGeoHashLenToMerge", minGeoHashLenToMerge);
-    }
-    else {
-      query = new SQLQuery("with "
-          +"indata as "
-          +"( select i, ${{geo}} as geo from ${schema}.${table} "
-          +"  where 1 = 1 "
-          +"    and ${{bboxQuery}} ${{searchQuery}}), "
-          +"cx2ids as "
-          +"( select left( gid, #{minGeoHashLenForLineMerge} ) as region, ids "
-          +"  from "
-          +"  ( select gid, array_agg( i ) as ids "
-          +"    from "
-          +"    ( select i, unnest( array[ ST_GeoHash( st_startpoint(geo),9 ) , ST_GeoHash( st_endpoint(geo), 9 ) ] ) as gid from indata where ( geometrytype(geo) = 'LINESTRING' ) ) o "
-          +"    group by gid "
-          +"  ) o	"
-          +"  where 1 = 1 "
-          +"    and cardinality(ids) = 2 "
-          +"), "
-          +"cxlist as "
-          +"( select count(1) over ( PARTITION BY region ) as rcount, array[(row_number() over ( PARTITION BY region ))::integer] as rids, region, ids from cx2ids ), "
-          +"mergedids as "
-          +"( with recursive mrgdids( step, region, rcount, rids, ids ) as "
-          +"  ( "
-          +"	  select 1, region, rcount, rids, ids from cxlist "
-          +"	 union all "
-          +"		select distinct on (region, rids[1] ) * "
-          +"		from "
-          +"		( select l.step+1 as step, l.region, l.rcount, array( select unnest( l.rids || r.rids ) order by 1 )  as rids, l.ids || r.ids as ids "
-          +"		  from mrgdids l join cxlist r on ( l.region = r.region and not (l.rids @> r.rids) and  (l.ids && r.ids ) ) "
-          +"		  where 1 = 1 "
-          +"		) i1 "
-          +"	) "
-          +"  select l.region, l.rcount, l.step, l.rids, array( select distinct unnest( l.ids ) ) as ids "
-          +"  from mrgdids l left join mrgdids r on ( l.region = r.region and l.step < r.step and l.rids <@ r.rids ) "
-          +"  where 1 = 1 "
-          +"    and r.region is null "
-          +"), "
-          +"ccxuniqid as "
-          +"( select distinct unnest(ids) as id from cx2ids ), "
-          +"iddata as "
-          +"(  select step, ids from mergedids "
-          +"  union "
-          +"   select 0 as step, array[i] as ids from indata where not i in (select id from ccxuniqid ) "
-          +"), "
-          +"finaldata as "
-          +"(	select "
-          +"   case when step = 0 "
-          +"    then ( SELECT ${{selection}} FROM ${schema}.${table} where i = ids[1] ) "
-          +"    else ( select jsonb_set( jsonb_set('{\"type\":\"Feature\",\"properties\":{}}'::jsonb,'{id}', to_jsonb( max(jsondata->>'id') )),'{properties,ids}', jsonb_agg( jsondata->>'id' )) from ${schema}.${table} where i in ( select unnest( ids ) ) ) "
-          +"   end as jsondata, "
-          +"   case when step = 0 "
-          +"    then ( select geo from ${schema}.${table} where i = ids[1] ) "
-          +"    else ( select ST_LineMerge( st_collect( geo ) ) from ${schema}.${table} where i in ( select unnest( ids )) ) "
-          +"   end as geo "
-          +"  from iddata "
-          +") "
-          +"select jsondata, ${{tweaksGeo}} as geo from finaldata LIMIT #{limit}")
-          .withQueryFragment("geo", "geo") //(event.getClip() ? clipProjGeom(bbox,"geo") : "geo")
-          .withQueryFragment("selection", buildSelectionFragment(event))
-          .withNamedParameter("minGeoHashLenForLineMerge", minGeoHashLenForLineMerge);
-
-    }
-    return query
-        .withVariable(SCHEMA, getSchema())
-        .withVariable(TABLE, readTableFromEvent(event))
-        .withQueryFragment("tweaksGeo", tweaksGeoSql)
-        .withQueryFragment("bboxQuery", bboxQuery)
-        .withNamedParameter("limit", event.getLimit());
-
-}
-
-  /** ###################################################################################### */
-
-  private SQLQuery generateCombinedQueryTweaks(GetFeaturesByBBoxEvent event, SQLQuery indexedQuery, String tweaksgeo, boolean testTweaksGeoIfNull, float sampleRatio, boolean sortByHashedValue)
-  {
-    SQLQuery searchQuery = generateSearchQuery(event);
-
-    final SQLQuery query = new SQLQuery("SELECT * FROM (SELECT ${{selection}}${{geo}} FROM ${schema}.${table} ${{sampling}} WHERE ${{indexedQuery}} ${{searchQuery}} ${{orderBy}}) tw ${{outerWhereClause}} LIMIT #{limit}")
-        .withVariable(SCHEMA, getSchema())
-        .withVariable(TABLE, readTableFromEvent(event) + HEAD_TABLE_SUFFIX)
-        .withQueryFragment("selection", buildSelectionFragment(event))
-        .withQueryFragment("geo", DhString.format(",%s as geo", tweaksgeo))
-        .withQueryFragment("sampling", "")
-        .withQueryFragment("indexedQuery", indexedQuery)
-        .withQueryFragment("searchQuery", "")
-        .withQueryFragment("orderBy", "")
-        .withQueryFragment("outerWhereClause", "")
-        .withNamedParameter("limit", event.getLimit());
-
-    if (sampleRatio > 0) {
-      SQLQuery sampling = new SQLQuery("tablesample system(#{samplePercentage}) repeatable(499)")
-          .withNamedParameter("samplePercentage", 100f * sampleRatio);
-      query.setQueryFragment("sampling", sampling);
-    }
-
-    if (searchQuery != null)
-      query.setQueryFragment("searchQuery", new SQLQuery("AND ${{sq}}").withQueryFragment("sq", searchQuery));
-
-    if (sortByHashedValue)
-      query.setQueryFragment("orderBy", "ORDER BY " + TweaksSQL.distributionFunctionIndexExpression());
-
-    if (testTweaksGeoIfNull)
-      query.setQueryFragment("outerWhereClause", "geo IS NOT NULL");
-
-    return query;
-  }
-
-  private static String getForceMode(boolean isForce2D) {
-    return isForce2D ? "ST_Force2D" : "ST_Force3D";
   }
 }

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeaturesByBBoxTweaked.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeaturesByBBoxTweaked.java
@@ -19,15 +19,22 @@
 
 package com.here.xyz.psql.query;
 
+import static com.here.xyz.events.GetFeaturesByTileEvent.ResponseType.GEO_JSON;
 import static com.here.xyz.responses.XyzError.ILLEGAL_ARGUMENT;
+import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.HEAD_TABLE_SUFFIX;
+import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.SCHEMA;
+import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.TABLE;
 
 import com.here.xyz.connectors.ErrorResponseException;
 import com.here.xyz.events.GetFeaturesByBBoxEvent;
 import com.here.xyz.events.GetFeaturesByTileEvent;
+import com.here.xyz.models.geojson.WebMercatorTile;
+import com.here.xyz.models.geojson.coordinates.BBox;
 import com.here.xyz.models.geojson.implementation.FeatureCollection;
 import com.here.xyz.psql.factory.TweaksSQL;
 import com.here.xyz.psql.query.bbox.GetSamplingStrengthEstimation;
 import com.here.xyz.psql.query.bbox.GetSamplingStrengthEstimation.SamplingStrengthEstimation;
+import com.here.xyz.psql.tools.DhString;
 import com.here.xyz.responses.XyzResponse;
 import com.here.xyz.util.db.SQLQuery;
 import java.sql.ResultSet;
@@ -45,6 +52,10 @@ public class GetFeaturesByBBoxTweaked<E extends GetFeaturesByBBoxEvent, R extend
       throws SQLException, ErrorResponseException {
     super(event);
     setUseReadReplica(true);
+  }
+
+  private static String getForceMode(boolean isForce2D) {
+    return isForce2D ? "ST_Force2D" : "ST_Force3D";
   }
 
   @Override
@@ -180,5 +191,403 @@ public class GetFeaturesByBBoxTweaked<E extends GetFeaturesByBBoxEvent, R extend
     hmap.put("algorithm", "distribution");
     hmap.put("strength", TweaksSQL.calculateDistributionStrength(estimationResult.rCount, Math.max(Math.min((int) tweakParams.getOrDefault(TweaksSQL.ENSURE_SAMPLINGTHRESHOLD, 10), 100), 10) * 1000));
     return hmap;
+  }
+
+  private SQLQuery generateCombinedQuery(GetFeaturesByBBoxEvent event, SQLQuery indexedQuery) {
+    final SQLQuery query = new SQLQuery(
+        "SELECT ${{selection}}, ${{geo}}"
+            + "    FROM ${schema}.${headTable} ${{tableSample}}"
+            + "    WHERE ${{filterWhereClause}} ${{orderBy}} ${{limit}}"
+    )
+        .withVariable(SCHEMA, getSchema())
+        .withVariable("headTable", getDefaultTable((E) event) + HEAD_TABLE_SUFFIX);
+
+    query.setQueryFragment("selection", buildSelectionFragment(event));
+    query.setQueryFragment("geo", buildGeoFragment((E) event));
+    query.setQueryFragment("tableSample", ""); //Can be overridden by caller
+
+    SQLQuery filterWhereClause = new SQLQuery("${{indexedQuery}} AND ${{searchQuery}}");
+
+    filterWhereClause.setQueryFragment("indexedQuery", indexedQuery);
+    SQLQuery searchQuery = generateSearchQuery(event);
+    if (searchQuery == null)
+      filterWhereClause.setQueryFragment("searchQuery", "TRUE");
+    else
+      filterWhereClause.setQueryFragment("searchQuery", searchQuery);
+
+    query.setQueryFragment("filterWhereClause", filterWhereClause);
+    query.setQueryFragment("orderBy", ""); //Can be overridden by caller
+
+    return query;
+  }
+
+  private SQLQuery buildSamplingTweaksQuery(GetFeaturesByBBoxEvent event, Map tweakParams) {
+    BBox bbox = event.getBbox();
+    boolean bSortByHashedValue = (boolean) tweakParams.get("sortByHashedValue");
+   int strength = 0;
+   boolean bDistribution  = true,
+           bDistribution2 = false,
+           bConvertGeo2Geojson = getResponseType(event) == GEO_JSON;
+
+   if( tweakParams != null )
+   {
+    if( tweakParams.get(TweaksSQL.SAMPLING_STRENGTH) instanceof Integer )
+     strength = (int) tweakParams.get(TweaksSQL.SAMPLING_STRENGTH);
+    else
+     strength = samplingStrengthFromText( (String) tweakParams.getOrDefault(TweaksSQL.SAMPLING_STRENGTH,"default"), true );
+
+     switch(((String) tweakParams.getOrDefault(TweaksSQL.SAMPLING_ALGORITHM, TweaksSQL.SAMPLING_ALGORITHM_DST)).toLowerCase() )
+     {
+       case TweaksSQL.SAMPLING_ALGORITHM_SZE  : bDistribution = false; break;
+       case TweaksSQL.SAMPLING_ALGORITHM_DST2 : bDistribution2 = true;
+       case TweaksSQL.SAMPLING_ALGORITHM_DST  :
+       default                                : bDistribution = true; break;
+     }
+   }
+
+   boolean bEnsureMode = TweaksSQL.ENSURE.equalsIgnoreCase(event.getTweakType());
+
+   float tblSampleRatio = ( (strength > 0 && bDistribution2) ? TweaksSQL.tableSampleRatio(strength) : -1f);
+
+   final String sCondition = ( ((bEnsureMode && strength == 0) || (tblSampleRatio >= 0.0)) ? "1 = 1" : TweaksSQL.strengthSql(strength,bDistribution)  ),
+                twqry = DhString.format(DhString.format("ST_Intersects(geo, ST_MakeEnvelope(%%.%1$df,%%.%1$df,%%.%1$df,%%.%1$df, 4326) ) and %%s", 14 /*GEOMETRY_DECIMAL_DIGITS*/), bbox.minLon(), bbox.minLat(), bbox.maxLon(), bbox.maxLat(), sCondition );
+
+   final SQLQuery tweakQuery = new SQLQuery(twqry);
+
+   if( !bEnsureMode || !bConvertGeo2Geojson ) {
+     SQLQuery combinedQuery = generateCombinedQuery(event, tweakQuery);
+     if (tblSampleRatio > 0.0)
+       combinedQuery.setQueryFragment("tableSample", DhString.format("tablesample system(%.6f) repeatable(499)", 100.0 * tblSampleRatio));
+     if (bSortByHashedValue)
+       combinedQuery.setQueryFragment("orderBy", "ORDER BY " + TweaksSQL.distributionFunctionIndexExpression());
+     return combinedQuery;
+   }
+
+
+   /* TweaksSQL.ENSURE and geojson requested (no mvt) */
+   boolean bTestTweaksGeoIfNull = false;
+   String tweaksGeoSql = clipProjGeom(bbox,"geo");
+   tweaksGeoSql = map2MvtGeom( event, bbox, tweaksGeoSql );
+   //convert to geojson
+   tweaksGeoSql = ( bConvertGeo2Geojson ? DhString.format("replace(ST_AsGeojson(" + getForceMode(event.isForce2D()) + "( %s ),%d),'nan','0')",tweaksGeoSql,GEOMETRY_DECIMAL_DIGITS)
+                                        : DhString.format( getForceMode(event.isForce2D()) + "( %s )",tweaksGeoSql ) );
+
+   return generateCombinedQueryTweaks(event, tweakQuery , tweaksGeoSql, bTestTweaksGeoIfNull, tblSampleRatio, bSortByHashedValue );
+}
+
+  private static String map2MvtGeom( GetFeaturesByBBoxEvent event, BBox bbox, String tweaksGeoSql )
+  {
+    boolean bExtentTweaks = // -> 2048 only if tweaks or viz been specified explicit
+        ( "viz".equals(event.getOptimizationMode()) || (event.getTweakParams() != null && event.getTweakParams().size() > 0 ) );
+
+    int extent = ( bExtentTweaks ? 2048 : 4096 ), extentPerMargin = extent / WebMercatorTile.TileSizeInPixel, extentWithMargin = extent, level = -1, tileX = -1, tileY = -1, margin = 0;
+    boolean hereTile = false;
+
+    if( event instanceof GetFeaturesByTileEvent )
+    { GetFeaturesByTileEvent tevnt = (GetFeaturesByTileEvent) event;
+      level = tevnt.getLevel();
+      tileX = tevnt.getX();
+      tileY = tevnt.getY();
+      margin = tevnt.getMargin();
+      extentWithMargin = extent + (margin * extentPerMargin);
+      hereTile = tevnt.getHereTileFlag();
+    }
+    else
+    { final WebMercatorTile tile = getTileFromBbox(bbox);
+      level = tile.level;
+      tileX = tile.x;
+      tileY = tile.y;
+    }
+
+    double wgs3857width = 20037508.342789244d, wgs4326width = 180d,
+        wgsWidth = 2 * ( !hereTile ? wgs3857width : wgs4326width ),
+        xwidth = wgsWidth,
+        ywidth = wgsWidth,
+        gridsize = (1L << level),
+        stretchFactor = 1.0 + ( margin / ((double) WebMercatorTile.TileSizeInPixel)), // xyz-hub uses margin for tilesize of 256 pixel.
+        xProjShift = (!hereTile ? (tileX - gridsize/2 + 0.5) * (xwidth / gridsize)      : -180d + (tileX + 0.5) * (xwidth / gridsize) ) ,
+        yProjShift = (!hereTile ? (tileY - gridsize/2 + 0.5) * (ywidth / gridsize) * -1 :  -90d + (tileY + 0.5) * (ywidth / gridsize) ) ;
+
+    String
+        box2d   = DhString.format( DhString.format("ST_MakeEnvelope(%%.%1$df,%%.%1$df,%%.%1$df,%%.%1$df, 4326)", 14 /*GEOMETRY_DECIMAL_DIGITS*/), bbox.minLon(), bbox.minLat(), bbox.maxLon(), bbox.maxLat() ),
+        // 1. build mvt
+        mvtgeom = DhString.format( (!hereTile ? "st_asmvtgeom(st_force2d(st_transform(%1$s,3857)), st_transform(%2$s,3857),%3$d,0,true)"
+                : "st_asmvtgeom(st_force2d(%1$s), %2$s,%3$d,0,true)")
+            , tweaksGeoSql, box2d, extentWithMargin);
+    // 2. project the mvt to tile
+    mvtgeom = DhString.format( (!hereTile ? "st_setsrid(st_translate(st_scale(st_translate(%1$s, %2$d , %2$d, 0.0), st_makepoint(%3$f,%4$f,1.0) ), %5$f , %6$f, 0.0 ), 3857)"
+            : "st_setsrid(st_translate(st_scale(st_translate(%1$s, %2$d , %2$d, 0.0), st_makepoint(%3$f,%4$f,1.0) ), %5$f , %6$f, 0.0 ), 4326)")
+        ,mvtgeom
+        ,-extentWithMargin/2 // => shift to stretch from tilecenter
+        ,stretchFactor*(xwidth / (gridsize*extent)), stretchFactor * (ywidth / (gridsize*extent)) * -1 // stretch tile to proj. size
+        ,xProjShift, yProjShift // shift to proj. position
+    );
+    // 3 project tile to wgs84 and map invalid geom to null
+
+    mvtgeom = DhString.format( (!hereTile ? "(select case st_isvalid(g) when true then g else null end from st_transform(%1$s,4326) g)"
+            : "(select case st_isvalid(g) when true then g else null end from %1$s g)")
+        , mvtgeom );
+
+    // 4. assure intersect with origin bbox in case of mapping errors
+    mvtgeom  = DhString.format("ST_Intersection(%1$s,st_setsrid(%2$s,4326))", mvtgeom, box2d);
+    // 5. map non-null but empty polygons to null - e.g. avoid -> "geometry": { "type": "Polygon", "coordinates": [] }
+    mvtgeom = DhString.format("(select case st_isempty(g) when false then g else null end from %1$s g)", mvtgeom );
+
+    // if geom = point | multipoint then no mvt <-> geo conversion should be done
+    mvtgeom = DhString.format("case strpos(ST_GeometryType( geo ), 'Point') > 0 when true then geo else %1$s end", mvtgeom );
+
+    return mvtgeom;
+  }
+
+  private static String clipProjGeom(BBox bbox, String tweaksGeoSql )
+  {
+    String fmt =  DhString.format(  " case st_within( %%1$s, ST_MakeEnvelope(%%2$.%1$df,%%3$.%1$df,%%4$.%1$df,%%5$.%1$df, 4326) ) "
+        + "  when true then %%1$s "
+        + "  else ST_Intersection(ST_MakeValid(%%1$s),ST_MakeEnvelope(%%2$.%1$df,%%3$.%1$df,%%4$.%1$df,%%5$.%1$df, 4326))"
+        + " end " , 14 /*GEOMETRY_DECIMAL_DIGITS*/ );
+    return DhString.format( fmt, tweaksGeoSql, bbox.minLon(), bbox.minLat(), bbox.maxLon(), bbox.maxLat());
+  }
+
+  private double cToleranceFromStrength(int strength )
+  {
+   double tolerance = 0.0001;
+   if(  strength > 0  && strength <= 25 )      tolerance = 0.0001 + ((0.001-0.0001)/25.0) * (strength -  1);
+   else if(  strength > 25 && strength <= 50 ) tolerance = 0.001  + ((0.01 -0.001) /25.0) * (strength - 26);
+   else if(  strength > 50 && strength <= 75 ) tolerance = 0.01   + ((0.1  -0.01)  /25.0) * (strength - 51);
+   else /* [76 - 100 ] */                      tolerance = 0.1    + ((1.0  -0.1)   /25.0) * (strength - 76);
+
+   return tolerance;
+  }
+
+  private SQLQuery buildSimplificationTweaksQuery(GetFeaturesByBBoxEvent event, Map tweakParams) throws SQLException
+  {
+    BBox bbox = event.getBbox();
+   int strength = 0,
+       iMerge = 0;
+   String tweaksGeoSql = "geo";
+   boolean bStrength = true, bTestTweaksGeoIfNull = true, convertGeo2Geojson = getResponseType(event) == GEO_JSON, bMvtRequested = !convertGeo2Geojson;
+
+   if( tweakParams != null )
+   {
+    if( tweakParams.get(TweaksSQL.SIMPLIFICATION_STRENGTH) instanceof Integer )
+     strength = (int) tweakParams.get(TweaksSQL.SIMPLIFICATION_STRENGTH);
+    else
+     switch(((String) tweakParams.getOrDefault(TweaksSQL.SIMPLIFICATION_STRENGTH,"default")).toLowerCase() )
+     { case "low"     : strength =  20;  break;
+       case "lowmed"  : strength =  40;  break;
+       case "med"     : strength =  60;  break;
+       case "medhigh" : strength =  80;  break;
+       case "high"    : strength = 100; break;
+       case "default" : bStrength = false;
+       default: strength  = 50; break;
+     }
+
+     String tweaksAlgorithm = ((String) tweakParams.getOrDefault(TweaksSQL.SIMPLIFICATION_ALGORITHM,"default")).toLowerCase();
+
+     // do clip before simplification -- preventing extrem large polygon for further working steps (except for mvt with gridbytilelevel, redundancy)
+     if (event.getClip() && !( TweaksSQL.SIMPLIFICATION_ALGORITHM_A05.equals( tweaksAlgorithm ) && bMvtRequested ) )
+      tweaksGeoSql = clipProjGeom( bbox,tweaksGeoSql );
+
+     //SIMPLIFICATION_ALGORITHM
+     int hint = 0;
+     String[] pgisAlgorithm = { "ST_SnapToGrid", "ftm_SimplifyPreserveTopology", "ftm_Simplify" };
+
+     switch( tweaksAlgorithm )
+     {
+       case TweaksSQL.SIMPLIFICATION_ALGORITHM_A03 : hint++;
+       case TweaksSQL.SIMPLIFICATION_ALGORITHM_A02 : hint++;
+       case TweaksSQL.SIMPLIFICATION_ALGORITHM_A01 :
+       {
+        double tolerance = ( bStrength ? cToleranceFromStrength( strength ) : Math.abs( bbox.maxLon() - bbox.minLon() ) / 4096 );
+        tweaksGeoSql = DhString.format("%s(%s, %f)", pgisAlgorithm[hint], tweaksGeoSql, tolerance );
+       }
+       break;
+
+       case TweaksSQL.SIMPLIFICATION_ALGORITHM_A05 : // gridbytilelevel - convert to/from mvt
+       {
+        if(!bMvtRequested)
+         tweaksGeoSql = map2MvtGeom( event, bbox, tweaksGeoSql );
+        bTestTweaksGeoIfNull = false;
+       }
+       break;
+
+       case TweaksSQL.SIMPLIFICATION_ALGORITHM_A06 : iMerge++;
+       case TweaksSQL.SIMPLIFICATION_ALGORITHM_A04 : iMerge++; break;
+
+       default: break;
+     }
+
+     //convert to geojson
+     tweaksGeoSql = ( convertGeo2Geojson ? DhString.format("replace(ST_AsGeojson(" + getForceMode(event.isForce2D()) + "( %s ),%d),'nan','0')",tweaksGeoSql,GEOMETRY_DECIMAL_DIGITS)
+                                          : DhString.format( getForceMode(event.isForce2D()) + "( %s )",tweaksGeoSql) );
+   }
+
+     final String bboxqry = DhString.format( DhString.format("ST_Intersects(geo, ST_MakeEnvelope(%%.%1$df,%%.%1$df,%%.%1$df,%%.%1$df, 4326) )", 14 /*GEOMETRY_DECIMAL_DIGITS*/), bbox.minLon(), bbox.minLat(), bbox.maxLon(), bbox.maxLat() );
+
+     if (iMerge == 0)
+       return generateCombinedQueryTweaks(event, new SQLQuery(bboxqry), tweaksGeoSql, bTestTweaksGeoIfNull, -1.0f, false );
+
+     // Merge Algorithm - only using low, med, high
+
+     int minGeoHashLenToMerge = 0,
+         minGeoHashLenForLineMerge = 3;
+
+     if      ( strength <= 20 ) { minGeoHashLenToMerge = 7; minGeoHashLenForLineMerge = 7; } //low
+     else if ( strength <= 40 ) { minGeoHashLenToMerge = 6; minGeoHashLenForLineMerge = 6; } //lowmed
+     else if ( strength <= 60 ) { minGeoHashLenToMerge = 6; minGeoHashLenForLineMerge = 5; } //med
+     else if ( strength <= 80 ) {                           minGeoHashLenForLineMerge = 4; } //medhigh
+
+     if( "geo".equals(tweaksGeoSql) ) // formal, just in case
+      tweaksGeoSql = ( convertGeo2Geojson ? DhString.format("replace(ST_AsGeojson(" + getForceMode(event.isForce2D()) + "( %s ),%d),'nan','0')",tweaksGeoSql,GEOMETRY_DECIMAL_DIGITS)
+                                           : DhString.format(getForceMode(event.isForce2D()) + "( %s )",tweaksGeoSql) );
+
+     if( convertGeo2Geojson )
+      tweaksGeoSql = DhString.format("(%s)::jsonb", tweaksGeoSql);
+
+
+     SQLQuery query = buildSimplificationTweaksMergeQuery(event, iMerge, tweaksGeoSql, minGeoHashLenToMerge, minGeoHashLenForLineMerge, bboxqry, convertGeo2Geojson);
+     final SQLQuery searchQuery = generateSearchQuery(event);
+     if (searchQuery != null)
+       query.setQueryFragment("searchQuery", new SQLQuery("AND ${{sq}}").withQueryFragment("sq", searchQuery));
+     return query;
+}
+
+  private SQLQuery buildSimplificationTweaksMergeQuery(GetFeaturesByBBoxEvent event, int iMerge, String tweaksGeoSql, int minGeoHashLenToMerge, int minGeoHashLenForLineMerge, String bboxQuery, boolean convertGeo2Geojson) {
+      SQLQuery query;
+      if (iMerge == 1) {
+        query = new SQLQuery("select jsondata, geo "
+            +"from "
+            +"( "
+            +" select jsonb_set('{\"type\": \"Feature\"}'::jsonb,'{properties}', jsonb_set( case when (ginfo->>1)::integer = 1 then jsonb_set( '{}'::jsonb,'{ids}', ids ) else '{}'::jsonb end , '{groupInfo}', ginfo )) as jsondata, ${{tweaksGeo}} as geo"
+            +" from "
+            +" ( "
+            +"  select jsonb_build_array(left(md5( gh || gsz ), 12), row_number() over w, count(1) over w, nrobj ) as ginfo, * "
+            +"  from "
+            +"  ( "
+            +"   select gh, case length(gh) > #{minGeoHashLenToMerge} when true then 0 else i end as gsz, count(1) as nrobj, jsonb_agg(id) as ids, (st_dump( st_union(oo.geo) )).geom as geo "
+            +"   from "
+            +"   ( "
+            +"    select ST_GeoHash(geo) as gh, i, id , geo "
+            +"    from "
+            +"    ( "
+            +"     select i, id, geo "  // fetch objects
+            +"     from ${schema}.${table} "
+            +"     where 1 = 1 "
+            +"       and ${{bboxQuery}} ${{searchQuery}} " + "    ) o "
+            +"   ) oo "
+            +"   group by gsz, gh"
+            +"  ) ooo window w as (partition by gh, gsz ) "
+            +" ) oooo "
+            +") ooooo "
+            +"where geo IS NOT NULL AND ${{geoCheck}} LIMIT #{limit}")
+            .withQueryFragment("geoCheck", convertGeo2Geojson
+                ? "geo->>'type' != 'GeometryCollection' and jsonb_array_length(geo->'coordinates') > 0 "
+                : "geometrytype(geo) != 'GEOMETRYCOLLECTION' and not st_isempty(geo) ")
+            .withNamedParameter("minGeoHashLenToMerge", minGeoHashLenToMerge);
+      }
+      else {
+        query = new SQLQuery("with "
+            +"indata as "
+            +"( select i, ${{geo}} as geo from ${schema}.${table} "
+            +"  where 1 = 1 "
+            +"    and ${{bboxQuery}} ${{searchQuery}}), "
+            +"cx2ids as "
+            +"( select left( gid, #{minGeoHashLenForLineMerge} ) as region, ids "
+            +"  from "
+            +"  ( select gid, array_agg( i ) as ids "
+            +"    from "
+            +"    ( select i, unnest( array[ ST_GeoHash( st_startpoint(geo),9 ) , ST_GeoHash( st_endpoint(geo), 9 ) ] ) as gid from indata where ( geometrytype(geo) = 'LINESTRING' ) ) o "
+            +"    group by gid "
+            +"  ) o	"
+            +"  where 1 = 1 "
+            +"    and cardinality(ids) = 2 "
+            +"), "
+            +"cxlist as "
+            +"( select count(1) over ( PARTITION BY region ) as rcount, array[(row_number() over ( PARTITION BY region ))::integer] as rids, region, ids from cx2ids ), "
+            +"mergedids as "
+            +"( with recursive mrgdids( step, region, rcount, rids, ids ) as "
+            +"  ( "
+            +"	  select 1, region, rcount, rids, ids from cxlist "
+            +"	 union all "
+            +"		select distinct on (region, rids[1] ) * "
+            +"		from "
+            +"		( select l.step+1 as step, l.region, l.rcount, array( select unnest( l.rids || r.rids ) order by 1 )  as rids, l.ids || r.ids as ids "
+            +"		  from mrgdids l join cxlist r on ( l.region = r.region and not (l.rids @> r.rids) and  (l.ids && r.ids ) ) "
+            +"		  where 1 = 1 "
+            +"		) i1 "
+            +"	) "
+            +"  select l.region, l.rcount, l.step, l.rids, array( select distinct unnest( l.ids ) ) as ids "
+            +"  from mrgdids l left join mrgdids r on ( l.region = r.region and l.step < r.step and l.rids <@ r.rids ) "
+            +"  where 1 = 1 "
+            +"    and r.region is null "
+            +"), "
+            +"ccxuniqid as "
+            +"( select distinct unnest(ids) as id from cx2ids ), "
+            +"iddata as "
+            +"(  select step, ids from mergedids "
+            +"  union "
+            +"   select 0 as step, array[i] as ids from indata where not i in (select id from ccxuniqid ) "
+            +"), "
+            +"finaldata as "
+            +"(	select "
+            +"   case when step = 0 "
+            +"    then ( SELECT ${{selection}} FROM ${schema}.${table} where i = ids[1] ) "
+            +"    else ( select jsonb_set( jsonb_set('{\"type\":\"Feature\",\"properties\":{}}'::jsonb,'{id}', to_jsonb( max(jsondata->>'id') )),'{properties,ids}', jsonb_agg( jsondata->>'id' )) from ${schema}.${table} where i in ( select unnest( ids ) ) ) "
+            +"   end as jsondata, "
+            +"   case when step = 0 "
+            +"    then ( select geo from ${schema}.${table} where i = ids[1] ) "
+            +"    else ( select ST_LineMerge( st_collect( geo ) ) from ${schema}.${table} where i in ( select unnest( ids )) ) "
+            +"   end as geo "
+            +"  from iddata "
+            +") "
+            +"select jsondata, ${{tweaksGeo}} as geo from finaldata LIMIT #{limit}")
+            .withQueryFragment("geo", "geo") //(event.getClip() ? clipProjGeom(bbox,"geo") : "geo")
+            .withQueryFragment("selection", buildSelectionFragment(event))
+            .withNamedParameter("minGeoHashLenForLineMerge", minGeoHashLenForLineMerge);
+
+      }
+      return query
+          .withVariable(SCHEMA, getSchema())
+          .withVariable(TABLE, readTableFromEvent(event))
+          .withQueryFragment("tweaksGeo", tweaksGeoSql)
+          .withQueryFragment("bboxQuery", bboxQuery)
+          .withNamedParameter("limit", event.getLimit());
+
+  }
+
+  /** ###################################################################################### */
+
+  private SQLQuery generateCombinedQueryTweaks(GetFeaturesByBBoxEvent event, SQLQuery indexedQuery, String tweaksgeo, boolean testTweaksGeoIfNull, float sampleRatio, boolean sortByHashedValue)
+  {
+    SQLQuery searchQuery = generateSearchQuery(event);
+
+    final SQLQuery query = new SQLQuery("SELECT * FROM (SELECT ${{selection}}${{geo}} FROM ${schema}.${table} ${{sampling}} WHERE ${{indexedQuery}} ${{searchQuery}} ${{orderBy}}) tw ${{outerWhereClause}} LIMIT #{limit}")
+        .withVariable(SCHEMA, getSchema())
+        .withVariable(TABLE, readTableFromEvent(event) + HEAD_TABLE_SUFFIX)
+        .withQueryFragment("selection", buildSelectionFragment(event))
+        .withQueryFragment("geo", DhString.format(",%s as geo", tweaksgeo))
+        .withQueryFragment("sampling", "")
+        .withQueryFragment("indexedQuery", indexedQuery)
+        .withQueryFragment("searchQuery", "")
+        .withQueryFragment("orderBy", "")
+        .withQueryFragment("outerWhereClause", "")
+        .withNamedParameter("limit", event.getLimit());
+
+    if (sampleRatio > 0) {
+      SQLQuery sampling = new SQLQuery("tablesample system(#{samplePercentage}) repeatable(499)")
+          .withNamedParameter("samplePercentage", 100f * sampleRatio);
+      query.setQueryFragment("sampling", sampling);
+    }
+
+    if (searchQuery != null)
+      query.setQueryFragment("searchQuery", new SQLQuery("AND ${{sq}}").withQueryFragment("sq", searchQuery));
+
+    if (sortByHashedValue)
+      query.setQueryFragment("orderBy", "ORDER BY " + TweaksSQL.distributionFunctionIndexExpression());
+
+    if (testTweaksGeoIfNull)
+      query.setQueryFragment("outerWhereClause", "geo IS NOT NULL");
+
+    return query;
   }
 }

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeaturesByGeometry.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeaturesByGeometry.java
@@ -34,21 +34,6 @@ public class GetFeaturesByGeometry extends Spatial<GetFeaturesByGeometryEvent, F
 
   @Override
   protected SQLQuery buildGeoFilter(GetFeaturesByGeometryEvent event) {
-    return buildSpatialGeoFilter(event);
-  }
-
-  @Override
-  protected SQLQuery buildClippedGeoFragment(final GetFeaturesByGeometryEvent event, SQLQuery geoFilter) {
-    if (!event.getClip())
-      return super.buildGeoFragment(event);
-
-    SQLQuery clippedGeo = new SQLQuery("ST_Intersection(ST_MakeValid(geo), ${{geoFilter}})")
-        .withQueryFragment("geoFilter", geoFilter);
-
-    return super.buildGeoFragment(event, clippedGeo);
-  }
-
-  public static SQLQuery buildSpatialGeoFilter(GetFeaturesByGeometryEvent event){
     final int radius = event.getRadius();
 
     SQLQuery geoFilter = event.getH3Index() != null
@@ -63,5 +48,4 @@ public class GetFeaturesByGeometry extends Spatial<GetFeaturesByGeometryEvent, F
               .withNamedParameter("radius", radius);
     return geoFilter;
   }
-
 }

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeaturesById.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeaturesById.java
@@ -32,9 +32,8 @@ public class GetFeaturesById extends GetFeatures<GetFeaturesByIdEvent, FeatureCo
   }
 
   @Override
-  protected SQLQuery buildQuery(GetFeaturesByIdEvent event) throws SQLException, ErrorResponseException {
-    return super.buildQuery(event)
-        .withQueryFragment("filterWhereClause", "id = ANY(#{ids})")
+  protected SQLQuery buildFilterWhereClause(GetFeaturesByIdEvent event) {
+    return new SQLQuery("id = ANY(#{ids})")
         .withNamedParameter("ids", event.getIds().toArray(new String[0]));
   }
 }

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/IterateFeatures.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/IterateFeatures.java
@@ -19,10 +19,8 @@
 
 package com.here.xyz.psql.query;
 
-import static com.here.xyz.events.ContextAwareEvent.SpaceContext.COMPOSITE_EXTENSION;
-import static com.here.xyz.events.ContextAwareEvent.SpaceContext.DEFAULT;
-
 import com.here.xyz.connectors.ErrorResponseException;
+import com.here.xyz.events.ContextAwareEvent;
 import com.here.xyz.events.IterateFeaturesEvent;
 import com.here.xyz.models.geojson.implementation.FeatureCollection;
 import com.here.xyz.psql.tools.ECPSTool;
@@ -34,7 +32,9 @@ import java.sql.SQLException;
 public class IterateFeatures extends SearchForFeatures<IterateFeaturesEvent, FeatureCollection> {
   private static final String HANDLE_ENCRYPTION_PHRASE = "IterateFeatures";
   protected long limit;
-  protected long start;
+  private boolean hasHandle;
+  private long start;
+  private int startDataset = -1;
   private String nextDataset = null;
   private String nextIOffset = "";
   private int numFeatures = 0;
@@ -42,100 +42,81 @@ public class IterateFeatures extends SearchForFeatures<IterateFeaturesEvent, Fea
   public IterateFeatures(IterateFeaturesEvent event) throws SQLException, ErrorResponseException {
     super(event);
     limit = event.getLimit();
+    hasHandle = event.getHandle() != null;
+    if (hasHandle)
+      parseHandleContent(event.getHandle());
   }
 
   @Override
-  protected SQLQuery buildQuery(IterateFeaturesEvent event) throws SQLException, ErrorResponseException {
-    if (isCompositeQuery(event)) {
-      SQLQuery extensionQuery = super.buildQuery(event);
-      extensionQuery.setQueryFragment("filterWhereClause", "TRUE"); //TODO: Do not support search on iterate for now
-      extensionQuery.setQueryFragment("iColumn", ", i, dataset");
-
-      if (is2LevelExtendedSpace(event)) {
-        int ds = 3;
-
-        ds--;
-        extensionQuery.setQueryFragment("iColumnBase", buildIColumnFragment(ds));
-        extensionQuery.setQueryFragment("iOffsetBase", buildIOffsetFragment(event, ds));
-
-        ds--;
-        extensionQuery.setQueryFragment("iColumnIntermediate", buildIColumnFragment(ds));
-        extensionQuery.setQueryFragment("iOffsetIntermediate", buildIOffsetFragment(event, ds));
-
-        ds--;
-        extensionQuery.setQueryFragment("iColumnExtension", buildIColumnFragment(ds));
-        extensionQuery.setQueryFragment("iOffsetExtension", buildIOffsetFragment(event, ds));
-      }
-      else {
-        int ds = 2;
-
-        ds--;
-        extensionQuery.setQueryFragment("iColumnBase", buildIColumnFragment(ds));
-        extensionQuery.setQueryFragment("iOffsetBase", buildIOffsetFragment(event, ds));
-
-        ds--;
-        extensionQuery.setQueryFragment("iColumnExtension", buildIColumnFragment(ds));
-        extensionQuery.setQueryFragment("iOffsetExtension", buildIOffsetFragment(event, ds));
-      }
-      extensionQuery.setNamedParameter("currentDataset", getDatasetFromHandle(event));
-
-      SQLQuery query = new SQLQuery(
-          "SELECT * FROM (${{extensionQuery}}) orderQuery ORDER BY dataset, i ${{limit}}");
-      query.setQueryFragment("extensionQuery", extensionQuery);
-      query.setQueryFragment("limit", buildLimitFragment(event.getLimit()));
-
-      return query;
-    }
-    else {
-      //It's not a composite space or only SUPER / EXTENSION is queried
-      SQLQuery query = super.buildQuery(event);
-      query.setQueryFragment("iColumn", ", i");
-
-      boolean hasHandle = event.getHandle() != null;
-      start = hasHandle ? Long.parseLong(event.getHandle()) : 0L;
-
-      if (hasSearch) {
-        if (hasHandle)
-          query.setQueryFragment("offset", "OFFSET #{startOffset}");
-      }
-      else {
-        if (hasHandle)
-          query.setQueryFragment("filterWhereClause", "i > #{startOffset}");
-
-        query.setQueryFragment("orderBy", "ORDER BY i");
-      }
-
-      if (hasHandle)
-        query.setNamedParameter("startOffset", start);
-
-      return query;
-    }
+  protected SQLQuery buildSelectClause(IterateFeaturesEvent event, int dataset) {
+    return new SQLQuery("${{innerSelectClause}}, i")
+        .withQueryFragment("innerSelectClause", super.buildSelectClause(event, dataset));
   }
 
-  protected boolean isCompositeQuery(IterateFeaturesEvent event) {
-    return isExtendedSpace(event) && (event.getContext() == DEFAULT || event.getContext() == COMPOSITE_EXTENSION);
+  @Override
+  protected SQLQuery buildFiltersFragment(IterateFeaturesEvent event, boolean isExtension, SQLQuery filterWhereClause, int dataset) {
+    final SQLQuery filtersFragment = super.buildFiltersFragment(event, isExtension, filterWhereClause, dataset);
+
+    if (!isCompositeQuery(event))
+      return filtersFragment;
+
+    return new SQLQuery("${{innerFilters}} ${{offsetFilter}}")
+        .withQueryFragment("innerFilters", filtersFragment)
+        .withQueryFragment("offsetFilter", buildOffsetFilterFragment(event, dataset));
   }
 
-  private static String buildIColumnFragment(int dataset) {
-    return ", i, " + dataset + " as dataset";
+  @Override
+  protected SQLQuery buildFilterWhereClause(IterateFeaturesEvent event) {
+    if (isCompositeQuery(event))
+      return new SQLQuery("TRUE"); //TODO: Do not support search on iterate for now
+
+    if (!hasSearch && event.getHandle() != null)
+      return new SQLQuery("i > #{startOffset}")
+          .withNamedParameter("startOffset", start);
+
+    return super.buildFilterWhereClause(event);
   }
 
-  private SQLQuery buildIOffsetFragment(IterateFeaturesEvent event, int dataset) {
+  @Override
+  protected String buildOrderByFragment(ContextAwareEvent event) {
+    if (hasSearch && hasHandle)
+      return super.buildOrderByFragment(event);
+
+    return "ORDER BY dataset, i";
+  }
+
+  private SQLQuery buildOffsetFilterFragment(IterateFeaturesEvent event, int dataset) {
     return new SQLQuery("AND " + dataset + " >= #{currentDataset} "
-        + "AND (" + dataset + " > #{currentDataset} OR i > #{startOffset}) ORDER BY i")
-        .withNamedParameter("startOffset", getIOffsetFromHandle(event));
+        + "AND (" + dataset + " > #{currentDataset} OR i > #{startOffset})")
+        .withNamedParameter("currentDataset", startDataset)
+        .withNamedParameter("startOffset", start);
   }
 
-  private int getDatasetFromHandle(IterateFeaturesEvent event) {
-    if (event.getHandle() == null)
-      return -1;
-    return Integer.parseInt(event.getHandle().split("_")[0]);
+  @Override
+  protected SQLQuery buildLimitFragment(IterateFeaturesEvent event) {
+    if (hasSearch && hasHandle)
+      return new SQLQuery("${{innerLimit}} OFFSET #{startOffset}")
+          .withQueryFragment("innerLimit", super.buildLimitFragment(event))
+          .withNamedParameter("startOffset", start);
+
+    return super.buildLimitFragment(event);
   }
 
-  private int getIOffsetFromHandle(IterateFeaturesEvent event) {
-    if (event.getHandle() == null)
-      return 0;
-    return Integer.parseInt(event.getHandle().split("_")[1]);
+  private void parseHandleContent(String handle) {
+    if (handle.contains("_")) {
+      startDataset = getDatasetFromHandle(handle);
+      start = getIOffsetFromHandle(handle);
+    }
+    else
+      start = Long.parseLong(handle);
+  }
+
+  private int getDatasetFromHandle(String handle) {
+    return Integer.parseInt(handle.split("_")[0]);
+  }
+
+  private int getIOffsetFromHandle(String handle) {
+    return Integer.parseInt(handle.split("_")[1]);
   }
 
   @Override

--- a/xyz-psql-connector/src/main/resources/xyz_ext.sql
+++ b/xyz-psql-connector/src/main/resources/xyz_ext.sql
@@ -3109,48 +3109,6 @@ BEGIN
 END$$;
 ------------------------------------------------
 ------------------------------------------------
-CREATE OR REPLACE FUNCTION transform_load_features_input(ids TEXT[], versions BIGINT[])
-    RETURNS LOAD_FEATURE_VERSION_INPUT[] AS
-$BODY$
-DECLARE
-    output LOAD_FEATURE_VERSION_INPUT[];
-    item LOAD_FEATURE_VERSION_INPUT;
-BEGIN
-    IF coalesce(array_length(ids, 1),0) > 0 THEN
-        FOR i IN 1 .. array_upper(ids, 1)
-            LOOP
-                item := ROW(ids[i], versions[i]);
-                SELECT array_append(output, item) into output;
-
-            END LOOP;
-    END IF;
-    RETURN output;
-END
-$BODY$
-    LANGUAGE plpgsql VOLATILE;
-------------------------------------------------
-------------------------------------------------
-CREATE OR REPLACE FUNCTION transform_load_features_input(ids TEXT[])
-    RETURNS LOAD_FEATURE_VERSION_INPUT[] AS
-$BODY$
-DECLARE
-    output LOAD_FEATURE_VERSION_INPUT[];
-    versions BIGINT[];
-BEGIN
-    IF array_length(ids, 1) IS NULL THEN
-        RETURN output;
-    ELSE
-        FOR i IN 1 .. array_upper(ids, 1)
-        LOOP
-            versions := array_append(versions, max_bigint());
-        END LOOP;
-        RETURN transform_load_features_input(ids, versions);
-    END IF;
-END
-$BODY$
-LANGUAGE plpgsql VOLATILE;
-------------------------------------------------
-------------------------------------------------
 CREATE OR REPLACE FUNCTION xyz_create_history_partition(schema TEXT, rootTable TEXT, partitionNo BIGINT, partitionSize BIGINT)
     RETURNS VOID AS
 $BODY$


### PR DESCRIPTION
- Group all select clause related fragments into one "selectClause" fragment
- Group all filter related fragments into existing filterWhereClause and simplify overriding it partially
- Pull up dataset identification column definition
- Pull up the orderBy fragment from IterateFeatures QR into GetFeatures QR
- Push down offset fragments into IterateFeatures QR
- Push down all tweaks related methods from GetFeaturesByBBox to GetFeaturesByBBoxTweaked