### PR TITLE
Some minor improvements in the tagging implementation

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/httpconnector/util/jobs/Export.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/httpconnector/util/jobs/Export.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2023 HERE Europe B.V.
+ * Copyright (C) 2017-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,7 +69,7 @@ import com.here.xyz.jobs.datasets.DatasetDescription;
 import com.here.xyz.jobs.datasets.FileBasedTarget;
 import com.here.xyz.jobs.datasets.FileOutputSettings;
 import com.here.xyz.jobs.datasets.Identifiable;
-import com.here.xyz.jobs.datasets.VersionRefSource;
+import com.here.xyz.jobs.datasets.VersionedSource;
 import com.here.xyz.jobs.datasets.files.Csv;
 import com.here.xyz.jobs.datasets.files.FileFormat;
 import com.here.xyz.jobs.datasets.files.GeoJson;
@@ -268,16 +268,17 @@ public class Export extends JDBCBasedJob<Export> {
                 if (readParamExtends() != null && context == null)
                     addParam(PARAM_CONTEXT, DEFAULT);
 
-                if (getSource() instanceof VersionRefSource<?> versionRefSource
+                if (getSource() instanceof VersionedSource<?> versionRefSource
                     && getSource() instanceof Identifiable<?> identifiable
                     && versionRefSource.getVersionRef() != null
-                    && !versionRefSource.getVersionRef().isResolved()) {
+                    && versionRefSource.getVersionRef().isTag()) {
                   final Ref ref = versionRefSource.getVersionRef();
                   try {
-                    long version = CService.hubWebClient.getTag(identifiable.getId(), ref.getVersionRef()).getVersion();
-                    ref.setVersion(version);
+                    long version = CService.hubWebClient.loadTag(identifiable.getId(), ref.getTag()).getVersion();
+                    versionRefSource.setVersionRef(new Ref(version));
                     setTargetVersion(String.valueOf(version));
-                  } catch (HubWebClientException e) {
+                  }
+                  catch (HubWebClientException e) {
                     return Future.failedFuture(e);
                   }
                 }

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/SpaceBasedApi.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/SpaceBasedApi.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) 2017-2024 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
 package com.here.xyz.hub.rest;
 
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
@@ -76,7 +95,7 @@ public abstract class SpaceBasedApi extends Api {
       return new Ref(versionRef);
     }
     catch (InvalidRef e) {
-      throw new HttpException(BAD_REQUEST, "Invalid value for version: " + version, e);
+      throw new HttpException(BAD_REQUEST, "Invalid value for versionRef: " + versionRef, e);
     }
   }
 }

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/task/FeatureTaskHandler.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/task/FeatureTaskHandler.java
@@ -776,25 +776,24 @@ public class FeatureTaskHandler {
   }
 
   static <X extends FeatureTask> void resolveVersionRef(final X task, final Callback<X> callback) {
-    if (!(task.getEvent() instanceof SelectiveEvent<?> event)) {
+    if (!(task.getEvent() instanceof SelectiveEvent event)) {
       callback.call(task);
       return;
     }
 
-    if (event.getRef() == null || event.getRef().isResolved()) {
+    if (event.getRef() == null || !event.getRef().isTag()) {
       callback.call(task);
       return;
     }
 
-    TagConfigClient.getInstance().getTag(task.getMarker(), event.getRef().getVersionRef(), task.space.getId())
+    TagConfigClient.getInstance().getTag(task.getMarker(), event.getRef().getTag(), task.space.getId())
         .onSuccess(tag -> {
           if (tag == null) {
-            callback.exception(new HttpException(BAD_REQUEST, "Version ref not found: " + event.getRef().getVersionRef()));
+            callback.exception(new HttpException(BAD_REQUEST, "Version ref not found: " + event.getRef().getTag()));
             return;
           }
 
-          event.getRef().setResolved(true);
-          event.getRef().setVersion(tag.getVersion());
+          event.setRef(new Ref(tag.getVersion()));
           callback.call(task);
         })
         .onFailure(t -> {

--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/TagTest.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/TagTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2023 HERE Europe B.V.
+ * Copyright (C) 2017-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 
 package com.here.xyz.hub.rest;
 
-import static com.here.xyz.hub.rest.TagApi.invalidTagId;
+import static com.here.xyz.models.hub.Tag.isValidId;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -28,19 +28,26 @@ import org.junit.Test;
 public class TagTest {
 
   @Test
-  public void testInvalidTagName() {
-    assertTrue(invalidTagId(""));
-    assertTrue(invalidTagId("  "));
-    assertTrue(invalidTagId("  abc"));
-    assertTrue(invalidTagId("  abc"));
-    assertTrue(invalidTagId("_abc"));
-    assertTrue(invalidTagId("1abc"));
-    assertTrue(invalidTagId("abc "));
-    assertTrue(invalidTagId("abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijX"));
-    assertTrue(invalidTagId("HEAD"));
-    assertFalse(invalidTagId("abcdefghij"));
-    assertFalse(invalidTagId("head"));
-    assertFalse(invalidTagId("a1bc"));
-    assertFalse(invalidTagId("abc"));
+  public void testInvalidTagNames() {
+    assertFalse(isValidId(""));
+    assertFalse(isValidId("  "));
+    assertFalse(isValidId("  abc"));
+    assertFalse(isValidId("  abc"));
+    assertFalse(isValidId("1abc"));
+    assertFalse(isValidId("abc "));
+    assertFalse(isValidId("abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijX"));
+    assertFalse(isValidId("HEAD"));
+    assertFalse(isValidId("*"));
+  }
+
+  @Test
+  public void testValidTagNames() {
+    assertTrue(isValidId("abcdefghij"));
+    assertTrue(isValidId("head"));
+    assertTrue(isValidId("a1bc"));
+    assertTrue(isValidId("abc"));
+    assertTrue(isValidId("a"));
+    assertTrue(isValidId("#27"));
+    assertTrue(isValidId("_abc"));
   }
 }

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/datasets/DatasetDescription.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/datasets/DatasetDescription.java
@@ -48,8 +48,7 @@ public abstract class DatasetDescription implements Typed {
   @JsonIgnore
   public abstract String getKey();
 
-  public static class Map extends Identifiable implements VersionRefSource<Map> {
-
+  public static class Map extends Identifiable implements VersionedSource<Map> {
     private Ref versionRef;
 
     @Override
@@ -69,10 +68,8 @@ public abstract class DatasetDescription implements Typed {
     }
   }
 
-  public static class Space<T extends Space> extends Identifiable<T> implements FilteringSource<T>, VersionRefSource<T> {
-
+  public static class Space<T extends Space> extends Identifiable<T> implements FilteringSource<T>, VersionedSource<T> {
     private Filters filters;
-
     private Ref versionRef;
 
     @Override

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/datasets/VersionedSource.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/datasets/VersionedSource.java
@@ -21,7 +21,7 @@ package com.here.xyz.jobs.datasets;
 
 import com.here.xyz.models.hub.Ref;
 
-public interface VersionRefSource<T extends VersionRefSource> {
+public interface VersionedSource<T extends VersionedSource> {
 
   Ref getVersionRef();
 

--- a/xyz-models/src/main/java/com/here/xyz/models/hub/Ref.java
+++ b/xyz-models/src/main/java/com/here/xyz/models/hub/Ref.java
@@ -22,66 +22,61 @@ package com.here.xyz.models.hub;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.here.xyz.XyzSerializable;
-import org.apache.commons.lang3.StringUtils;
 
 public class Ref implements XyzSerializable {
-
   public static final String HEAD = "HEAD";
   public static final String ALL_VERSIONS = "*";
+  private String tag;
   private long version = -1;
   private boolean head;
   private boolean allVersions;
-  private String versionRef;
-  private boolean resolved;
 
   @JsonCreator
   public Ref(String ref) {
-    if (ref == null || ref.isEmpty() || HEAD.equals(ref)) {
+    if (ref == null || ref.isEmpty() || HEAD.equals(ref))
       head = true;
-      setResolved(true);
-    }
-    else if (ALL_VERSIONS.equals(ref)) {
+    else if (ALL_VERSIONS.equals(ref))
       allVersions = true;
-      setResolved(true);
-    }
-    else if (StringUtils.isNumeric(ref)) {
+    else
       try {
         setVersion(Long.parseLong(ref));
-        setResolved(true);
-      } catch (NumberFormatException e) {
-        throw new InvalidRef("Invalid ref: the provided ref is not a valid ref or version: \"" + ref + "\"");
       }
-    }
-    else {
-      this.versionRef = ref;
-      setResolved(false);
-    }
+      catch (NumberFormatException e) {
+        if (!Tag.isValidId(ref))
+          throw new InvalidRef("Invalid ref: the provided ref is not a valid ref or version: \"" + ref + "\"");
+
+        tag = ref;
+      }
   }
 
   public Ref(long version) {
     setVersion(version);
   }
 
-  public void setVersion(long version) {
+  /**
+   * Validates & sets the version internally(!).
+   * NOTE: This method should stay private to keep the immutability of this Ref model.
+   * @param version
+   */
+  private void setVersion(long version) {
     if (version < 0)
       throw new InvalidRef("Invalid ref: The provided version number may not be lower than 0");
 
     this.version = version;
-    setResolved(true);
   }
 
   @JsonValue
   @Override
   public String toString() {
-    if (version < 0 && !head && !allVersions && resolved)
+    if (!isTag() && version < 0 && !head && !allVersions)
       throw new IllegalArgumentException("Not a valid ref");
+    if (isTag())
+      return tag;
     if (head)
       return HEAD;
     if (allVersions)
       return ALL_VERSIONS;
-    if (resolved)
-      return String.valueOf(version);
-    return versionRef;
+    return String.valueOf(version);
   }
 
   @Override
@@ -89,6 +84,26 @@ public class Ref implements XyzSerializable {
     return o instanceof Ref otherRef && otherRef.toString().equals(toString());
   }
 
+  /**
+   * @return <code>true</code> if this ref depicts a tag, <code>false</code> otherwise
+   */
+  public boolean isTag() {
+    return tag != null;
+  }
+
+  /**
+   * If this ref is depicting a tag, this method returns the tag's ID.
+   * @return The tag name if this ref depicts a tag, <code>null</code> otherwise
+   */
+  public String getTag() {
+    return tag;
+  }
+
+  /**
+   * The version being referenced by this ref object.
+   * A valid version is an integer >= 0 where 0 is the very first version of an empty space just after having been created.
+   * TODO: Fix DB queries accordingly to take into account the empty space as first history state
+   */
   public long getVersion() {
     if (!isSingleVersion())
       throw new NumberFormatException("Ref is not depicting a single version.");
@@ -107,18 +122,6 @@ public class Ref implements XyzSerializable {
 
   public boolean isSingleVersion() {
     return !isAllVersions();
-  }
-
-  public boolean isResolved() {
-    return resolved;
-  }
-
-  public void setResolved(boolean resolved) {
-    this.resolved = resolved;
-  }
-
-  public String getVersionRef() {
-    return versionRef;
   }
 
   public static class InvalidRef extends IllegalArgumentException {

--- a/xyz-models/src/main/java/com/here/xyz/models/hub/Tag.java
+++ b/xyz-models/src/main/java/com/here/xyz/models/hub/Tag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2023 HERE Europe B.V.
+ * Copyright (C) 2017-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,10 +20,13 @@
 package com.here.xyz.models.hub;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_DEFAULT;
+import static com.here.xyz.models.hub.Ref.ALL_VERSIONS;
+import static com.here.xyz.models.hub.Ref.HEAD;
 
-import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.google.common.base.Strings;
 import com.here.xyz.XyzSerializable;
+import java.util.regex.Pattern;
 
 public class Tag implements XyzSerializable {
   /**
@@ -37,11 +40,9 @@ public class Tag implements XyzSerializable {
   private String spaceId;
 
   /**
-   * The version pointer.
-   * Versions below -2 are invalid versions.
-   * The version -2 is the default version, when version is not provided for example.
-   * The version -1 points to the initial version of a space without data.
-   * The version 0 points to the initial version of a space with data.
+   * The version this tag is pointing to.
+   *
+   * @see Ref#getVersion()
    */
   private long version = -2;
 
@@ -103,5 +104,8 @@ public class Tag implements XyzSerializable {
    return this;
   }
 
-
+  public static boolean isValidId(String tagId) {
+    return !Strings.isNullOrEmpty(tagId) && !HEAD.equals(tagId) && !ALL_VERSIONS.equals(tagId)
+        && Pattern.matches("^[^0-9\s][^\s]{0,49}$", tagId);
+  }
 }

--- a/xyz-util/src/main/java/com/here/xyz/util/web/HubWebClient.java
+++ b/xyz-util/src/main/java/com/here/xyz/util/web/HubWebClient.java
@@ -175,7 +175,7 @@ public class HubWebClient {
         .build());
   }
 
-  public Tag getTag(String spaceId, String tagId) throws HubWebClientException {
+  public Tag loadTag(String spaceId, String tagId) throws HubWebClientException {
     try {
       return deserialize(request(HttpRequest.newBuilder()
           .GET()

--- a/xyz-util/src/main/java/com/here/xyz/util/web/HubWebClientAsync.java
+++ b/xyz-util/src/main/java/com/here/xyz/util/web/HubWebClientAsync.java
@@ -77,6 +77,10 @@ public class HubWebClientAsync extends HubWebClient {
     return async.run(() -> postTag(spaceId, tag));
   }
 
+  public Future<Tag> loadTagAsync(String spaceId, String tagId) {
+    return async.run(() -> loadTag(spaceId, tagId));
+  }
+
   public Future<Void> deleteTagAsync(String spaceId, String tagId) {
     return async.run(() -> {
       deleteTag(spaceId, tagId);


### PR DESCRIPTION
- Improve (De-)serialization of tag model in DynamoTagConfigClient
- Make Ref model immutable (again)
- Remove new usages of apache-commons lib (which is to be removed from dependencies soon)
- Rename abstract dataset VersionRefSource to VersionedSource
- Rename HubWebClient#getTag() to #loadTag() to match the style of the other entity loading methods (and also to indicate that the method call could be a longer running one as it's a query to remote system)
- Add missing method HubWebClientAsync#loadTagAsync()