### PR TITLE
Fix request throttling for clients

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/models/Connector.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/models/Connector.java
@@ -149,7 +149,7 @@ public class Connector extends com.here.xyz.models.hub.Connector {
 
   @JsonIgnore
   public int getMaxConnectionsPerRequester() {
-    int connections = connectionSettings.maxConnectionsPerRequester == 0 ? 60 : connectionSettings.maxConnectionsPerRequester;
+    int connections = connectionSettings.maxConnectionsPerRequester == 0 ? 100 : connectionSettings.maxConnectionsPerRequester;
     return (int) Math.ceil((double) connections / Node.count());
   }
 

--- a/xyz-models/src/main/java/com/here/xyz/models/hub/Connector.java
+++ b/xyz-models/src/main/java/com/here/xyz/models/hub/Connector.java
@@ -158,7 +158,7 @@ public class Connector {
     public int maxConnections = 512;
     private int minConnections = 0;
 
-    public int maxConnectionsPerRequester = 60;
+    public int maxConnectionsPerRequester = 100;
 
     @Override
     public boolean equals(Object o) {


### PR DESCRIPTION
- Increase maxConnectionsPerRequester to 100
- Prevent psql connector invocation when request is throttled