### PR TITLE
Fix ResourcesRegistry#getReservedVirtualUnits() to aggregate reserved resources correctly

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/WarmupRemoteFunctionThread.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/WarmupRemoteFunctionThread.java
@@ -25,16 +25,16 @@ import com.here.xyz.hub.connectors.models.Connector;
 import com.here.xyz.util.service.Core;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.MarkerManager.Log4jMarker;
 
 /**
- *
+ * @deprecated The warmup logic is done by the infrastructure instead.
+ * TODO: Remove this class.
  */
+@Deprecated
 public class WarmupRemoteFunctionThread extends Thread {
 
   private static final String name = WarmupRemoteFunctionThread.class.getSimpleName();
@@ -96,22 +96,6 @@ public class WarmupRemoteFunctionThread extends Thread {
           logger.error("Unexpected exception while trying to send warm-up requests", e);
         }
       }
-    }
-  }
-
-  private void monitorActiveConnections() {
-    for (final RpcClient client : RpcClient.getAllInstances()) {
-      ConcurrentHashMap<String, AtomicInteger> connectionByRequster = client.getFunctionClient().getUsedConnectionsByRequester();
-      final StringBuilder sb = new StringBuilder("Active connections by requester for client ")
-          .append(client.getConnector().id).append(": ");
-      for( String requester : connectionByRequster.keySet() ){
-
-        int count = connectionByRequster.get(requester).get();
-        if(count > 0){
-            sb.append(requester).append(':').append(count).append(';');
-        }
-      }
-      logger.warn(sb.toString());
     }
   }
 

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/Job.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/Job.java
@@ -398,7 +398,7 @@ public class Job implements XyzSerializable {
   /**
    * Calculates the overall loads (needed resources) of this job by aggregating the resource loads of all steps of this job.
    * The aggregation of parallel steps is done in the way that all resource-loads of parallel running steps will be added while
-   * in the case of sequentially running steps always the maximum of each pairwise equal resources will be taken into account.
+   * in the case of sequentially running steps always the maximum of the step's resources will be taken into account.
    *
    * @return A list of overall resource-loads being reserved by this job
    */

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/Step.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/Step.java
@@ -373,10 +373,6 @@ public abstract class Step<T extends Step> implements Typed, StepExecution {
     return pipeline;
   }
 
-  public boolean isRunning() {
-    return getStatus().getState().equals(RuntimeInfo.State.RUNNING);
-  }
-
   public void setPipeline(boolean pipeline) {
     this.pipeline = pipeline;
   }

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/resources/Load.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/resources/Load.java
@@ -19,6 +19,8 @@
 
 package com.here.xyz.jobs.steps.resources;
 
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class Load {
@@ -68,5 +70,11 @@ public class Load {
       loads.put(resource, loads.containsKey(resource) ? Math.max(loads.get(resource), units) : units);
     else
       loads.put(resource, loads.containsKey(resource) ? loads.get(resource) + units : units);
+  }
+
+  public static Map<ExecutionResource, Double> toLoadsMap(List<Load> loads, boolean maximize) {
+    Map<ExecutionResource, Double> loadsMap = new HashMap<>();
+    loads.forEach(load -> addLoad(loadsMap, load.getResource(), load.getEstimatedVirtualUnits(), maximize));
+    return loadsMap;
   }
 }


### PR DESCRIPTION
Only resources of parallel running steps should be added. For sequential steps the maximum of the loads should be used instead. Re-use already implemented Job#calculateResourceLoads() for that purpose.