### PR TITLE
Improve S3 scanning performance

### DIFF
--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/inputs/Input.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/inputs/Input.java
@@ -276,7 +276,8 @@ public abstract class Input <T extends Input> implements Typed {
   }
 
   private static boolean inputIsCompressed(S3ObjectSummary objectSummary) {
-    //TODO: Check compression in another way (e.g. file suffix?)
+    if (objectSummary.getKey().endsWith(".gz"))
+      return true;
     ObjectMetadata metadata = S3Client.getInstance(objectSummary.getBucketName()).loadMetadata(objectSummary.getKey());
     return metadata.getContentEncoding() != null && metadata.getContentEncoding().equalsIgnoreCase("gzip");
   }

--- a/xyz-jobs/xyz-job-steps/src/test/java/com/here/xyz/jobs/steps/impl/transport/QuickValidatorTest.java
+++ b/xyz-jobs/xyz-job-steps/src/test/java/com/here/xyz/jobs/steps/impl/transport/QuickValidatorTest.java
@@ -34,6 +34,7 @@ import com.here.xyz.jobs.steps.Config;
 import com.here.xyz.jobs.steps.TestSteps;
 import com.here.xyz.jobs.steps.impl.transport.ImportFilesToSpace.EntityPerLine;
 import com.here.xyz.jobs.steps.impl.transport.ImportFilesToSpace.Format;
+import com.here.xyz.jobs.steps.inputs.UploadUrl;
 import com.here.xyz.util.service.BaseHttpServerVerticle.ValidationException;
 import java.io.IOException;
 import org.junit.jupiter.api.BeforeEach;
@@ -123,7 +124,10 @@ public class QuickValidatorTest extends TestSteps {
   }
 
   private void validate(String s3Key, Format format, boolean isCompressed, EntityPerLine entityPerLine) throws ValidationException {
-    ImportFilesQuickValidator.validate(Config.instance.JOBS_S3_BUCKET, s3Key, format, isCompressed, entityPerLine);
+    ImportFilesQuickValidator.validate(new UploadUrl()
+        .withS3Bucket(Config.instance.JOBS_S3_BUCKET)
+        .withS3Key(s3Key)
+        .withCompressed(isCompressed), format, entityPerLine);
   }
 
   @Test


### PR DESCRIPTION
- ... for compressed files in general (for now this improvement works only for files that are named with a ".gz" suffix)
- ... for non-compressed files in ImportFilesQuickValidator