### PR TITLE
Some import fixes

### DIFF
--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/Job.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/Job.java
@@ -295,7 +295,6 @@ public class Job implements XyzSerializable {
   }
 
   private Future<Void> updateStep(Step<?> step, State previousStepState) {
-
     if (previousStepState != null && !step.getStatus().getState().isFinal() && previousStepState.isFinal())
       //In case the step was already marked to have a final state, ignore any subsequent non-final updates to it
       return Future.succeededFuture();
@@ -315,7 +314,7 @@ public class Job implements XyzSerializable {
     int overallWorkUnits = getSteps().stepStream().mapToInt(s -> s.getEstimatedExecutionSeconds()).sum();
     getStatus().setEstimatedProgress((float) completedWorkUnits / (float) overallWorkUnits);
 
-    if (step.getStatus().getState() == FAILED) {
+    if (previousStepState != FAILED && step.getStatus().getState() == FAILED) {
       getStatus()
           .withState(FAILED)
           .withErrorMessage(step.getStatus().getErrorMessage())

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/compiler/ImportFromFiles.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/compiler/ImportFromFiles.java
@@ -19,7 +19,6 @@
 
 package com.here.xyz.jobs.steps.compiler;
 
-import static com.here.xyz.jobs.datasets.space.UpdateStrategy.DEFAULT_UPDATE_STRATEGY;
 import static com.here.xyz.jobs.steps.impl.transport.ImportFilesToSpace.Format.CSV_GEOJSON;
 import static com.here.xyz.jobs.steps.impl.transport.ImportFilesToSpace.Format.CSV_JSON_WKB;
 import static com.here.xyz.jobs.steps.impl.transport.ImportFilesToSpace.Format.GEOJSON;
@@ -76,15 +75,10 @@ public class ImportFromFiles implements JobCompilationInterceptor {
         .withSpaceId(spaceId)
         .withFormat(importStepFormat)
         .withEntityPerLine(getEntityPerLine(sourceFormat))
-        .withJobId(job.getId())
-        .withUpdateStrategy(DEFAULT_UPDATE_STRATEGY);
+        .withJobId(job.getId());
 
     if (importFilesStep.getExecutionMode().equals(LambdaBasedStep.ExecutionMode.SYNC) || importFilesStep.keepIndices())
-    /**
-     * Perform only Import Step.
-     * In Sync-mode we are writing from Lambda to RDS in a SYNC way.
-     * If indexes should get kept we are still writing ASYC but its faster to keep remove the indices.
-     */
+      //Perform only the import Step
       return (CompilationStepGraph) new CompilationStepGraph()
             .addExecution(importFilesStep);
 

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/execution/db/DatabaseBasedStep.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/execution/db/DatabaseBasedStep.java
@@ -256,7 +256,7 @@ public abstract class DatabaseBasedStep<T extends DatabaseBasedStep> extends Lam
           }
         });
 
-    //If the heartbeat is called, but the query is not running anymore, it might be a failure => throw UnknownStateException
+    //If the heartbeat is called, but no query is running anymore, it might be a failure, but it could also be a success => throw UnknownStateException
     if (!someQueryIsRunning)
       throw new UnknownStateException("No query is running anymore for step " + getGlobalStepId() + ". "
           + "Either the step is completed or failed.");


### PR DESCRIPTION
- Add proper exception handling to write_feature() wrapper-function
- Do not set the default updateStrategy in the ImportFromFiles compilation-interceptor anymore
- Fix JobAdminApi to set additionally set all RUNNING steps to CANCELLED on job-timeout
- Fix Job#updateStep() to not overwrite the error information on an already FAILED step anymore (e.g., in case of in-flight state-checks)