### PR TITLE
Some minor Job API V2 improvements

### DIFF
--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/datasets/DatasetDescription.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/datasets/DatasetDescription.java
@@ -19,8 +19,11 @@
 
 package com.here.xyz.jobs.datasets;
 
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_DEFAULT;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
@@ -39,6 +42,7 @@ import com.here.xyz.models.hub.Ref;
     @JsonSubTypes.Type(value = Spaces.class, name = "Spaces"),
     @JsonSubTypes.Type(value = Files.class, name = "Files")
 })
+@JsonInclude(NON_DEFAULT)
 public abstract class DatasetDescription implements Typed {
 
   /**

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/datasets/FileOutputSettings.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/datasets/FileOutputSettings.java
@@ -19,6 +19,8 @@
 
 package com.here.xyz.jobs.datasets;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.here.xyz.XyzSerializable;
 import com.here.xyz.jobs.datasets.files.Csv;
 import com.here.xyz.jobs.datasets.files.FileChunking;
@@ -28,6 +30,7 @@ import com.here.xyz.jobs.datasets.files.Partitioning;
 import com.here.xyz.jobs.datasets.files.Partitioning.FeatureKey;
 import java.util.Map;
 
+@JsonInclude(Include.NON_DEFAULT)
 public class FileOutputSettings {
   private FileFormat format = new GeoJson();
   private Partitioning partitioning = new FeatureKey();
@@ -143,5 +146,10 @@ public class FileOutputSettings {
   public FileOutputSettings withMaxTilesPerFile(int maxTilesPerFile) {
     setMaxTilesPerFile(maxTilesPerFile);
     return this;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    return XyzSerializable.equals(this, obj);
   }
 }

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/datasets/files/FileInputSettings.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/datasets/files/FileInputSettings.java
@@ -19,6 +19,8 @@
 
 package com.here.xyz.jobs.datasets.files;
 
+import com.here.xyz.XyzSerializable;
+
 public class FileInputSettings {
   private FileFormat format = new GeoJson();
 
@@ -33,5 +35,10 @@ public class FileInputSettings {
   public FileInputSettings withFormat(FileFormat format) {
     setFormat(format);
     return this;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    return XyzSerializable.equals(this, obj);
   }
 }

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/service/JobAdminApi.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/service/JobAdminApi.java
@@ -48,11 +48,18 @@ public class JobAdminApi extends Api {
   private static final String ADMIN_STATE_MACHINE_EVENTS = "/admin/state/events";
 
   public JobAdminApi(Router router) {
+    router.route(HttpMethod.GET, ADMIN_JOBS).handler(handleErrors(this::getJobs));
     router.route(HttpMethod.GET, ADMIN_JOB).handler(handleErrors(this::getJob));
     router.route(HttpMethod.DELETE, ADMIN_JOBS).handler(handleErrors(this::deleteJob));
     router.route(HttpMethod.POST, ADMIN_JOB_STEPS).handler(handleErrors(this::postStep));
     router.route(HttpMethod.GET, ADMIN_JOB_STEP).handler(handleErrors(this::getStep));
     router.route(HttpMethod.POST, ADMIN_STATE_MACHINE_EVENTS).handler(handleErrors(this::postStateEvent));
+  }
+
+  private void getJobs(RoutingContext context) {
+    Job.loadAll()
+        .onSuccess(res -> sendAdminResponse(context, OK.code(), res))
+        .onFailure(err -> sendErrorResponse(context, err));
   }
 
   private void getJob(RoutingContext context) {

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/execution/db/DatabaseBasedStep.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/execution/db/DatabaseBasedStep.java
@@ -108,6 +108,10 @@ public abstract class DatabaseBasedStep<T extends DatabaseBasedStep> extends Lam
 
   private Object executeQuery(SQLQuery query, Database db, double estimatedMaxAcuLoad, ResultSetHandler<?> resultSetHandler,
       boolean isWriteQuery, boolean async, boolean withCallbacks) throws TooManyResourcesClaimed, SQLException {
+    query
+        .withLabel("jobId", getJobId())
+        .withLabel("stepId", getId());
+
     if (async) {
       query = (withCallbacks ? wrapQuery(query) : query)
           .withAsync(true)

--- a/xyz-models/src/main/java/com/here/xyz/XyzSerializable.java
+++ b/xyz-models/src/main/java/com/here/xyz/XyzSerializable.java
@@ -332,6 +332,17 @@ public interface XyzSerializable {
     }
   }
 
+  static boolean equals(Object o1, Object o2) {
+    return equals(o1, o2, null);
+  }
+
+  static boolean equals(Object o1, Object o2, Class<? extends SerializationView> view) {
+    if (o1 == null || o2 == null)
+      return o1 == o2;
+
+    return toMap(o1, view).equals(toMap(o2, view));
+  }
+
   interface SerializationView {}
 
   /**


### PR DESCRIPTION
- Add missing admin endpoint /admin/jobs to retrieve all jobs with internal view
  - Add generic methods (Api#sendInternalResponse()) to use default mapper for admin responses
- Add job ID and step ID as labels to all DB queries being started from within the Job Framework
- Do not serialize default values on "source" & "target" fields of a job config
  - Use Include.NON_DEFAULT for all DatasetDescriptions
  - Add implementations for the #equals() method of sub-objects of FileInputSettings & FileOutputSettings
  - Add generic utility method XyzSerializable#equals() as an easy way to do deep-equality checks