### PR TITLE
Improve s3-explorer to work with localstack

### DIFF
--- a/Dockerfile-s3-explorer
+++ b/Dockerfile-s3-explorer
@@ -1,0 +1,10 @@
+FROM deskoh/aws-js-s3-explorer
+
+#Patch settings to use local stack endpoint and default local bucket
+RUN echo 'AWS.config = new AWS.Config({credentials: new AWS.Credentials("localstack", "localstack"), endpoint: new AWS.Endpoint("http://localhost:4566"), s3ForcePathStyle: true}); \
+    addEventListener("load", event => { \
+    settingsScope.settings.entered_bucket = "test-bucket"; \
+    settingsScope.settings.auth = "auth"; \
+    settingsScope.settings.cred = {endpointUrl: "http://localhost:4566", accessKeyId: "localstack", secretAccessKey: "localstack", s3ForcePathStyle: true}; \
+    settingsScope.update(); \
+    });' >> explorer.js

--- a/docker-compose-dynamodb.yml
+++ b/docker-compose-dynamodb.yml
@@ -82,10 +82,14 @@ services:
             - AWS_ACCESS_KEY_ID=localstack
             - AWS_SECRET_ACCESS_KEY=localstack
             - AWS_DEFAULT_REGION=eu-west-1
+            - EXTRA_CORS_ALLOWED_ORIGINS=http://localhost:5001
         volumes:
             - ./xyz-hub-test/src/test/resources/mock-servers/localstack/docker-entrypoint-initaws.d/01-create-bucket.sh:/etc/localstack/init/ready.d/init-aws.sh
     s3-explorer:
-        image: deskoh/aws-js-s3-explorer
+        image: aws-js-s3-explorer
+        build:
+            context: ./
+            dockerfile: Dockerfile-s3-explorer
         container_name: s3-explorer
         ports:
             - "5001:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,5 +59,14 @@ services:
             - AWS_ACCESS_KEY_ID=localstack
             - AWS_SECRET_ACCESS_KEY=localstack
             - AWS_DEFAULT_REGION=eu-west-1
+            - EXTRA_CORS_ALLOWED_ORIGINS=http://localhost:5001
         volumes:
             - ./xyz-hub-test/src/test/resources/mock-servers/localstack/docker-entrypoint-initaws.d/01-create-bucket.sh:/etc/localstack/init/ready.d/init-aws.sh
+    s3-explorer:
+        image: aws-js-s3-explorer
+        build:
+            context: ./
+            dockerfile: Dockerfile-s3-explorer
+        container_name: s3-explorer
+        ports:
+            - "5001:8080"


### PR DESCRIPTION
- Allow CORS for localstack S3 from localhost:5001 (S3 explorer)
- Patch AWS.config & S3-explorer config at startup to use localstack endpoint and default test-bucket with predefined testing credentials