### PR TITLE
Support pipeline style processing for jobs

### DIFF
--- a/.run/JobService.run.xml
+++ b/.run/JobService.run.xml
@@ -19,6 +19,9 @@
 
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="JobService" type="Application" factoryName="Application">
+    <envs>
+      <env name="PARALLEL_STEPS_SUPPORTED" value="false" />
+    </envs>
     <option name="MAIN_CLASS_NAME" value="com.here.xyz.jobs.service.JobService" />
     <module name="xyz-job-service" />
     <extension name="coverage">

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/datasets/DatasetDescription.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/datasets/DatasetDescription.java
@@ -32,6 +32,7 @@ import com.here.xyz.jobs.datasets.DatasetDescription.Map;
 import com.here.xyz.jobs.datasets.DatasetDescription.Space;
 import com.here.xyz.jobs.datasets.filters.FilteringSource;
 import com.here.xyz.jobs.datasets.filters.Filters;
+import com.here.xyz.jobs.datasets.streams.Notifications;
 import com.here.xyz.models.hub.Ref;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -40,7 +41,8 @@ import com.here.xyz.models.hub.Ref;
     @JsonSubTypes.Type(value = Map.class, name = "Map"),
     @JsonSubTypes.Type(value = Space.class, name = "Space"),
     @JsonSubTypes.Type(value = Spaces.class, name = "Spaces"),
-    @JsonSubTypes.Type(value = Files.class, name = "Files")
+    @JsonSubTypes.Type(value = Files.class, name = "Files"),
+    @JsonSubTypes.Type(value = Notifications.class, name = "Notifications")
 })
 @JsonInclude(NON_DEFAULT)
 public abstract class DatasetDescription implements Typed {

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/datasets/streams/DynamicStream.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/datasets/streams/DynamicStream.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2017-2024 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.xyz.jobs.datasets.streams;
+
+import com.here.xyz.jobs.datasets.DatasetDescription;
+
+public abstract class DynamicStream extends DatasetDescription {
+
+  @Override
+  public String getKey() {
+    return getClass().getSimpleName();
+  }
+}

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/datasets/streams/Notifications.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/datasets/streams/Notifications.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2017-2024 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.xyz.jobs.datasets.streams;
+
+public class Notifications extends DynamicStream {
+}

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/service/Config.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/service/Config.java
@@ -47,4 +47,9 @@ public class Config extends com.here.xyz.jobs.steps.Config {
    * The ARN of the role needed for step function
    */
   public String STATE_MACHINE_ROLE;
+
+  /**
+   * Whether steps in a StepGraph can be executed in parallel at all within the target environment.
+   */
+  public boolean PARALLEL_STEPS_SUPPORTED = true;
 }

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/JobCompiler.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/JobCompiler.java
@@ -65,7 +65,12 @@ public class JobCompiler {
           + "Multiple compilation interceptors were found: "
           + interceptorCandidates.stream().map(c -> c.getClass().getSimpleName()).collect(Collectors.joining(", ")), errors);
 
-    return async.run(() -> interceptorCandidates.get(0).compile(job).enrich(job.getId()));
+    return async.run(() -> interceptorCandidates.get(0).compile(job).enrich(job.getId()))
+        .map(graph -> {
+          //Pass the info to all steps whether they belong to a "pipeline-job" or not
+          graph.stepStream().forEach(step -> step.withPipeline(job.isPipeline()));
+          return graph;
+        });
   }
 
   public static JobCompiler getInstance() {

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/StepGraph.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/StepGraph.java
@@ -21,6 +21,7 @@ package com.here.xyz.jobs.steps;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.here.xyz.jobs.service.Config;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -120,7 +121,7 @@ public class StepGraph implements StepExecution {
   }
 
   public void setParallel(boolean parallel) {
-    this.parallel = parallel;
+    this.parallel = Config.instance.PARALLEL_STEPS_SUPPORTED && parallel;
   }
 
   public StepGraph withParallel(boolean parallel) {

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/Step.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/Step.java
@@ -70,6 +70,8 @@ public abstract class Step<T extends Step> implements Typed, StepExecution {
   private final String MODEL_BASED_PREFIX = "/modelBased";
   @JsonIgnore
   private List<Input> inputs;
+  @JsonView({Internal.class, Static.class})
+  private boolean pipeline;
 
   /**
    * Provides a list of the resource loads which will be consumed by this step during its execution.
@@ -207,7 +209,7 @@ public abstract class Step<T extends Step> implements Typed, StepExecution {
     return Input.currentInputsCount(jobId, inputType);
   }
 
-  protected <T extends Input> List<T> loadInputsSample(int maxSampleSize, Class<T> inputType) {
+  protected <I extends Input> List<I> loadInputsSample(int maxSampleSize, Class<I> inputType) {
     return Input.loadInputsSample(jobId, maxSampleSize, inputType);
   }
 
@@ -364,5 +366,18 @@ public abstract class Step<T extends Step> implements Typed, StepExecution {
             .stream()
             .mapToLong(input -> input instanceof UploadUrl uploadUrl ? uploadUrl.getEstimatedUncompressedByteSize() : 0)
             .sum());
+  }
+
+  public boolean isPipeline() {
+    return pipeline;
+  }
+
+  public void setPipeline(boolean pipeline) {
+    this.pipeline = pipeline;
+  }
+
+  public T withPipeline(boolean pipeline) {
+    setPipeline(pipeline);
+    return (T) this;
   }
 }

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/inputs/Input.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/inputs/Input.java
@@ -145,6 +145,13 @@ public abstract class Input <T extends Input> implements Typed {
     return (List<T>) inputsStream.collect(Collectors.toList());
   }
 
+  public static ModelBasedInput resolveRawInput(Map<String, Object> rawInput) {
+    if (rawInput == null)
+      throw new NullPointerException("The raw input may not be null");
+    //TODO: Support resolving InputReferences here
+    return XyzSerializable.fromMap(rawInput, ModelBasedInput.class);
+  }
+
   private static Input createInput(String s3Key, long byteSize, boolean isCompressed) {
     //TODO: Support ModelBasedInputs
     return new UploadUrl()

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseHandler.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseHandler.java
@@ -124,7 +124,7 @@ public abstract class DatabaseHandler extends StorageConnector {
     }
 
     /**
-     * Checks whether the lastest version of all SQL scripts is installed on the DB and returns all script schemas for the use in the
+     * Checks whether the latest version of all SQL scripts is installed on the DB and returns all script schemas for the use in the
      * search path.
      * @return The script schema names (including the newest script version for each script) to be used in the search path
      */


### PR DESCRIPTION
- Add new abstract DatasetDescription "DynamicStream", that depicts a source of inputs that flow in randomly & indefinitely (e.g. like queues)
  - Jobs with type of source will behave like a pipeline rather than a batch-job that includes: - Not accepting any inputs before the job is RUNNING - Only accepting ModelBasedInputs (with a size <= 256KB) - The job runs endless (but until it is cancelled by the job creator) - The job does not process anything unless there are incoming inputs
- Add new DatasetDescription "Notifications", that indicates that the job is capable of receiving a stream of inputs from the XYZ notifications system
- Add method Job#isPipeline() that will return true exactly if the source is instanceof DynamicStream
- Add method Job#consumeInput() that takes a ModelBasedInput, but only if the job is a "pipeline-job"
- Enhance JobApi#postJobInput() to accept ModelBasedInputs for "pipeline-jobs"
- Add new field Step#pipeline that indicates that a step is part of a "pipeline-job"
- Enhance JobCompiler to set the pipeline field of all steps accordingly
- Enhance StateMachineExecutor to support creating express workflow SFNs and send inputs to them for "pipeline-jobs"
- Enhance GraphTransformer to only support SYNC integration with Lambdas for "pipeline-jobs"
- Enhance LambdaBasedStep to receive & parse the StepFunction's input from the context when being part of a "pipeline-job"