### PR TITLE
Fix missing namespace properties in non-modified features

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/task/FeatureTaskHandler.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/task/FeatureTaskHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2023 HERE Europe B.V.
+ * Copyright (C) 2017-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1291,8 +1291,8 @@ public class FeatureTaskHandler {
         if( task.hasNonModified ){
           task.modifyOp.entries.stream().filter(e -> !e.isModified).forEach(e -> {
             try {
-              if(e.result != null)
-                fc.getFeatures().add(e.result);
+              if(e.base != null)
+                fc.getFeatures().add(e.base);
             } catch (JsonProcessingException ignored) {}
           });
         }

--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/UpdateFeatureApiIT.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/UpdateFeatureApiIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2023 HERE Europe B.V.
+ * Copyright (C) 2017-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.notNullValue;
 
 import com.here.xyz.XyzSerializable;
 import com.here.xyz.models.geojson.coordinates.LineStringCoordinates;
@@ -385,4 +386,32 @@ public class UpdateFeatureApiIT extends TestSpaceWithFeature {
         then().
         statusCode(OK.code());
   }
+
+  @Test
+  public void updateFeatureById_putNonModified() {
+    given().
+        accept(APPLICATION_GEO_JSON).
+        contentType(APPLICATION_GEO_JSON).
+        headers(getAuthHeaders(AuthProfile.ACCESS_OWNER_1_ADMIN)).
+        body(content("/xyz/hub/updateFeatureNonModified.json")).
+        when().
+        put(getSpacesPath() + "/x-psql-test/features")
+        .prettyPeek().
+        then().
+        statusCode(OK.code()).
+        body("features[0].properties.'@ns:com:here:xyz'.createdAt", notNullValue());
+
+    given().
+        accept(APPLICATION_GEO_JSON).
+        contentType(APPLICATION_GEO_JSON).
+        headers(getAuthHeaders(AuthProfile.ACCESS_OWNER_1_ADMIN)).
+        body(content("/xyz/hub/updateFeatureNonModified.json")).
+        when().
+        put(getSpacesPath() + "/x-psql-test/features")
+        .prettyPeek().
+        then().
+        statusCode(OK.code()).
+        body("features[0].properties.'@ns:com:here:xyz'.createdAt", notNullValue());
+  }
+
 }

--- a/xyz-hub-test/src/test/resources/xyz/hub/updateFeatureNonModified.json
+++ b/xyz-hub-test/src/test/resources/xyz/hub/updateFeatureNonModified.json
@@ -1,0 +1,21 @@
+{
+    "type": "Feature",
+    "id": "A",
+    "geometry": {
+        "type": "Point",
+        "coordinates": [
+            0.0,
+            0.0,
+            0.0
+        ]
+    },
+    "properties": {
+        "@ns:com:here:xyz": {
+            "space": "x-psql-test",
+            "createdAt": 1711038285360,
+            "updatedAt": 1711038285360,
+            "version": 1
+        },
+        "name": "test"
+    }
+}


### PR DESCRIPTION
Features contained in the request payload, which require no update in the database are returned in the payload response.
Those features were provided in the response payload without the properties from the xyz namespace.