### PR TITLE
Enable to pass Job inputs from foreign S3 buckets

### DIFF
--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/util/AsyncS3Client.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/util/AsyncS3Client.java
@@ -24,9 +24,11 @@ import com.here.xyz.jobs.service.Config;
 import com.here.xyz.util.Async;
 import io.vertx.core.Future;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class AsyncS3Client extends S3Client {
-  private static final AsyncS3Client instance = new AsyncS3Client(Config.instance.JOBS_S3_BUCKET);
+  private static final Map<String, AsyncS3Client> instances = new ConcurrentHashMap<>();
   private static final Async ASYNC = new Async(20, AsyncS3Client.class);
 
   protected AsyncS3Client(String bucketName) {
@@ -34,7 +36,13 @@ public class AsyncS3Client extends S3Client {
   }
 
   public static AsyncS3Client getInstance() {
-    return instance;
+    return getInstance(Config.instance.JOBS_S3_BUCKET);
+  }
+
+  public static AsyncS3Client getInstance(String bucketName) {
+    if (!instances.containsKey(bucketName))
+      instances.put(bucketName, new AsyncS3Client(bucketName));
+    return instances.get(bucketName);
   }
 
   //NOTE: Only the long-blocking methods are added as async variants

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/inputs/InputsFromS3.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/inputs/InputsFromS3.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2017-2024 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.xyz.jobs.steps.inputs;
+
+import java.util.List;
+
+public class InputsFromS3 extends Input<InputsFromS3> {
+  private String bucketArn;
+  private String prefix;
+
+  public String getPrefix() {
+    return prefix;
+  }
+
+  public void setPrefix(String prefix) {
+    this.prefix = prefix;
+  }
+
+  public InputsFromS3 withBucketArn(String bucketArn) {
+    setBucketArn(bucketArn);
+    return this;
+  }
+
+  public String getBucketArn() {
+    return bucketArn;
+  }
+
+  public void setBucketArn(String bucketArn) {
+    this.bucketArn = bucketArn;
+  }
+
+  public InputsFromS3 withPrefix(String prefix) {
+    setPrefix(prefix);
+    return this;
+  }
+
+  public void dereference(String forJob) {
+    //First load the inputs from the (foreign bucket)
+    List<Input> inputs = loadInputsInParallel(getBucketArn(), getPrefix());
+    inputs.forEach(input -> input.setS3Bucket(getBucketArn()));
+    //Store the metadata for the job that accesses the bucket
+    storeMetadata(forJob, inputs, null);
+  }
+}

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/inputs/UploadUrl.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/inputs/UploadUrl.java
@@ -28,12 +28,12 @@ public class UploadUrl extends Input<UploadUrl> {
 
   @JsonView(Public.class)
   public URL getUrl() {
-    return S3Client.getInstance().generateUploadURL(getS3Key());
+    return S3Client.getInstance(getS3Bucket()).generateUploadURL(getS3Key());
   }
 
   @JsonView(Public.class)
   public URL getDownloadUrl() {
-    return S3Client.getInstance().generateDownloadURL(getS3Key());
+    return S3Client.getInstance(getS3Bucket()).generateDownloadURL(getS3Key());
   }
 
   @JsonIgnore

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/util/S3Client.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/util/S3Client.java
@@ -45,10 +45,12 @@ import java.net.URL;
 import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.zip.GZIPOutputStream;
 
 public class S3Client {
-  private static S3Client instance;
+  private static Map<String, S3Client> instances = new ConcurrentHashMap<>();
   private final String bucketName;
   protected static final int PRESIGNED_URL_EXPIRATION_SECONDS = 7 * 24 * 60 * 60;
 
@@ -81,9 +83,13 @@ public class S3Client {
   }
 
   public static S3Client getInstance() {
-    if (instance == null)
-      instance = new S3Client(Config.instance.JOBS_S3_BUCKET);
-    return instance;
+    return getInstance(Config.instance.JOBS_S3_BUCKET);
+  }
+
+  public static S3Client getInstance(String bucketName) {
+    if (!instances.containsKey(bucketName))
+      instances.put(bucketName, new S3Client(bucketName));
+    return instances.get(bucketName);
   }
 
   private URL generatePresignedUrl(String key, HttpMethod method) {

--- a/xyz-util/src/main/java/com/here/xyz/util/web/HubWebClient.java
+++ b/xyz-util/src/main/java/com/here/xyz/util/web/HubWebClient.java
@@ -38,12 +38,13 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import net.jodah.expiringmap.ExpirationPolicy;
 import net.jodah.expiringmap.ExpiringMap;
 
 public class HubWebClient extends XyzWebClient {
-  private static Map<String, HubWebClient> instances = new HashMap<>();
+  private static Map<String, HubWebClient> instances = new ConcurrentHashMap<>();
   private ExpiringMap<String, Connector> connectorCache = ExpiringMap.builder()
       .expirationPolicy(ExpirationPolicy.CREATED)
       .expiration(3, TimeUnit.MINUTES)


### PR DESCRIPTION
- Introduce new input type "InputsFromS3" that a user can specify to pass input files using a reference to an S3 Bucket & Key-prefix (given the service' account got access rights granted)
- Change Input classes & metadata models accordingly to contain a reference to the target S3 bucket
- Enhance S3Client to work with arbitrary buckets rather than only with the service' default bucket