### PR TITLE
Job reusability

### DIFF
--- a/.run/JobService.run.xml
+++ b/.run/JobService.run.xml
@@ -13,6 +13,7 @@
     </extension>
     <method v="2">
       <option name="Make" enabled="true" />
+      <option name="RunConfigurationTask" enabled="true" run_configuration_name="jobServiceSetup" run_configuration_type="ShConfigurationType" />
     </method>
   </configuration>
 </component>

--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/TagApiIT.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/TagApiIT.java
@@ -100,7 +100,7 @@ public class TagApiIT extends TestSpaceWithFeature {
       _createTag()
               .statusCode(OK.code())
               .body("id", equalTo("XYZ_1"))
-              .body("version", equalTo(-1));
+              .body("version", equalTo(0));
 
       given()
               .headers(getAuthHeaders(AuthProfile.ACCESS_ALL))
@@ -155,7 +155,7 @@ public class TagApiIT extends TestSpaceWithFeature {
               .get("/spaces/" + getSpaceId() + "/tags/XYZ_1")
               .then()
               .statusCode(OK.code())
-              .body("version", equalTo(-1));
+              .body("version", equalTo(0));
   }
 
   @Test
@@ -242,7 +242,7 @@ public class TagApiIT extends TestSpaceWithFeature {
         .then()
         .body("size()", is(1))
         .body( "[0].tags.XYZ_1.id", equalTo("XYZ_1"))
-        .body( "[0].tags.XYZ_1.version", equalTo(-1));
+        .body( "[0].tags.XYZ_1.version", equalTo(0));
   }
 
   @Ignore("Disabled. Takes too long")
@@ -398,7 +398,7 @@ public class TagApiIT extends TestSpaceWithFeature {
         .then()
         .statusCode(OK.code())
         .body("id", equalTo("XYZ_1"))
-        .body("version", equalTo(-1))
+        .body("version", equalTo(0))
         .body("$", not(hasKey("system")));
 
     given()
@@ -407,7 +407,7 @@ public class TagApiIT extends TestSpaceWithFeature {
         .then()
         .statusCode(OK.code())
         .body("id", equalTo("XYZ_2"))
-        .body("version", equalTo(-1))
+        .body("version", equalTo(0))
         .body("$", hasKey("system"))
         .body("system", equalTo(true));
   }

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/Job.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/Job.java
@@ -629,7 +629,9 @@ public class Job implements XyzSerializable {
         this.secondaryResourceKey = extension.getSpaceId();
       }
     } catch (XyzWebClient.WebClientException e) {
-      throw new RuntimeException(e);
+      //Ignore if space is not present anymore
+      if(!(e instanceof XyzWebClient.ErrorResponseException er && er.getStatusCode() == 404))
+        throw new RuntimeException(e);
     }
     return this.secondaryResourceKey;
   }

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/config/DynamoJobConfigClient.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/config/DynamoJobConfigClient.java
@@ -32,14 +32,15 @@ import com.here.xyz.jobs.steps.Step;
 import com.here.xyz.util.service.aws.dynamo.DynamoClient;
 import com.here.xyz.util.service.aws.dynamo.IndexDefinition;
 import io.vertx.core.Future;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 public class DynamoJobConfigClient extends JobConfigClient {
   private static final Logger logger = LogManager.getLogger();
@@ -97,6 +98,40 @@ public class DynamoJobConfigClient extends JobConfigClient {
     });
   }
 
+  public Future<List<Job>> loadJobs(String resourceKey, String extendedResourceKey) {
+    return dynamoClient.executeQueryAsync(() -> {
+      List<Job> jobs = new LinkedList<>();
+
+      // Query by resourceKey
+      jobTable.getIndex("resourceKey-index")
+              .query("resourceKey", resourceKey)
+              .pages()
+              .forEach(page ->
+                      page.forEach(jobItem ->
+                              jobs.add(XyzSerializable.fromMap(jobItem.asMap(), Job.class))
+                      )
+              );
+
+      // If extendedResourceKey is provided, query it too
+      if (extendedResourceKey != null) {
+        jobTable.getIndex("resourceKey-index")
+                .query("resourceKey", extendedResourceKey)
+                .pages()
+                .forEach(page ->
+                        page.forEach(jobItem -> {
+                          Job job = XyzSerializable.fromMap(jobItem.asMap(), Job.class);
+                          // Avoid duplicates
+                          if (!jobs.contains(job)) {
+                            jobs.add(job);
+                          }
+                        })
+                );
+      }
+
+      return jobs;
+    });
+  }
+
   @Override
   public Future<List<Job>> loadJobs(String resourceKey) {
     return dynamoClient.executeQueryAsync(() -> {
@@ -114,6 +149,17 @@ public class DynamoJobConfigClient extends JobConfigClient {
     if (resourceKey != null)
       //TODO: Use an index with hash- *and* range-key
       return loadJobs(resourceKey).map(jobs -> jobs.stream().filter(job -> state == null || job.getStatus().getState() == state).toList());
+    else if (state != null)
+      return loadJobs(state);
+    else
+      return loadJobs();
+  }
+
+  @Override
+  public Future<List<Job>> loadJobs(String resourceKey, String extendedResourceKey, State state) {
+    if (resourceKey != null)
+      //TODO: Use an index with hash- *and* range-key
+      return loadJobs(resourceKey, extendedResourceKey).map(jobs -> jobs.stream().filter(job -> state == null || job.getStatus().getState() == state).toList());
     else if (state != null)
       return loadJobs(state);
     else
@@ -223,8 +269,9 @@ public class DynamoJobConfigClient extends JobConfigClient {
     if (dynamoClient.isLocal()) {
       logger.info("DynamoDB running locally, initializing Jobs table.");
       try {
-        List<IndexDefinition> indexes = List.of(new IndexDefinition("resourceKey"), new IndexDefinition("state"));
-        dynamoClient.createTable(jobTable.getTableName(), "id:S,resourceKey:S,state:S", "id", indexes, "keepUntil");
+        List<IndexDefinition> indexes = List.of(new IndexDefinition("resourceKey"), new IndexDefinition("state"),
+                new IndexDefinition("extendedResourceKey"));
+        dynamoClient.createTable(jobTable.getTableName(), "id:S,resourceKey:S,extendedResourceKey:S,state:S", "id", indexes, "keepUntil");
         //TODO: Register a dynamo stream (also in CFN) to ensure we're getting informed when a job expires
       }
       catch (Exception e) {

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/config/InMemJobConfigClient.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/config/InMemJobConfigClient.java
@@ -78,6 +78,19 @@ public class InMemJobConfigClient extends JobConfigClient {
   }
 
   @Override
+  public Future<List<Job>> loadJobs(String resourceKey, String extendedResourceKey, State state) {
+    return loadJobs().map(jobs ->
+            jobs.stream()
+                    .filter(job ->
+                            (resourceKey == null || job.getResourceKey().equals(resourceKey)
+                              || (extendedResourceKey != null && job.getResourceKey().equals(extendedResourceKey)))
+                            && (state == null || job.getStatus().getState() == state)
+                    )
+                    .toList()
+    );
+  }
+
+  @Override
   public Future<Void> storeJob(Job job) {
     jobMap.put(job.getId(), job);
     return Future.succeededFuture();

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/config/InMemJobConfigClient.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/config/InMemJobConfigClient.java
@@ -78,12 +78,12 @@ public class InMemJobConfigClient extends JobConfigClient {
   }
 
   @Override
-  public Future<List<Job>> loadJobs(String resourceKey, String extendedResourceKey, State state) {
+  public Future<List<Job>> loadJobs(String resourceKey, String secondaryResourceKey, State state) {
     return loadJobs().map(jobs ->
             jobs.stream()
                     .filter(job ->
                             (resourceKey == null || job.getResourceKey().equals(resourceKey)
-                              || (extendedResourceKey != null && job.getResourceKey().equals(extendedResourceKey)))
+                              || (secondaryResourceKey != null && job.getResourceKey().equals(secondaryResourceKey)))
                             && (state == null || job.getStatus().getState() == state)
                     )
                     .toList()

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/config/JobConfigClient.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/config/JobConfigClient.java
@@ -76,6 +76,13 @@ public abstract class JobConfigClient implements Initializable {
    */
   public abstract Future<List<Job>> loadJobs(String resourceKey, State state);
 
+  /**
+   * Load all jobs related to a specified resourceKey OR extendedResourceKey (e.g., space ID) that are having the specified state.
+   * @param resourceKey
+   * @return
+   */
+  public abstract Future<List<Job>> loadJobs(String resourceKey, String extendedResourceKey, State state);
+
   public abstract Future<Void> storeJob(Job job);
 
   /**

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/config/JobConfigClient.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/config/JobConfigClient.java
@@ -77,11 +77,11 @@ public abstract class JobConfigClient implements Initializable {
   public abstract Future<List<Job>> loadJobs(String resourceKey, State state);
 
   /**
-   * Load all jobs related to a specified resourceKey OR extendedResourceKey (e.g., space ID) that are having the specified state.
+   * Load all jobs related to a specified resourceKey OR secondaryResourceKey (e.g., space ID) that are having the specified state.
    * @param resourceKey
    * @return
    */
-  public abstract Future<List<Job>> loadJobs(String resourceKey, String extendedResourceKey, State state);
+  public abstract Future<List<Job>> loadJobs(String resourceKey, String secondaryResourceKey, State state);
 
   public abstract Future<Void> storeJob(Job job);
 

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/datasets/DatasetDescription.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/datasets/DatasetDescription.java
@@ -29,7 +29,6 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import com.fasterxml.jackson.annotation.JsonView;
 import com.here.xyz.Typed;
-import com.here.xyz.events.UpdateStrategy;
 import com.here.xyz.jobs.datasets.DatasetDescription.Map;
 import com.here.xyz.jobs.datasets.DatasetDescription.Space;
 import com.here.xyz.jobs.datasets.filters.FilteringSource;
@@ -81,7 +80,7 @@ public abstract class DatasetDescription implements Typed {
     @JsonView({Public.class, Static.class})
     private Filters filters;
     @JsonView({Public.class, Static.class})
-    private Ref versionRef;
+    private Ref versionRef = new Ref(Ref.HEAD);
 
     @Override
     public Filters getFilters() {

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/datasets/filters/Filters.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/datasets/filters/Filters.java
@@ -25,6 +25,8 @@ import static com.here.xyz.events.ContextAwareEvent.SpaceContext.DEFAULT;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonView;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.here.xyz.XyzSerializable;
 import com.here.xyz.XyzSerializable.Internal;
 import com.here.xyz.XyzSerializable.Public;
 import com.here.xyz.XyzSerializable.Static;
@@ -54,7 +56,11 @@ public class Filters {
 
   public void setPropertyFilter(Object propertyFilter) {
     if (propertyFilter instanceof ArrayList propFilter){
-      this.propertyFilter = new PropertiesQuery(propFilter);
+        try {
+            this.propertyFilter = XyzSerializable.deserialize(XyzSerializable.serialize(propFilter), PropertiesQuery.class);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
     }
     else if (propertyFilter instanceof String propFilter) {
       this.propertyFilter = PropertiesQuery.fromString(propFilter);

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/StepGraph.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/StepGraph.java
@@ -128,4 +128,16 @@ public class StepGraph implements StepExecution {
     setParallel(parallel);
     return this;
   }
+
+  public StepGraph findConnectedSubGraph(StepGraph other) {
+    StepExecution currentNode = executions.get(0);
+    StepExecution currentOtherNode = other.executions.get(0);
+    StepGraph subGraph = new StepGraph();
+
+    if (isEquivalentTo(other))
+      return this;
+    for (StepExecution execution : executions) {}
+
+    return subGraph;
+  }
 }

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/StepGraph.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/StepGraph.java
@@ -164,6 +164,9 @@ public class StepGraph implements StepExecution {
 
     if (isEquivalentTo(other))
       return this;
+
+    //TODO: other.executions has multiple parallel steps - this.executions only one.
+    // Than we have to check each of the parallel steps if they fit to the  this.execution
     for (int i = 0; i < Math.min(executions.size(), other.getExecutions().size()); i++) {
       currentNode = executions.get(i);
       currentOtherNode = other.executions.get(i);

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/compiler/ExportToFiles.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/compiler/ExportToFiles.java
@@ -72,7 +72,7 @@ public class ExportToFiles implements JobCompilationInterceptor {
                     .withOutputMetadata(outputMetadata);
   }
 
-  private static Ref resolveVersionRef(String spaceId, Ref versionRef) {
+  public static Ref resolveVersionRef(String spaceId, Ref versionRef) {
     if(versionRef == null || versionRef.isRange())
       return versionRef;
 

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/compiler/ExportToFiles.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/compiler/ExportToFiles.java
@@ -22,17 +22,11 @@ package com.here.xyz.jobs.steps.compiler;
 import com.here.xyz.jobs.Job;
 import com.here.xyz.jobs.datasets.DatasetDescription.Space;
 import com.here.xyz.jobs.datasets.Files;
-
 import com.here.xyz.jobs.datasets.files.GeoJson;
 import com.here.xyz.jobs.datasets.filters.Filters;
 import com.here.xyz.jobs.steps.CompilationStepGraph;
-import com.here.xyz.jobs.steps.Config;
-import com.here.xyz.jobs.steps.JobCompiler;
 import com.here.xyz.jobs.steps.impl.transport.ExportSpaceToFiles;
 import com.here.xyz.models.hub.Ref;
-import com.here.xyz.responses.StatisticsResponse;
-import com.here.xyz.util.web.HubWebClient;
-
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -58,38 +52,17 @@ public class ExportToFiles implements JobCompilationInterceptor {
             .addExecution(compileExportStep(spaceId, jobId, filters, versionRef, false, true, outputMetadata));
   }
 
-  public static ExportSpaceToFiles compileExportStep(String spaceId, String jobId, Filters filters, Ref versionRef, boolean useSystemOutput, boolean addStatistics, Map<String, String> outputMetadata) {
-    versionRef = resolveVersionRef(spaceId, versionRef);
+  public static ExportSpaceToFiles compileExportStep(String spaceId, String jobId, Filters filters, Ref versionRef, boolean useSystemOutput,
+      boolean addStatistics, Map<String, String> outputMetadata) {
     return new ExportSpaceToFiles()
-                    .withSpaceId(spaceId)
-                    .withJobId(jobId)
-                    .withSpatialFilter(filters != null ? filters.getSpatialFilter() : null)
-                    .withPropertyFilter(filters != null ? filters.getPropertyFilter() : null)
-                    .withContext(filters != null ? filters.getContext() : null)
-                    .withVersionRef(versionRef)
-                    .withUseSystemOutput(useSystemOutput)
-                    .withAddStatisticsToUserOutput(addStatistics)
-                    .withOutputMetadata(outputMetadata);
-  }
-
-  public static Ref resolveVersionRef(String spaceId, Ref versionRef) {
-    if(versionRef == null || versionRef.isRange())
-      return versionRef;
-
-    try {
-      Long resolvedVersion = null;
-      if (versionRef.isHead()) {
-        StatisticsResponse statisticsResponse = HubWebClient.getInstance(Config.instance.HUB_ENDPOINT).loadSpaceStatistics(spaceId);
-        resolvedVersion = statisticsResponse.getMaxVersion().getValue();
-      } else if (versionRef.isTag()) {
-        long version = HubWebClient.getInstance(Config.instance.HUB_ENDPOINT).loadTag(spaceId, versionRef.getTag()).getVersion();
-        if (version >= 0) {
-          resolvedVersion = version;
-        }
-      }
-      return resolvedVersion == null ? versionRef : new Ref(resolvedVersion);
-    } catch (Exception e) {
-      throw new JobCompiler.CompilationError("Unable to resolve '" + versionRef + "' VersionRef!");
-    }
+        .withSpaceId(spaceId)
+        .withJobId(jobId)
+        .withSpatialFilter(filters != null ? filters.getSpatialFilter() : null)
+        .withPropertyFilter(filters != null ? filters.getPropertyFilter() : null)
+        .withContext(filters != null ? filters.getContext() : null)
+        .withVersionRef(versionRef)
+        .withUseSystemOutput(useSystemOutput)
+        .withAddStatisticsToUserOutput(addStatistics)
+        .withOutputMetadata(outputMetadata);
   }
 }

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/compiler/ExportToFiles.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/compiler/ExportToFiles.java
@@ -43,7 +43,7 @@ public class ExportToFiles implements JobCompilationInterceptor {
   @Override
   public boolean chooseMe(Job job) {
     return job.getTarget() instanceof Files
-            && allowedSourceTypes.contains(job.getSource().getClass())
+            && job.getSource().getClass().getSimpleName().equalsIgnoreCase("Space")
             && ((Files<?>) job.getTarget()).getOutputSettings().getFormat() instanceof GeoJson;
   }
 

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/execution/GraphTransformer.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/execution/GraphTransformer.java
@@ -154,15 +154,18 @@ public class GraphTransformer {
 
     NamedState firstState;
     NamedState lastState;
+
+    //delete all DelegateOutputSteps from Graph
+    StepGraph prunedStepGraph = pruneDelegateOutputSteps(stepGraph);
+
     if (stepGraph.isParallel()) {
       //The top-level graph is parallel, compile it into a single ParallelState and add it
-      NamedState parallelState = firstState = lastState = compileToParallelState(stepGraph, null);
+      NamedState parallelState = firstState = lastState = compileToParallelState(prunedStepGraph, null);
       machineBuilder.state(parallelState.stateName, parallelState.stateBuilder);
     }
     else {
-      //delete all DelegateOutputSteps from Graph
-      final List<NamedState> sequentialStates = compileExecutions(
-              pruneDelegateOutputSteps(stepGraph).getExecutions(), null);
+
+      final List<NamedState> sequentialStates = compileExecutions(prunedStepGraph.getExecutions(), null);
       //The top-level graph is sequential, compile all steps into the according states and add them
       sequentialStates.forEach(state -> machineBuilder.state(state.stateName, state.stateBuilder));
       firstState = sequentialStates.get(0);

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/execution/GraphTransformer.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/execution/GraphTransformer.java
@@ -112,6 +112,41 @@ public class GraphTransformer {
     }
   }
 
+  /**
+   * Removes all {@code DelegateOutputsPseudoStep} instances from the given {@code StepGraph},
+   * returning a new {@code StepGraph} containing only the relevant steps.
+   *
+   * <p>This method recursively traverses the given {@code StepGraph}. If a nested {@code StepGraph}
+   * contains non-{@code DelegateOutputsPseudoStep} instances, it is cleaned and added to the new graph.
+   * Any {@code StepGraph} or {@code StepExecution} containing only {@code DelegateOutputsPseudoStep}
+   * instances is excluded from the result.</p>
+   *
+   * <p>The returned graph is a new instance and does not modify the original input {@code StepGraph}.</p>
+   *
+   * @param stepGraph the input {@code StepGraph} to be cleaned.
+   * @return a new {@code StepGraph} with all {@code DelegateOutputsPseudoStep} instances removed.
+   */
+  protected StepGraph pruneDelegateOutputSteps(StepGraph stepGraph){
+    StepGraph newGraph = new StepGraph(); // Create a new StepGraph instance
+
+    for (StepExecution stepExecution : stepGraph.getExecutions()) {
+      if (stepExecution instanceof StepGraph graph) {
+        // Recursively clean and add the nested StepGraph
+        StepGraph cleanedGraph = pruneDelegateOutputSteps(graph);
+
+        // Add the cleaned StepGraph only if it contains non-DelegateOutputsPseudoSteps
+        if (cleanedGraph.getExecutions().stream()
+                .anyMatch(exec -> !(exec instanceof DelegateOutputsPseudoStep))) {
+          newGraph.getExecutions().add(cleanedGraph);
+        }
+      } else if (!(stepExecution instanceof DelegateOutputsPseudoStep)) {
+        // Add non-DelegateOutputsPseudoStep directly
+        newGraph.getExecutions().add(stepExecution);
+      }
+    }
+    return newGraph;
+  }
+
   protected String compileToStateMachine(String stateMachineDescription, StepGraph stepGraph) {
     StateMachine.Builder machineBuilder = StateMachine.builder()
         .comment(stateMachineDescription)
@@ -125,8 +160,10 @@ public class GraphTransformer {
       machineBuilder.state(parallelState.stateName, parallelState.stateBuilder);
     }
     else {
+      //delete all DelegateOutputSteps from Graph
+      final List<NamedState> sequentialStates = compileExecutions(
+              pruneDelegateOutputSteps(stepGraph).getExecutions(), null);
       //The top-level graph is sequential, compile all steps into the according states and add them
-      final List<NamedState> sequentialStates = compileExecutions(stepGraph.getExecutions(), null);
       sequentialStates.forEach(state -> machineBuilder.state(state.stateName, state.stateBuilder));
       firstState = sequentialStates.get(0);
       lastState = sequentialStates.get(sequentialStates.size() - 1);
@@ -193,11 +230,14 @@ public class GraphTransformer {
           //It's a sequential subgraph so compile all elements to states and add them
           states.addAll(compileExecutions(sg.getExecutions(), previousState));
       }
-      else
+      else {
         //It's a step, compile it into a state & add it to the map
-        states.add(compile((Step<?>) execution, previousState));
+        NamedState<TaskState.Builder> compile = compile((Step<?>) execution, previousState);
+        if(compile != null)
+          states.add(compile((Step<?>) execution, previousState));
+      }
 
-      previousState = states.get(states.size() - 1).stateBuilder;
+      previousState = states.size() > 0 ? states.get(states.size() - 1).stateBuilder : null;
     }
     return states;
   }
@@ -220,6 +260,8 @@ public class GraphTransformer {
     }
     else if (step instanceof LambdaBasedStep lambdaStep)
       compile(lambdaStep, state);
+    else if (step instanceof DelegateOutputsPseudoStep)
+      return null;
     else
       throw new NotImplementedException("The provided step implementation (" + step.getClass().getSimpleName() + ") is not supported.");
     //TODO: Add other implementations here (e.g. EcsBasedStep)

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/execution/GraphTransformer.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/execution/GraphTransformer.java
@@ -127,7 +127,7 @@ public class GraphTransformer {
    * @return a new {@code StepGraph} with all {@code DelegateOutputsPseudoStep} instances removed.
    */
   protected StepGraph pruneDelegateOutputSteps(StepGraph stepGraph){
-    StepGraph newGraph = new StepGraph(); // Create a new StepGraph instance
+    StepGraph newGraph = new StepGraph().withParallel(stepGraph.isParallel()); // Create a new StepGraph instance
 
     for (StepExecution stepExecution : stepGraph.getExecutions()) {
       if (stepExecution instanceof StepGraph graph) {
@@ -158,7 +158,7 @@ public class GraphTransformer {
     //delete all DelegateOutputSteps from Graph
     StepGraph prunedStepGraph = pruneDelegateOutputSteps(stepGraph);
 
-    if (stepGraph.isParallel()) {
+    if (prunedStepGraph.isParallel()) {
       //The top-level graph is parallel, compile it into a single ParallelState and add it
       NamedState parallelState = firstState = lastState = compileToParallelState(prunedStepGraph, null);
       machineBuilder.state(parallelState.stateName, parallelState.stateBuilder);

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/execution/GraphTransformer.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/execution/GraphTransformer.java
@@ -128,6 +128,7 @@ public class GraphTransformer {
    */
   protected StepGraph pruneDelegateOutputSteps(StepGraph stepGraph){
     StepGraph newGraph = new StepGraph().withParallel(stepGraph.isParallel()); // Create a new StepGraph instance
+    List<String[]> replacements = new ArrayList();
 
     for (StepExecution stepExecution : stepGraph.getExecutions()) {
       if (stepExecution instanceof StepGraph graph) {
@@ -142,8 +143,11 @@ public class GraphTransformer {
       } else if (!(stepExecution instanceof DelegateOutputsPseudoStep)) {
         // Add non-DelegateOutputsPseudoStep directly
         newGraph.getExecutions().add(stepExecution);
+      } else if (stepExecution instanceof DelegateOutputsPseudoStep delegateStep) {
+        replacements.add(delegateStep.getReplacementPathForFiles());
       }
     }
+
     return newGraph;
   }
 
@@ -155,7 +159,6 @@ public class GraphTransformer {
     NamedState firstState;
     NamedState lastState;
 
-    //delete all DelegateOutputSteps from Graph
     StepGraph prunedStepGraph = pruneDelegateOutputSteps(stepGraph);
 
     if (prunedStepGraph.isParallel()) {

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/execution/JobExecutor.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/execution/JobExecutor.java
@@ -327,7 +327,7 @@ public abstract class JobExecutor implements Initializable {
   private static Future<Void> reuseExistingJobIfPossible(Job job) {
     if(job.getResourceKey() == null)
       return Future.succeededFuture();
-    return JobConfigClient.getInstance().loadJobs(job.getResourceKey(), job.getExtendedResourceKey(), SUCCEEDED)
+    return JobConfigClient.getInstance().loadJobs(job.getResourceKey(), job.getSecondaryResourceKey(), SUCCEEDED)
         .compose(candidates -> shrinkGraphByReusingOtherGraph(job, candidates.stream()
             .filter(candidate -> !job.getId().equals(candidate.getId())) //Do not try to compare the job to itself
             .map(candidate -> candidate.getSteps().findConnectedEquivalentSubGraph(job.getSteps()))

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/execution/JobExecutor.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/execution/JobExecutor.java
@@ -375,15 +375,15 @@ public abstract class JobExecutor implements Initializable {
    * @param executions  StepExecutions of current Graph
    * @param reusedExecutions StepExecutions which should get reused
    */
-  private static void replaceWithDelegateOutputSteps(
-          List<StepExecution> executions, List<StepExecution> reusedExecutions) {
+  private static void replaceWithDelegateOutputSteps(List<StepExecution> executions, List<StepExecution> reusedExecutions) {
     for (int i = 0; i < reusedExecutions.size(); i++) {
       StepExecution execution = executions.get(i);
       StepExecution reusedExecution = reusedExecutions.get(i);
 
       if (execution instanceof StepGraph graph && reusedExecution instanceof StepGraph reusedGraph) {
         replaceWithDelegateOutputSteps(graph.getExecutions(), reusedGraph.getExecutions());
-      } else if (execution instanceof Step step && reusedExecution instanceof Step reusedStep) {
+      }
+      else if (execution instanceof Step step && reusedExecution instanceof Step reusedStep) {
         // Replace the execution with DelegateOutputsPseudoStep
         executions.set(i, new DelegateOutputsPseudoStep(reusedStep.getJobId(), reusedStep.getId(), ((Step<?>) execution).getJobId(),
                 ((Step<?>) execution).getId()).withOutputMetadata(reusedStep.getOutputMetadata()));

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/execution/JobExecutor.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/execution/JobExecutor.java
@@ -472,6 +472,8 @@ public abstract class JobExecutor implements Initializable {
         // Recursive injection for nested StepGraph
         updateExecutionDependencies(graph.getExecutions(), previousStepIdsOfFirstNewNode, newJobId, stepIdsOfLastReusedNodes, jobIdLastReusedNode);
       } else if (executionNode instanceof Step<?> step) {
+        if(previousStepIdsOfFirstNewNode == null)
+          continue;
         // Replace previous StepIds
         if (!step.getPreviousStepIds().isEmpty() && step.getPreviousStepIds().removeAll(previousStepIdsOfFirstNewNode)) {
           step.getPreviousStepIds().addAll(stepIdsOfLastReusedNodes);

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/execution/JobExecutor.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/execution/JobExecutor.java
@@ -386,7 +386,7 @@ public abstract class JobExecutor implements Initializable {
       } else if (execution instanceof Step step && reusedExecution instanceof Step reusedStep) {
         // Replace the execution with DelegateOutputsPseudoStep
         executions.set(i, new DelegateOutputsPseudoStep(reusedStep.getJobId(), reusedStep.getId(), ((Step<?>) execution).getJobId(),
-                ((Step<?>) execution).getId() ));
+                ((Step<?>) execution).getId()).withOutputMetadata(reusedStep.getOutputMetadata()));
       }
     }
   }

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/execution/JobExecutor.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/execution/JobExecutor.java
@@ -377,7 +377,7 @@ public abstract class JobExecutor implements Initializable {
         replaceWithDelegateOutputSteps(graph.getExecutions(), reusedGraph.getExecutions());
       } else if (execution instanceof Step step && reusedExecution instanceof Step reusedStep) {
         // Replace the execution with DelegateOutputsPseudoStep
-        executions.set(i, new DelegateOutputsPseudoStep(reusedStep.getJobId(), reusedStep.getId()));
+        executions.set(i, new DelegateOutputsPseudoStep(reusedStep.getJobId(), reusedStep.getId(), ((Step<?>) execution).getJobId() ));
       }
     }
   }

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/util/test/JobTestBase.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/util/test/JobTestBase.java
@@ -65,8 +65,14 @@ public class JobTestBase extends StepTestBase {
         delete("/jobs/" + jobId );
     }
 
-    public static RuntimeStatus getJobStatus(String jobId) throws IOException, InterruptedException {
+    public static Map getJob(String jobId, boolean useAdminEndpoint) throws IOException, InterruptedException {
         logger.info("Get job ...");
+        HttpResponse<byte[]> jobResponse = get((useAdminEndpoint ? "/admin" : "/") +"/jobs/" + jobId);
+        return XyzSerializable.deserialize(jobResponse.body(), new TypeReference<Map>() {});
+    }
+
+    public static RuntimeStatus getJobStatus(String jobId) throws IOException, InterruptedException {
+        logger.info("Get job status...");
         HttpResponse<byte[]> statusResponse = get("/jobs/" + jobId + "/status");
         return XyzSerializable.deserialize(statusResponse.body(), RuntimeStatus.class);
     }

--- a/xyz-jobs/xyz-job-service/src/test/java/com/here/xyz/jobs/ExportJobTestIT.java
+++ b/xyz-jobs/xyz-job-service/src/test/java/com/here/xyz/jobs/ExportJobTestIT.java
@@ -5,8 +5,11 @@ import com.here.xyz.jobs.datasets.FileOutputSettings;
 import com.here.xyz.jobs.datasets.Files;
 import com.here.xyz.jobs.datasets.files.GeoJson;
 import com.here.xyz.jobs.datasets.filters.Filters;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.util.Map;
 
 import static com.here.xyz.jobs.datasets.files.FileFormat.EntityPerLine.Feature;
 
@@ -17,6 +20,7 @@ public class ExportJobTestIT extends JobTest {
     public void setUp() {
         super.setUp();
         putRandomFeatureCollectionToSpace(SPACE_ID, featureCount);
+//        patchSpace(SPACE_ID, Map.of("readOnly", true));
     }
 
     @Test
@@ -38,8 +42,18 @@ public class ExportJobTestIT extends JobTest {
         createSelfRunningJob(exportJob2);
         checkJobReusage(exportJob1, exportJob2, featureCount, true);
 
-        deleteJob(exportJob1.getId());
+        boolean exceptionRaised = false;
+        try{
+            deleteJob(exportJob1.getId());
+        }catch (RuntimeException e){
+            //Job can not get deleted due to references to job2
+            exceptionRaised = true;
+        }
+        Assertions.assertTrue(exceptionRaised);
+
+        //delete in correct order
         deleteJob(exportJob2.getId());
+        deleteJob(exportJob1.getId());
     }
 
     @Test

--- a/xyz-jobs/xyz-job-service/src/test/java/com/here/xyz/jobs/ExportJobTestIT.java
+++ b/xyz-jobs/xyz-job-service/src/test/java/com/here/xyz/jobs/ExportJobTestIT.java
@@ -4,17 +4,19 @@ import com.here.xyz.jobs.datasets.DatasetDescription;
 import com.here.xyz.jobs.datasets.FileOutputSettings;
 import com.here.xyz.jobs.datasets.Files;
 import com.here.xyz.jobs.datasets.files.GeoJson;
+import com.here.xyz.jobs.datasets.filters.Filters;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static com.here.xyz.jobs.datasets.files.FileFormat.EntityPerLine.Feature;
 
 public class ExportJobTestIT extends JobTest {
+    private final int featureCount = 50;
 
     @BeforeEach
     public void setUp() {
         super.setUp();
-        putRandomFeatureCollectionToSpace(SPACE_ID,50);
+        putRandomFeatureCollectionToSpace(SPACE_ID, featureCount);
     }
 
     @Test
@@ -22,15 +24,52 @@ public class ExportJobTestIT extends JobTest {
         Job exportJob = buildExportJob();
         createSelfRunningJob(exportJob);
 
-        checkSucceededJob(exportJob);
+        checkSucceededJob(exportJob, featureCount);
         deleteJob(exportJob.getId());
     }
 
+    @Test
+    public void testReusingSimpleExportMatch() throws Exception {
+        Job exportJob1 = buildExportJob();
+        createSelfRunningJob(exportJob1);
+        checkSucceededJob(exportJob1, featureCount);
+
+        Job exportJob2 = buildExportJob(generateJobId());
+        createSelfRunningJob(exportJob2);
+        checkJobReusage(exportJob1, exportJob2, featureCount, true);
+
+        deleteJob(exportJob1.getId());
+        deleteJob(exportJob2.getId());
+    }
+
+    @Test
+    public void testReusingSimpleExportMismatch() throws Exception {
+        Job exportJob1 = buildExportJob();
+        createSelfRunningJob(exportJob1);
+        checkSucceededJob(exportJob1, featureCount);
+
+        //Job could not reuse the first one
+        Job exportJob2 = buildExportJob(generateJobId(), new Filters().withPropertyFilter("p.test<10"));
+        createSelfRunningJob(exportJob2);
+        checkJobReusage(exportJob1, exportJob2, 10, false);
+
+        deleteJob(exportJob1.getId());
+        deleteJob(exportJob2.getId());
+    }
+
     private Job buildExportJob() {
+        return buildExportJob(JOB_ID);
+    }
+
+    private Job buildExportJob(String jobId){
+        return buildExportJob(jobId, null);
+    }
+
+    private Job buildExportJob(String jobId, Filters filters) {
         return new Job()
-                .withId(JOB_ID)
+                .withId(jobId)
                 .withDescription("Export Job Test")
-                .withSource(new DatasetDescription.Space<>().withId(SPACE_ID))
+                .withSource(new DatasetDescription.Space<>().withId(SPACE_ID).withFilters(filters))
                 .withTarget(new Files<>().withOutputSettings(new FileOutputSettings().withFormat(new GeoJson().withEntityPerLine(Feature))));
     }
 }

--- a/xyz-jobs/xyz-job-service/src/test/java/com/here/xyz/jobs/ExportJobTestIT.java
+++ b/xyz-jobs/xyz-job-service/src/test/java/com/here/xyz/jobs/ExportJobTestIT.java
@@ -42,6 +42,8 @@ public class ExportJobTestIT extends JobTest {
         createSelfRunningJob(exportJob2);
         checkJobReusage(exportJob1, exportJob2, featureCount, true);
 
+        //inactive cause we allow the deletion currently
+        /**
         boolean exceptionRaised = false;
         try{
             deleteJob(exportJob1.getId());
@@ -49,7 +51,7 @@ public class ExportJobTestIT extends JobTest {
             //Job can not get deleted due to references to job2
             exceptionRaised = true;
         }
-        Assertions.assertTrue(exceptionRaised);
+        Assertions.assertTrue(exceptionRaised);*/
 
         //delete in correct order
         deleteJob(exportJob2.getId());

--- a/xyz-jobs/xyz-job-service/src/test/java/com/here/xyz/jobs/ExportJobTestIT.java
+++ b/xyz-jobs/xyz-job-service/src/test/java/com/here/xyz/jobs/ExportJobTestIT.java
@@ -1,17 +1,14 @@
 package com.here.xyz.jobs;
 
+import static com.here.xyz.jobs.datasets.files.FileFormat.EntityPerLine.Feature;
+
 import com.here.xyz.jobs.datasets.DatasetDescription;
 import com.here.xyz.jobs.datasets.FileOutputSettings;
 import com.here.xyz.jobs.datasets.Files;
 import com.here.xyz.jobs.datasets.files.GeoJson;
 import com.here.xyz.jobs.datasets.filters.Filters;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import java.util.Map;
-
-import static com.here.xyz.jobs.datasets.files.FileFormat.EntityPerLine.Feature;
 
 public class ExportJobTestIT extends JobTest {
     private final int featureCount = 50;
@@ -20,7 +17,10 @@ public class ExportJobTestIT extends JobTest {
     public void setUp() {
         super.setUp();
         putRandomFeatureCollectionToSpace(SPACE_ID, featureCount);
-//        patchSpace(SPACE_ID, Map.of("readOnly", true));
+    }
+
+    public void cleanup() {
+        //TODO: Cleanup the created job
     }
 
     @Test

--- a/xyz-jobs/xyz-job-service/src/test/java/com/here/xyz/jobs/JobTest.java
+++ b/xyz-jobs/xyz-job-service/src/test/java/com/here/xyz/jobs/JobTest.java
@@ -49,7 +49,7 @@ public class JobTest extends JobTestBase {
             if(jobOutput.get("type").equals("FileStatistics")){
                 foundStatistics = true;
                 Assertions.assertEquals(expectedFeatureCount, jobOutput.get("exportedFeatures"));
-                Assertions.assertEquals(8, jobOutput.get("exportedFiles"));
+                Assertions.assertEquals(1, jobOutput.get("exportedFiles"));
                 Assertions.assertTrue((int) jobOutput.get("exportedFiles") > 0);
             }else if(jobOutput.get("type").equals("DownloadUrl")){
                 foundUrls = true;

--- a/xyz-jobs/xyz-job-service/src/test/java/com/here/xyz/jobs/JobTest.java
+++ b/xyz-jobs/xyz-job-service/src/test/java/com/here/xyz/jobs/JobTest.java
@@ -6,6 +6,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 
 public class JobTest extends JobTestBase {
     @BeforeEach
@@ -18,9 +20,56 @@ public class JobTest extends JobTestBase {
         deleteSpace(SPACE_ID);
     }
 
-    protected void checkSucceededJob(Job exportJob) throws IOException, InterruptedException {
-        RuntimeStatus status = getJobStatus(exportJob.getId());
+    protected void checkSucceededJob(Job exportJob, int expectedFeatureCount) throws IOException, InterruptedException {
+        checkRuntimeStatus(exportJob.getId());
+        checkOutputs(exportJob, expectedFeatureCount);
+    }
+
+    protected void checkJobReusage(Job reusedJob, Job exportJob, int expectedFeatureCount, boolean expectMatch) throws IOException, InterruptedException {
+        checkRuntimeStatus(exportJob.getId());
+        checkOutputs(reusedJob, exportJob, expectedFeatureCount, expectMatch);
+    }
+
+    private void checkRuntimeStatus(String jobId) throws IOException, InterruptedException {
+        RuntimeStatus status = getJobStatus(jobId);
         Assertions.assertEquals(RuntimeInfo.State.SUCCEEDED, status.getState());
         Assertions.assertEquals(status.getOverallStepCount(), status.getSucceededSteps());
+    }
+
+    private void checkOutputs(Job exportJob, int expectedFeatureCount) throws IOException, InterruptedException {
+        checkOutputs(null, exportJob, expectedFeatureCount, false);
+    }
+
+    private void checkOutputs(Job firstJob, Job secondJob, int expectedFeatureCount, boolean expectMatch) throws IOException, InterruptedException {
+        boolean foundStatistics = false;
+        boolean foundUrls = false;
+
+        List<Map> jobOutputs = getJobOutputs(secondJob.getId());
+        for (Map jobOutput : jobOutputs) {
+            if(jobOutput.get("type").equals("FileStatistics")){
+                foundStatistics = true;
+                Assertions.assertEquals(expectedFeatureCount, jobOutput.get("exportedFeatures"));
+                Assertions.assertEquals(8, jobOutput.get("exportedFiles"));
+                Assertions.assertTrue((int) jobOutput.get("exportedFiles") > 0);
+            }else if(jobOutput.get("type").equals("DownloadUrl")){
+                foundUrls = true;
+                if(expectMatch) {
+                    //all links should point to firstJob (reused) Job
+                    Assertions.assertTrue(((String) jobOutput.get("url")).contains(firstJob.getId()));
+                    //no link should have a reference to the new job (secondJob)
+                    Assertions.assertFalse(((String) jobOutput.get("url")).contains(secondJob.getId()));
+                }else{
+                    //all links should point to secondJob as reference
+                    Assertions.assertTrue(((String) jobOutput.get("url")).contains(secondJob.getId()));
+                    if(firstJob != null){
+                        //no link should have a reference to the firstJob (noMatch)
+                        Assertions.assertFalse(((String) jobOutput.get("url")).contains(firstJob.getId()));
+                    }
+                }
+            }
+        }
+
+        Assertions.assertTrue(foundStatistics);
+        Assertions.assertTrue(foundUrls);
     }
 }

--- a/xyz-jobs/xyz-job-service/src/test/java/com/here/xyz/jobs/com/here/xyz/jobs/steps/execution/JobExecutor.java
+++ b/xyz-jobs/xyz-job-service/src/test/java/com/here/xyz/jobs/com/here/xyz/jobs/steps/execution/JobExecutor.java
@@ -12,6 +12,8 @@ import com.here.xyz.jobs.steps.impl.transport.ImportFilesToSpace;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -26,9 +28,16 @@ public class JobExecutor {
     private static final String SOURCE_ID2 = "SOURCE_2";
 
     {
-        new Config();
-        Config.instance.PARALLEL_STEPS_SUPPORTED = true;
-        Config.instance.JOBS_DYNAMODB_TABLE_ARN = "arn:aws:dynamodb:localhost:000000008000:table/xyz-jobs-local";
+        try {
+            new Config();
+            Config.instance.PARALLEL_STEPS_SUPPORTED = true;
+            Config.instance.JOBS_DYNAMODB_TABLE_ARN = "arn:aws:dynamodb:localhost:000000008000:table/xyz-jobs-local";
+            Config.instance.LOCALSTACK_ENDPOINT = new URI("http://localhost:4566");
+            Config.instance.JOBS_S3_BUCKET = "test-bucket";
+            Config.instance.AWS_REGION = "us-east-1";
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Test

--- a/xyz-jobs/xyz-job-service/src/test/java/com/here/xyz/jobs/com/here/xyz/jobs/steps/execution/JobExecutor.java
+++ b/xyz-jobs/xyz-job-service/src/test/java/com/here/xyz/jobs/com/here/xyz/jobs/steps/execution/JobExecutor.java
@@ -1,0 +1,411 @@
+package com.here.xyz.jobs.com.here.xyz.jobs.steps.execution;
+
+import com.here.xyz.jobs.Job;
+import com.here.xyz.jobs.service.Config;
+import com.here.xyz.jobs.steps.CompilationStepGraph;
+import com.here.xyz.jobs.steps.Step;
+import com.here.xyz.jobs.steps.StepExecution;
+import com.here.xyz.jobs.steps.StepGraph;
+import com.here.xyz.jobs.steps.execution.DelegateOutputsPseudoStep;
+import com.here.xyz.jobs.steps.impl.transport.ExportSpaceToFiles;
+import com.here.xyz.jobs.steps.impl.transport.ImportFilesToSpace;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.here.xyz.jobs.steps.impl.transport.ImportFilesToSpace.Format.GEOJSON;
+
+public class JobExecutor {
+    private static final String JOB_ID1 = "TEST_JOB_1";
+    private static final String JOB_ID2 = "TEST_JOB_2";
+    private static final String SOURCE_ID1 = "SOURCE_1";
+    private static final String SOURCE_ID2 = "SOURCE_2";
+
+    {
+        new Config();
+        Config.instance.PARALLEL_STEPS_SUPPORTED = true;
+        Config.instance.JOBS_DYNAMODB_TABLE_ARN = "arn:aws:dynamodb:localhost:000000008000:table/xyz-jobs-local";
+    }
+
+    @Test
+    public void testReuseSequentialGraph(){
+        //      |   (reusable)
+        //      |   (reusable)
+        //      |   (not-reusable)
+
+        CompilationStepGraph graph1 = connectStepExecutions(List.of(
+                stepGenerator(ExportSpaceToFiles.class, JOB_ID1, SOURCE_ID1),
+                stepGenerator(ExportSpaceToFiles.class, JOB_ID1, SOURCE_ID1),
+                stepGenerator(ExportSpaceToFiles.class, JOB_ID1, SOURCE_ID1)
+        ),false);
+        graph1 = (CompilationStepGraph) graph1.enrich(JOB_ID1);
+
+        CompilationStepGraph graph2 = connectStepExecutions(List.of(
+                stepGenerator(ExportSpaceToFiles.class, JOB_ID2, SOURCE_ID1),
+                stepGenerator(ExportSpaceToFiles.class, JOB_ID2, SOURCE_ID1),
+                stepGenerator(ExportSpaceToFiles.class, JOB_ID2, SOURCE_ID2) //not reusable
+        ),false);
+        graph2 = (CompilationStepGraph) graph2.enrich(JOB_ID1);
+
+        StepGraph connectedEquivalentSubGraph = graph2.findConnectedEquivalentSubGraph(graph1);
+        //2 Steps can be reused
+        Assertions.assertEquals(2, connectedEquivalentSubGraph.getExecutions().size());
+
+        com.here.xyz.jobs.steps.execution.JobExecutor.shrinkGraphByReusingOtherGraph(
+                new Job().withId(JOB_ID1).withSteps(graph2),
+                connectedEquivalentSubGraph
+        ).onSuccess(graph ->
+                {
+                    Step execution1 = (Step)graph.getExecutions().get(0);
+                    Step execution2 = (Step)graph.getExecutions().get(1);
+                    Step execution3 = (Step)graph.getExecutions().get(2);
+
+                    Assertions.assertInstanceOf(DelegateOutputsPseudoStep.class, execution1);
+                    Assertions.assertInstanceOf(DelegateOutputsPseudoStep.class, execution2);
+                    Assertions.assertInstanceOf(ExportSpaceToFiles.class, execution3);
+
+                    //Check if previousStepId is set correct
+                    Assertions.assertEquals(new HashSet<>(List.of(execution2.getId()))
+                            , execution3.getPreviousStepIds());
+                }
+        );
+    }
+
+    @Test
+    public void testReuseSequentialGraphWithInputIds(){
+        //      |   (reusable)
+        //      |   (reusable)
+        //      |   (not-reusable)
+        ExportSpaceToFiles exportStep = (ExportSpaceToFiles)stepGenerator(ExportSpaceToFiles.class, JOB_ID1, SOURCE_ID1);
+
+        CompilationStepGraph graph1 = connectStepExecutions(List.of(
+                exportStep,
+                stepGenerator(ImportFilesToSpace.class, JOB_ID1, SOURCE_ID2, Set.of(exportStep.getId()))
+        ),false);
+        graph1 = (CompilationStepGraph) graph1.enrich(JOB_ID1);
+
+        ExportSpaceToFiles exportStep2 = (ExportSpaceToFiles)stepGenerator(ExportSpaceToFiles.class, JOB_ID1, SOURCE_ID1);
+        CompilationStepGraph graph2 = connectStepExecutions(List.of(
+                exportStep2,
+                stepGenerator(ImportFilesToSpace.class, JOB_ID2, SOURCE_ID2, Set.of(exportStep2.getId())) //not reusable
+        ),false);
+        graph2 = (CompilationStepGraph) graph2.enrich(JOB_ID1);
+
+        StepGraph connectedEquivalentSubGraph = graph2.findConnectedEquivalentSubGraph(graph1);
+        //Only ExportStep can be reused. Imports are not implementing isEquivalentTo().
+        Assertions.assertEquals(1, connectedEquivalentSubGraph.getExecutions().size());
+
+        com.here.xyz.jobs.steps.execution.JobExecutor.shrinkGraphByReusingOtherGraph(
+                new Job().withId(JOB_ID1).withSteps(graph1),
+                connectedEquivalentSubGraph
+        ).onSuccess(graph ->
+                {
+                    Step execution1 = (Step)graph.getExecutions().get(0);
+                    Step execution2 = (Step)graph.getExecutions().get(1);
+
+                    Assertions.assertInstanceOf(DelegateOutputsPseudoStep.class, execution1);
+                    Assertions.assertInstanceOf(ImportFilesToSpace.class, execution2);
+
+                    //Check if previousStepIds are set correct
+                    Assertions.assertEquals(new HashSet<>(List.of(execution1.getId()))
+                            , execution2.getPreviousStepIds());
+                    //Check if inputStepIds are set correct (+ linked to reused job)
+                    Assertions.assertEquals(new HashSet<>(List.of(JOB_ID1 +":"+ exportStep.getId()))
+                            , execution2.getInputStepIds());
+                }
+        );
+    }
+
+    @Test
+    public void testReuseParallelGraph(){
+        //      |(reusable)  |(reusable)  |(not-reusable)
+
+        CompilationStepGraph graph1 = connectStepExecutions(List.of(
+                stepGenerator(ExportSpaceToFiles.class, JOB_ID1, SOURCE_ID1),
+                stepGenerator(ExportSpaceToFiles.class, JOB_ID1, SOURCE_ID1),
+                stepGenerator(ExportSpaceToFiles.class, JOB_ID1, SOURCE_ID1)
+        ),true);
+        graph1 = (CompilationStepGraph) graph1.enrich(JOB_ID1);
+
+        CompilationStepGraph graph2 = connectStepExecutions(List.of(
+                stepGenerator(ExportSpaceToFiles.class, JOB_ID2, SOURCE_ID1),
+                stepGenerator(ExportSpaceToFiles.class, JOB_ID2, SOURCE_ID1),
+                stepGenerator(ExportSpaceToFiles.class, JOB_ID2, SOURCE_ID2) //not reusable
+        ),true);
+        graph2 = (CompilationStepGraph) graph2.enrich(JOB_ID2);
+
+        StepGraph connectedEquivalentSubGraph = graph2.findConnectedEquivalentSubGraph(graph1);
+        //2 Steps can be reused
+        Assertions.assertEquals(2, connectedEquivalentSubGraph.getExecutions().size());
+
+        com.here.xyz.jobs.steps.execution.JobExecutor.shrinkGraphByReusingOtherGraph(
+                new Job().withId(JOB_ID1).withSteps(graph2),
+                connectedEquivalentSubGraph
+        ).onSuccess(graph ->
+                {
+                    Assertions.assertTrue(graph.isParallel());
+                    Step execution1 = (Step)graph.getExecutions().get(0);
+                    Step execution2 = (Step)graph.getExecutions().get(1);
+                    Step execution3 = (Step)graph.getExecutions().get(2);
+
+                    Assertions.assertInstanceOf(DelegateOutputsPseudoStep.class, execution1);
+                    Assertions.assertInstanceOf(DelegateOutputsPseudoStep.class, execution2);
+                    Assertions.assertInstanceOf(ExportSpaceToFiles.class, execution3);
+
+                    //Check if previousStepId is set correct
+                    graph.getExecutions().forEach(step ->{
+                        Assertions.assertTrue(((Step)step).getPreviousStepIds().isEmpty());
+                    });
+                }
+        );
+    }
+
+    @Test
+    public void testReuseParallelAndSequentialGraph(){
+        //      |  |  | (all reusable)
+        //      _______
+        //         |    (reusable)
+        //         |    (not-reusable)
+
+        CompilationStepGraph graph1 = connectStepExecutions(List.of(
+                connectStepExecutions(List.of(
+                        stepGenerator(ExportSpaceToFiles.class, JOB_ID1, SOURCE_ID1),
+                        stepGenerator(ExportSpaceToFiles.class, JOB_ID1, SOURCE_ID1),
+                        stepGenerator(ExportSpaceToFiles.class, JOB_ID1, SOURCE_ID1)
+                ),true),
+                stepGenerator(ExportSpaceToFiles.class, JOB_ID1, SOURCE_ID1),
+                stepGenerator(ExportSpaceToFiles.class, JOB_ID1, SOURCE_ID1)
+        ),false);
+        graph1 = (CompilationStepGraph) graph1.enrich(JOB_ID1);
+
+        CompilationStepGraph graph2 = connectStepExecutions(List.of(
+                connectStepExecutions(List.of(
+                        stepGenerator(ExportSpaceToFiles.class, JOB_ID2, SOURCE_ID1),
+                        stepGenerator(ExportSpaceToFiles.class, JOB_ID2, SOURCE_ID1),
+                        stepGenerator(ExportSpaceToFiles.class, JOB_ID2, SOURCE_ID1)
+                ),true),
+                stepGenerator(ExportSpaceToFiles.class, JOB_ID2, SOURCE_ID1),
+                stepGenerator(ExportSpaceToFiles.class, JOB_ID2, SOURCE_ID2),
+                stepGenerator(ExportSpaceToFiles.class, JOB_ID2, SOURCE_ID2)
+        ),false);
+        graph2 = (CompilationStepGraph) graph2.enrich(JOB_ID2);
+
+        StepGraph connectedEquivalentSubGraph = graph2.findConnectedEquivalentSubGraph(graph1);
+        //4 Steps can be potentially reused
+        Assertions.assertEquals(4, com.here.xyz.jobs.steps.execution.JobExecutor.getAllLeafExecutionNodes(connectedEquivalentSubGraph).size());
+
+        com.here.xyz.jobs.steps.execution.JobExecutor.shrinkGraphByReusingOtherGraph(
+                new Job().withId(JOB_ID1).withSteps(graph2),
+                connectedEquivalentSubGraph
+        ).onSuccess(graph ->
+                {
+
+                    StepGraph execution1Graph = (StepGraph)graph.getExecutions().get(0);
+                    Assertions.assertTrue(execution1Graph.isParallel());
+                    execution1Graph.getExecutions().forEach(step -> Assertions.assertInstanceOf(DelegateOutputsPseudoStep.class, step));
+
+                    Step execution2 = (Step)graph.getExecutions().get(1);
+                    Step execution3 = (Step)graph.getExecutions().get(2);
+
+                    Assertions.assertInstanceOf(DelegateOutputsPseudoStep.class, execution2);
+                    Assertions.assertInstanceOf(ExportSpaceToFiles.class, execution3);
+
+                    //Check if previousStepId is set correct
+                    Assertions.assertEquals(new HashSet<>(List.of(execution2.getId()))
+                            , execution3.getPreviousStepIds());
+                }
+        );
+    }
+
+    //TODO: Verify if behavior is correct
+    @Test
+    public void testReuseParallelAndSequentialGraph2(){
+        //      |  |  | (reusable) | (not-reusable)
+        //      _______
+        //         |    (reusable)
+
+        CompilationStepGraph graph1 = connectStepExecutions(List.of(
+                stepGenerator(ExportSpaceToFiles.class, JOB_ID1, SOURCE_ID1)
+        ),false);
+        graph1 = (CompilationStepGraph) graph1.enrich(JOB_ID1);
+
+        CompilationStepGraph graph2 = connectStepExecutions(List.of(
+                connectStepExecutions(List.of(
+                        stepGenerator(ExportSpaceToFiles.class, JOB_ID2, SOURCE_ID1),
+                        stepGenerator(ExportSpaceToFiles.class, JOB_ID2, SOURCE_ID2)
+                ),true),
+                stepGenerator(ExportSpaceToFiles.class, JOB_ID2, SOURCE_ID1)
+        ),false);
+        graph2 = (CompilationStepGraph) graph2.enrich(JOB_ID2);
+
+        StepGraph connectedEquivalentSubGraph = graph2.findConnectedEquivalentSubGraph(graph1);
+        //4 Steps can be potentially reused
+        Assertions.assertEquals(0, com.here.xyz.jobs.steps.execution.JobExecutor.getAllLeafExecutionNodes(connectedEquivalentSubGraph).size());
+
+        com.here.xyz.jobs.steps.execution.JobExecutor.shrinkGraphByReusingOtherGraph(
+                new Job().withId(JOB_ID1).withSteps(graph2),
+                connectedEquivalentSubGraph
+        ) .onSuccess(graph -> Assertions.assertNull(graph));
+    }
+
+    @Test
+    public void testReuseMixedGraph(){
+        //    |      (reusable)
+        //   - -
+        //   | |     (all reusable)
+        //   - -
+        //    |      (not-reusable)
+        //    |      (not-reusable)
+
+        CompilationStepGraph graph1 = connectStepExecutions(List.of(
+                stepGenerator(ExportSpaceToFiles.class, JOB_ID1, SOURCE_ID1),
+                connectStepExecutions(List.of(
+                        stepGenerator(ExportSpaceToFiles.class, JOB_ID1, SOURCE_ID1),
+                        stepGenerator(ExportSpaceToFiles.class, JOB_ID1, SOURCE_ID1)
+                ),true),
+                stepGenerator(ExportSpaceToFiles.class, JOB_ID1, SOURCE_ID1)
+        ),false);
+        graph1 = (CompilationStepGraph) graph1.enrich(JOB_ID1);
+
+        CompilationStepGraph graph2 = connectStepExecutions(List.of(
+                stepGenerator(ExportSpaceToFiles.class, JOB_ID2, SOURCE_ID1),
+                connectStepExecutions(List.of(
+                        stepGenerator(ExportSpaceToFiles.class, JOB_ID2, SOURCE_ID1),
+                        stepGenerator(ExportSpaceToFiles.class, JOB_ID2, SOURCE_ID1)
+                ),true),
+                stepGenerator(ExportSpaceToFiles.class, JOB_ID2, SOURCE_ID2), //not reusable
+                stepGenerator(ExportSpaceToFiles.class, JOB_ID2, SOURCE_ID2)  //not reusable
+        ),false);
+        graph2 = (CompilationStepGraph) graph2.enrich(JOB_ID2);
+
+        StepGraph connectedEquivalentSubGraph = graph2.findConnectedEquivalentSubGraph(graph1);
+        //3 Steps can be potentially reused
+        Assertions.assertEquals(3, com.here.xyz.jobs.steps.execution.JobExecutor.getAllLeafExecutionNodes(connectedEquivalentSubGraph).size());
+
+        com.here.xyz.jobs.steps.execution.JobExecutor.shrinkGraphByReusingOtherGraph(
+                new Job().withId(JOB_ID1).withSteps(graph2),
+                connectedEquivalentSubGraph
+        ).onSuccess(graph ->
+                {
+
+                    Step execution1 = (Step)graph.getExecutions().get(0);
+                    Assertions.assertInstanceOf(DelegateOutputsPseudoStep.class, execution1);
+
+                    StepGraph execution2Graph = (StepGraph)graph.getExecutions().get(1);
+                    Assertions.assertTrue(execution2Graph.isParallel());
+                    execution2Graph.getExecutions().forEach(step -> Assertions.assertInstanceOf(DelegateOutputsPseudoStep.class, step));
+                    Set<String> execution2Ids = execution2Graph.getExecutions().stream().map(stepExecution -> ((Step) stepExecution).getId()).collect(Collectors.toSet());
+
+                    Step execution3 = (Step)graph.getExecutions().get(2);
+                    Step execution4 = (Step)graph.getExecutions().get(3);
+
+                    Assertions.assertInstanceOf(ExportSpaceToFiles.class, execution3);
+                    Assertions.assertInstanceOf(ExportSpaceToFiles.class, execution4);
+
+                    //Check if previousStepId is set correct
+                    Assertions.assertEquals(execution2Ids, execution3.getPreviousStepIds());
+                }
+        );
+    }
+
+    @Test
+    public void testReuseMixedGraph2() {
+        //    |      (reusable)
+        //   - -
+        //   | |     (left reusable & right not)
+        //   - -
+        //    |      (reusable)
+
+        CompilationStepGraph graph1 = connectStepExecutions(List.of(
+                stepGenerator(ExportSpaceToFiles.class, JOB_ID1, SOURCE_ID1),
+                connectStepExecutions(List.of(
+                        stepGenerator(ExportSpaceToFiles.class, JOB_ID1, SOURCE_ID1),
+                        stepGenerator(ExportSpaceToFiles.class, JOB_ID1, SOURCE_ID1)
+                ),true),
+                stepGenerator(ExportSpaceToFiles.class, JOB_ID1, SOURCE_ID1)
+        ),false);
+        graph1 = (CompilationStepGraph) graph1.enrich(JOB_ID1);
+
+        CompilationStepGraph graph2 = connectStepExecutions(List.of(
+                stepGenerator(ExportSpaceToFiles.class, JOB_ID2, SOURCE_ID1),
+                connectStepExecutions(List.of(
+                        stepGenerator(ExportSpaceToFiles.class, JOB_ID2, SOURCE_ID1),
+                        stepGenerator(ExportSpaceToFiles.class, JOB_ID2, SOURCE_ID2) //not reusable
+                ),true),
+                stepGenerator(ExportSpaceToFiles.class, JOB_ID2, SOURCE_ID1)
+        ),false);
+        graph2 = (CompilationStepGraph) graph2.enrich(JOB_ID2);
+
+
+        StepGraph connectedEquivalentSubGraph = graph2.findConnectedEquivalentSubGraph(graph1);
+        //3 Steps can be potentially reused
+        Assertions.assertEquals(3, com.here.xyz.jobs.steps.execution.JobExecutor.getAllLeafExecutionNodes(connectedEquivalentSubGraph).size());
+
+        com.here.xyz.jobs.steps.execution.JobExecutor.shrinkGraphByReusingOtherGraph(
+                new Job().withId(JOB_ID1).withSteps(graph2),
+                connectedEquivalentSubGraph
+        ).onSuccess(graph ->
+                {
+
+                    Step execution1 = (Step)graph.getExecutions().get(0);
+                    Assertions.assertInstanceOf(DelegateOutputsPseudoStep.class, execution1);
+
+                    StepGraph execution2Graph = (StepGraph)graph.getExecutions().get(1);
+                    Assertions.assertTrue(execution2Graph.isParallel());
+                    Assertions.assertInstanceOf(DelegateOutputsPseudoStep.class, execution2Graph.getExecutions().get(0));
+                    Assertions.assertInstanceOf(ExportSpaceToFiles.class, execution2Graph.getExecutions().get(1));
+
+                    Step execution3 = (Step)graph.getExecutions().get(2);
+                    Assertions.assertInstanceOf(DelegateOutputsPseudoStep.class, execution3);
+
+                    //Check if previousStepId is set correct
+                    //TODO: verify if empty previousStepIds are ok for DelegateOutputsPseudoStep
+                    Assertions.assertTrue(((Step)execution2Graph.getExecutions().get(0)).getPreviousStepIds().isEmpty());
+                    Assertions.assertEquals(Set.of(execution1.getId()), ((Step)execution2Graph.getExecutions().get(1)).getPreviousStepIds());
+                }
+        );
+    }
+
+    public static CompilationStepGraph connectStepExecutions(List<StepExecution> stepExecutions, boolean isParallel) {
+        CompilationStepGraph compilationStepGraph = new CompilationStepGraph();
+
+        stepExecutions.forEach(stepExecution -> {
+            compilationStepGraph.addExecution(stepExecution);
+        });
+
+        compilationStepGraph.setParallel(isParallel);
+
+        return compilationStepGraph;
+    }
+
+    public StepExecution stepGenerator(Class stepType, String jobId, String sourceId) {
+        return stepGenerator(stepType, jobId, sourceId, null);
+    }
+
+    public StepExecution stepGenerator(Class stepType, String jobId, String sourceId, Set<String> inputStepIds){
+
+        return switch (stepType.getSimpleName()) {
+            case "ExportSpaceToFiles" -> new ExportSpaceToFiles()
+                    .withSpaceId(sourceId)
+                    .withJobId(jobId)
+                    .withUseSystemOutput(true);
+
+            case "ImportFilesToSpace" -> {
+                ImportFilesToSpace importFilesToSpace = new ImportFilesToSpace()
+                        .withFormat(GEOJSON)
+                        .withSpaceId(sourceId)
+                        .withJobId(jobId);
+                if(inputStepIds != null) {
+                    importFilesToSpace.setInputStepIds(inputStepIds);
+                    importFilesToSpace.setUseSystemInput(true);
+                }
+                yield importFilesToSpace;
+            }
+            default -> throw new IllegalStateException("Unexpected value: " + stepType);
+        };
+    }
+}

--- a/xyz-jobs/xyz-job-service/src/test/java/com/here/xyz/jobs/com/here/xyz/jobs/steps/execution/JobExecutor.java
+++ b/xyz-jobs/xyz-job-service/src/test/java/com/here/xyz/jobs/com/here/xyz/jobs/steps/execution/JobExecutor.java
@@ -123,7 +123,7 @@ public class JobExecutor {
                     Assertions.assertEquals(new HashSet<>(List.of(execution1.getId()))
                             , execution2.getPreviousStepIds());
                     //Check if inputStepIds are set correct (+ linked to reused job)
-                    Assertions.assertEquals(new HashSet<>(List.of(JOB_ID1 +":"+ exportStep.getId()))
+                    Assertions.assertEquals(new HashSet<>(List.of(JOB_ID1 +"."+ exportStep.getId()))
                             , execution2.getInputStepIds());
                 }
         );

--- a/xyz-jobs/xyz-job-service/src/test/java/com/here/xyz/jobs/steps/compiler/ExportToFilesTest.java
+++ b/xyz-jobs/xyz-job-service/src/test/java/com/here/xyz/jobs/steps/compiler/ExportToFilesTest.java
@@ -13,6 +13,7 @@ import com.here.xyz.jobs.steps.impl.transport.ExportSpaceToFiles;
 import com.here.xyz.models.hub.Ref;
 import com.here.xyz.models.hub.Space;
 import com.here.xyz.models.hub.Tag;
+import com.here.xyz.util.service.BaseHttpServerVerticle;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -32,14 +33,14 @@ public class ExportToFilesTest extends JobTest {
     }
 
     @Test
-    public void testResolveHeadVersion(){
+    public void testResolveHeadVersion() throws BaseHttpServerVerticle.ValidationException {
         CompilationStepGraph graph = new ExportToFiles().compile(buildExportJobWithVersionRef(new Ref("HEAD")));
         final ExportSpaceToFiles exportSpaceToFilesStep = getAndPrepareStep(graph);
         //HEAD should point to version 3
         Assertions.assertEquals(3, exportSpaceToFilesStep.getVersionRef().getVersion());
     }
 
-    private static ExportSpaceToFiles getAndPrepareStep(CompilationStepGraph graph) {
+    private static ExportSpaceToFiles getAndPrepareStep(CompilationStepGraph graph) throws BaseHttpServerVerticle.ValidationException {
         final ExportSpaceToFiles exportSpaceToFilesStep = (ExportSpaceToFiles) graph.getExecutions().get(0);
         exportSpaceToFilesStep.prepare(null, null);
         return exportSpaceToFilesStep;
@@ -53,7 +54,7 @@ public class ExportToFilesTest extends JobTest {
     }
 
     @Test
-    public void testResolveExistingTag(){
+    public void testResolveExistingTag() throws BaseHttpServerVerticle.ValidationException {
         String tagName = "TAG1";
         int tagVersion = 2;
 

--- a/xyz-jobs/xyz-job-service/src/test/java/com/here/xyz/jobs/steps/compiler/ExportToFilesTest.java
+++ b/xyz-jobs/xyz-job-service/src/test/java/com/here/xyz/jobs/steps/compiler/ExportToFilesTest.java
@@ -50,7 +50,7 @@ public class ExportToFilesTest extends JobTest {
     public void testResolveNotExistingTag(){
         CompilationStepGraph graph = new ExportToFiles().compile(buildExportJobWithVersionRef(new Ref("NA")));
         //NA not exists - should fail
-        Assertions.assertThrows(IllegalArgumentException.class, () -> getAndPrepareStep(graph));
+        Assertions.assertThrows(BaseHttpServerVerticle.ValidationException.class, () -> getAndPrepareStep(graph));
     }
 
     @Test

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/RuntimeInfo.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/RuntimeInfo.java
@@ -219,7 +219,7 @@ public class RuntimeInfo<T extends RuntimeInfo> implements XyzSerializable {
         NONE, new State[]{null}, //Allows all transitions at initialization. Needed to allow proper deserialization into the POJO.
         NOT_READY, new State[]{SUBMITTED, FAILED},
         SUBMITTED, new State[]{PENDING, CANCELLING, FAILED},
-        PENDING, new State[]{RUNNING, CANCELLING, FAILED},
+        PENDING, new State[]{RUNNING, CANCELLING, SUCCEEDED, FAILED},
         RESUMING, new State[]{PENDING, CANCELLING, FAILED},
         RUNNING, new State[]{SUCCEEDED, CANCELLING, FAILED},
         CANCELLING, new State[]{CANCELLED, FAILED},

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/datasets/filters/SpatialFilter.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/datasets/filters/SpatialFilter.java
@@ -113,4 +113,18 @@ public class SpatialFilter {
       throw new BaseHttpServerVerticle.ValidationException(e.getMessage());
     }
   }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true; // Check for reference equality
+    }
+    if (obj == null || getClass() != obj.getClass()) {
+      return false; // Check for null and type compatibility
+    }
+    SpatialFilter other = (SpatialFilter) obj;
+    return radius == other.radius &&
+            clip == other.clip &&
+            (geometry == null ? other.geometry == null : geometry.getJTSGeometry().equals(other.geometry.getJTSGeometry())); // Compare fields
+  }
 }

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/Step.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/Step.java
@@ -337,6 +337,12 @@ public abstract class Step<T extends Step> implements Typed, StepExecution {
     S3Client.getInstance().deleteFolder(stepS3Prefix());
   }
 
+  /**
+   * Will be called right after the job compilation, but juts before the step validation call.
+   *
+   * @param owner
+   * @param ownerAuth
+   */
   public void prepare(String owner, JobClientInfo ownerAuth) {
     //Nothing to do by default. May be overridden.
   }

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/Step.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/Step.java
@@ -346,6 +346,23 @@ public abstract class Step<T extends Step> implements Typed, StepExecution {
    */
   public abstract boolean validate() throws ValidationException;
 
+  /**
+   * Should be overridden in subclasses to enable the possibility to check whether two steps of two different StepGraphs
+   * are equivalent in their actions and their outcome.
+   * That means that the other step would produce exactly the same outputs
+   * for the provided inputs and step-parameters / step-fields (step-settings).
+   *
+   * Not overriding this method for a step, means that this step will never be found to be equivalent to some other provided step.
+   * That could be the case if a step implementation cannot guarantee to provide the same outputs again by any condition.
+   *
+   * @param other The step of a different StepGraph
+   * @return `true` only if this step and the provided ones produce the same outputs for the same inputs & settings
+   */
+  @Override
+  public boolean isEquivalentTo(StepExecution other) {
+    return false;
+  }
+
   public String getId() {
     return id;
   }

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/Step.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/Step.java
@@ -207,9 +207,9 @@ public abstract class Step<T extends Step> implements Typed, StepExecution {
               //Inject jobId for reusability
               String jId = jobId;
               String sId = stepId;
-              if(stepId.indexOf(":") != -1){
-                jId = stepId.substring(0, stepId.indexOf(":"));
-                sId = stepId.substring(stepId.indexOf(":") + 1);
+              if(stepId.indexOf(".") != -1){
+                jId = stepId.substring(0, stepId.indexOf("."));
+                sId = stepId.substring(stepId.indexOf(".") + 1);
               }
               return Output.stepOutputS3Prefix(jId, sId, userOutput, false);
             })
@@ -499,7 +499,7 @@ public abstract class Step<T extends Step> implements Typed, StepExecution {
 
   public void setInputStepIds(Set<String> inputStepIds) {
     this.inputStepIds = inputStepIds.stream()
-            .map(stepId -> stepId.contains(":") ? stepId : jobId + ":" + stepId)
+            .map(stepId -> stepId.contains(".") ? stepId : jobId + "." + stepId)
             .collect(Collectors.toSet());
   }
 

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/Step.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/Step.java
@@ -343,7 +343,7 @@ public abstract class Step<T extends Step> implements Typed, StepExecution {
    * @param owner
    * @param ownerAuth
    */
-  public void prepare(String owner, JobClientInfo ownerAuth) {
+  public void prepare(String owner, JobClientInfo ownerAuth) throws ValidationException {
     //Nothing to do by default. May be overridden.
   }
 

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/StepExecution.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/StepExecution.java
@@ -28,7 +28,5 @@ import com.here.xyz.Typed;
 })
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface StepExecution extends Typed {
-  default boolean isEquivalentTo(StepExecution other) {
-    return true;
-  }
+  boolean isEquivalentTo(StepExecution other);
 }

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/StepExecution.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/StepExecution.java
@@ -27,4 +27,8 @@ import com.here.xyz.Typed;
     @JsonSubTypes.Type(value = Step.class)
 })
 @JsonIgnoreProperties(ignoreUnknown = true)
-public interface StepExecution extends Typed {}
+public interface StepExecution extends Typed {
+  default boolean isEquivalentTo(StepExecution other) {
+    return true;
+  }
+}

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/execution/DelegateOutputsPseudoStep.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/execution/DelegateOutputsPseudoStep.java
@@ -1,12 +1,22 @@
 package com.here.xyz.jobs.steps.execution;
 
+import com.amazonaws.services.s3.model.AmazonS3Exception;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonView;
+import com.here.xyz.XyzSerializable;
 import com.here.xyz.jobs.RuntimeInfo;
 import com.here.xyz.jobs.steps.Step;
 import com.here.xyz.jobs.steps.resources.Load;
+import com.here.xyz.jobs.util.S3Client;
 import com.here.xyz.util.service.BaseHttpServerVerticle;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
+import java.io.IOException;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+
 /**
  * NOTE: This step implementation is a placeholder step, that will be used by the JobExecutor to inject outputs of a formerly run
  * job into the StepGraph of this job.
@@ -17,16 +27,23 @@ import java.util.List;
  */
 
 public class DelegateOutputsPseudoStep extends Step<DelegateOutputsPseudoStep> {
+    private static final Logger logger = LogManager.getLogger();
+
     @JsonView({Internal.class, Static.class})
     private String delegateJobId; //The old job ID
     @JsonView({Internal.class, Static.class})
     private String delegateStepId; //The old step ID
+    @JsonView({Internal.class, Static.class})
+    private String targetJobId; //The current job ID
 
     DelegateOutputsPseudoStep(){}
 
-    DelegateOutputsPseudoStep(String delegateJobId, String delegateStepId) {
+    DelegateOutputsPseudoStep(String delegateJobId, String delegateStepId, String targetJobId) {
         this.delegateJobId = delegateJobId;
         this.delegateStepId = delegateStepId;
+        this.targetJobId = targetJobId;
+
+        addJobReferenceToDelegatedJob(delegateJobId, targetJobId);
     }
 
     @Override
@@ -80,5 +97,50 @@ public class DelegateOutputsPseudoStep extends Step<DelegateOutputsPseudoStep> {
     @Override
     public boolean validate() throws BaseHttpServerVerticle.ValidationException {
         return true;
+    }
+
+    public static String referenceMetaS3Key(String jobId) {
+        return jobId + "/meta/referencing_jobs.json";
+    }
+
+    public static void saveReferenceMetadata(String jobId, ReferenceMetadata metadata) throws IOException {
+        if (metadata != null) {
+            S3Client.getInstance().putObject(referenceMetaS3Key(jobId), "application/json", metadata.serialize());
+        }
+    }
+
+    public static ReferenceMetadata loadReferenceMetadata(String delegateJobId) throws IOException {
+        try {
+            return XyzSerializable.deserialize(S3Client.getInstance().loadObjectContent(referenceMetaS3Key(delegateJobId)),
+                    ReferenceMetadata.class);
+        } catch (AmazonS3Exception e) {
+            if (e.getStatusCode() == 404) {
+                return ReferenceMetadata.empty();
+            }
+            throw e;
+        }
+    }
+
+    private static void addJobReferenceToDelegatedJob(String delegateJobId, String jobIdToReference) {
+        try {
+            ReferenceMetadata metadata = loadReferenceMetadata(delegateJobId);
+
+            if(metadata == null)
+                metadata = new ReferenceMetadata(Set.of(jobIdToReference));
+            else
+                metadata.referencingJobs().add(jobIdToReference);
+
+            saveReferenceMetadata(delegateJobId, metadata);
+        } catch (IOException e) {
+            logger.error("Error handling ReferenceMetadata for job {}.", delegateJobId, e);
+            throw new RuntimeException("Not able to add reference to delegate job!");
+        }
+    }
+
+    public record ReferenceMetadata(@JsonProperty Set<String> referencingJobs) implements XyzSerializable {
+        // Static factory method for an "empty constructor"
+        public static ReferenceMetadata empty() {
+            return new ReferenceMetadata(new HashSet<>());
+        }
     }
 }

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/execution/DelegateOutputsPseudoStep.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/execution/DelegateOutputsPseudoStep.java
@@ -1,0 +1,84 @@
+package com.here.xyz.jobs.steps.execution;
+
+import com.fasterxml.jackson.annotation.JsonView;
+import com.here.xyz.jobs.RuntimeInfo;
+import com.here.xyz.jobs.steps.Step;
+import com.here.xyz.jobs.steps.resources.Load;
+import com.here.xyz.util.service.BaseHttpServerVerticle;
+
+import java.util.List;
+/**
+ * NOTE: This step implementation is a placeholder step, that will be used by the JobExecutor to inject outputs of a formerly run
+ * job into the StepGraph of this job.
+ * This step depicts a step of the formerly run job that was found to be a predecessor of the step at the border of the re-usable subgraph
+ * of the formerly run StepGraph that was cut out because it matched a part of the new job's StepGraph.
+ * This pseudo step creates a link to the new Job's StepGraph and the old step's outputs.
+ * That way the succeeding Step(s) of the new StepGraph can access the outputs that have been produced by the old step.
+ */
+
+public class DelegateOutputsPseudoStep extends Step<DelegateOutputsPseudoStep> {
+    @JsonView({Internal.class, Static.class})
+    private String delegateJobId; //The old job ID
+    @JsonView({Internal.class, Static.class})
+    private String delegateStepId; //The old step ID
+
+    DelegateOutputsPseudoStep(){}
+
+    DelegateOutputsPseudoStep(String delegateJobId, String delegateStepId) {
+        this.delegateJobId = delegateJobId;
+        this.delegateStepId = delegateStepId;
+    }
+
+    @Override
+    public String getJobId(){
+        return delegateJobId;
+    }
+
+    @Override
+    public String getId(){
+        return delegateStepId;
+    }
+
+    @Override
+    public RuntimeInfo getStatus(){
+        return new RuntimeInfo().withState(RuntimeInfo.State.SUCCEEDED);
+    }
+
+    @Override
+    public List<Load> getNeededResources() {
+        return List.of();
+    }
+
+    @Override
+    public int getTimeoutSeconds() {
+        return 0;
+    }
+
+    @Override
+    public int getEstimatedExecutionSeconds() {
+        return 0;
+    }
+
+    @Override
+    public String getDescription() {
+        return "A pseudo step that just delegates outputs of a Step of another StepGraph into this StepGraph";
+    }
+
+    @Override
+    public void execute() throws Exception {
+        throw new IllegalAccessException("This method should never be called");
+    }
+
+    @Override
+    public void resume() throws Exception {
+        execute();
+    }
+
+    @Override
+    public void cancel() throws Exception {}
+
+    @Override
+    public boolean validate() throws BaseHttpServerVerticle.ValidationException {
+        return true;
+    }
+}

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/execution/LambdaBasedStep.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/execution/LambdaBasedStep.java
@@ -176,6 +176,7 @@ public abstract class LambdaBasedStep<T extends LambdaBasedStep> extends Step<T>
       return;
 
     try {
+      logger.info("[{}] unregister StateCheckTrigger {}", getStateCheckRuleName(), getGlobalStepId());
       //List all targets
       List<String> targetIds = cloudwatchEventsClient().listTargetsByRule(
               ListTargetsByRuleRequest.builder().rule(getStateCheckRuleName()).build())
@@ -191,6 +192,7 @@ public abstract class LambdaBasedStep<T extends LambdaBasedStep> extends Step<T>
       cloudwatchEventsClient().deleteRule(DeleteRuleRequest.builder().name(getStateCheckRuleName()).build());
     }
     catch (ResourceNotFoundException e) {
+      logger.error("[{}] unregister StateCheckTrigger failed! {}", getStateCheckRuleName(), getGlobalStepId(), e);
       //Ignore the exception, as the rule is not existing (yet)
     }
   }

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/SpaceBasedStep.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/SpaceBasedStep.java
@@ -30,11 +30,11 @@ import com.here.xyz.events.ContextAwareEvent.SpaceContext;
 import com.here.xyz.jobs.steps.Config;
 import com.here.xyz.jobs.steps.execution.db.Database;
 import com.here.xyz.jobs.steps.execution.db.DatabaseBasedStep;
+import com.here.xyz.jobs.steps.impl.transport.CopySpace;
+import com.here.xyz.jobs.steps.impl.transport.CopySpacePost;
+import com.here.xyz.jobs.steps.impl.transport.CopySpacePre;
 import com.here.xyz.jobs.steps.impl.transport.ExportSpaceToFiles;
 import com.here.xyz.jobs.steps.impl.transport.ImportFilesToSpace;
-import com.here.xyz.jobs.steps.impl.transport.CopySpace;
-import com.here.xyz.jobs.steps.impl.transport.CopySpacePre;
-import com.here.xyz.jobs.steps.impl.transport.CopySpacePost;
 import com.here.xyz.models.hub.Space;
 import com.here.xyz.models.hub.Tag;
 import com.here.xyz.responses.StatisticsResponse;
@@ -113,7 +113,7 @@ public abstract class SpaceBasedStep<T extends SpaceBasedStep> extends DatabaseB
   }
 
   protected StatisticsResponse loadSpaceStatistics(String spaceId, SpaceContext context) throws WebClientException {
-    return hubWebClient().loadSpaceStatistics(spaceId, context, true);
+    return hubWebClient().loadSpaceStatistics(spaceId, context, false);
   }
 
   protected StatisticsResponse loadSpaceStatistics(String spaceId, SpaceContext context, boolean skipCache) throws WebClientException {

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/SpaceBasedStep.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/SpaceBasedStep.java
@@ -71,6 +71,9 @@ public abstract class SpaceBasedStep<T extends SpaceBasedStep> extends DatabaseB
   @JsonIgnore
   protected Space superSpace;
 
+  @JsonIgnore
+  protected StatisticsResponse spaceStatistics;
+
   public String getSpaceId() {
     return spaceId;
   }
@@ -110,7 +113,11 @@ public abstract class SpaceBasedStep<T extends SpaceBasedStep> extends DatabaseB
   }
 
   protected StatisticsResponse loadSpaceStatistics(String spaceId, SpaceContext context) throws WebClientException {
-    return hubWebClient().loadSpaceStatistics(spaceId, context);
+    return hubWebClient().loadSpaceStatistics(spaceId, context, true);
+  }
+
+  protected StatisticsResponse loadSpaceStatistics(String spaceId, SpaceContext context, boolean skipCache) throws WebClientException {
+    return hubWebClient().loadSpaceStatistics(spaceId, context, skipCache);
   }
 
   protected Tag loadTag(String spaceId, String tagId) throws WebClientException {
@@ -135,6 +142,14 @@ public abstract class SpaceBasedStep<T extends SpaceBasedStep> extends DatabaseB
       space = loadSpace(getSpaceId());
     }
     return space;
+  }
+
+  protected StatisticsResponse spaceStatistics(SpaceContext context, boolean skipCache) throws WebClientException {
+    if (spaceStatistics == null) {
+      logger.info("[{}] Loading statistics for space {}.", getGlobalStepId(), getSpaceId());
+      spaceStatistics = loadSpaceStatistics(getSpaceId(), context, skipCache);
+    }
+    return spaceStatistics;
   }
 
   protected Space superSpace() throws WebClientException {

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/ExportSpaceToFiles.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/ExportSpaceToFiles.java
@@ -76,7 +76,7 @@ import java.util.UUID;
  */
 public class ExportSpaceToFiles extends SpaceBasedStep<ExportSpaceToFiles> {
   //Defines how many features a source layer need to have to start parallelization.
-  public static final int PARALLELIZTATION_MIN_THRESHOLD = 10;//TODO: put back to 500k
+  public static final int PARALLELIZTATION_MIN_THRESHOLD = 200_000;
   //Defines how many export threads are getting used
   public static final int PARALLELIZTATION_THREAD_COUNT = 8;
   //Defines how large the area of a defined spatialFilter can be

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/ExportSpaceToFiles.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/ExportSpaceToFiles.java
@@ -170,8 +170,8 @@ public class ExportSpaceToFiles extends SpaceBasedStep<ExportSpaceToFiles> {
     return this;
   }
 
-  @JsonView({Internal.class, Static.class})
-  private StatisticsResponse statistics = null;
+  @JsonView({Internal.class})
+  private StatisticsResponse statistics = null; //TODO: Move caching into HubWebClient
 
   @Override
   public List<Load> getNeededResources() {
@@ -201,7 +201,6 @@ public class ExportSpaceToFiles extends SpaceBasedStep<ExportSpaceToFiles> {
    *   <li>The following properties must be equal between the two instances:
    *     <ul>
    *       <li>Space ID</li>
-   *       <li>Format</li>
    *       <li>Context</li>
    *       <li>Version reference (if not null)</li>
    *       <li>Spatial filter (if not null)</li>
@@ -213,7 +212,7 @@ public class ExportSpaceToFiles extends SpaceBasedStep<ExportSpaceToFiles> {
    *
    * @param other The other {@link StepExecution} to compare against.
    * @return {@code true} if the other step execution is equivalent to this one; {@code false} otherwise.
-   * @throws RuntimeException If an exception occurs while fetching space statistics or comparing values.
+   * @throws RuntimeException If an exception occurs while comparing values.
    */
   @Override
   public boolean isEquivalentTo(StepExecution other) {

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/ExportSpaceToFiles.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/ExportSpaceToFiles.java
@@ -46,6 +46,7 @@ import com.here.xyz.jobs.steps.impl.tools.ResourceAndTimeCalculator;
 import com.here.xyz.jobs.steps.outputs.DownloadUrl;
 import com.here.xyz.jobs.steps.outputs.FeatureStatistics;
 import com.here.xyz.jobs.steps.outputs.FileStatistics;
+import com.here.xyz.jobs.steps.outputs.ResourceHint;
 import com.here.xyz.jobs.steps.resources.IOResource;
 import com.here.xyz.jobs.steps.resources.Load;
 import com.here.xyz.jobs.steps.resources.TooManyResourcesClaimed;
@@ -243,7 +244,7 @@ public class ExportSpaceToFiles extends SpaceBasedStep<ExportSpaceToFiles> {
         if(((ExportSpaceToFiles) other).getSpaceId().equals(getSpaceId())
             && currentMaxVersion == (statistics == null ? 0 : statistics.getMaxVersion().getValue())
             && ((ExportSpaceToFiles) other).format == format
-            && ((ExportSpaceToFiles) other).context == context
+            && (((ExportSpaceToFiles) other).context == context || (space().getExtension() == null && ((ExportSpaceToFiles) other).context == null && context == SUPER ))
             && (((ExportSpaceToFiles) other).versionRef == null || ((ExportSpaceToFiles) other).versionRef.equals(versionRef))
             && (((ExportSpaceToFiles) other).spatialFilter == null || ((ExportSpaceToFiles) other).spatialFilter.equals(spatialFilter))
             && (((ExportSpaceToFiles) other).propertyFilter == null || ((ExportSpaceToFiles) other).propertyFilter.equals(propertyFilter))
@@ -363,6 +364,8 @@ public class ExportSpaceToFiles extends SpaceBasedStep<ExportSpaceToFiles> {
     infoLog(STEP_ON_ASYNC_SUCCESS, this,"Job Statistics: bytes=" + statistics.getExportedBytes() + " files=" + statistics.getExportedFiles());
     if(addStatisticsToUserOutput)
       registerOutputs(List.of(statistics), true);
+
+    registerOutputs(List.of(new ResourceHint().withLayerName(getSpaceId()).withSpaceContext(context)), false);
 
     infoLog(STEP_ON_ASYNC_SUCCESS, this,"Cleanup temporary table");
     runWriteQuerySync(buildTemporaryJobTableDropStatement(getSchema(db()), getTemporaryJobTableName(getId())), db(), 0);

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/ExportSpaceToFiles.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/ExportSpaceToFiles.java
@@ -40,6 +40,7 @@ import com.here.xyz.events.ContextAwareEvent.SpaceContext;
 import com.here.xyz.events.PropertiesQuery;
 import com.here.xyz.jobs.datasets.filters.SpatialFilter;
 import com.here.xyz.jobs.steps.S3DataFile;
+import com.here.xyz.jobs.steps.StepExecution;
 import com.here.xyz.jobs.steps.impl.SpaceBasedStep;
 import com.here.xyz.jobs.steps.impl.tools.ResourceAndTimeCalculator;
 import com.here.xyz.jobs.steps.outputs.DownloadUrl;
@@ -203,6 +204,25 @@ public class ExportSpaceToFiles extends SpaceBasedStep<ExportSpaceToFiles> {
     }catch (Exception e){
       throw new RuntimeException(e);
     }
+  }
+
+  @Override
+  public boolean isEquivalentTo(StepExecution other) {
+    if(other instanceof ExportSpaceToFiles) {
+      try {
+        if(((ExportSpaceToFiles) other).getSpaceId().equals(getSpaceId())
+            && ((ExportSpaceToFiles) other).format == format
+            && ((ExportSpaceToFiles) other).context == context
+            && ((ExportSpaceToFiles) other).versionRef == versionRef
+            && ((ExportSpaceToFiles) other).spatialFilter == spatialFilter
+            && ((ExportSpaceToFiles) other).propertyFilter == propertyFilter
+            && ((ExportSpaceToFiles) other).isUseSystemOutput() == isUseSystemOutput())
+          return true;
+      }catch (Exception e){
+        throw new RuntimeException(e);
+      }
+    }
+    return false;
   }
 
   @Override

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/ExportSpaceToFiles.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/ExportSpaceToFiles.java
@@ -97,17 +97,6 @@ public class ExportSpaceToFiles extends SpaceBasedStep<ExportSpaceToFiles> {
 
   /**
    * TODO:
-   *   Spatial-Filters
-   *    DONE
-   *
-   *   Content-Filters
-   *    DONE private String propertyFilter;
-   *    DONE private SpaceContext context;
-   *   ? private String targetVersion;
-   *
-   *   Version Filter:
-   *    DONE private VersionRef versionRef;
-   *
    *   Partitioning - part of EMR?
    *    private String partitionKey;
    *    --Required if partitionKey=tileId
@@ -240,14 +229,19 @@ public class ExportSpaceToFiles extends SpaceBasedStep<ExportSpaceToFiles> {
          * - deal with compositeSpaces which have a readOnly Base-Layer
          * - check how to deal with TTL (keepUntil)!
          */
-        //space needs to be in readOnly mode
-        if(!space().isReadOnly())
-          return false;
 
-        long currentMaxVersion = spaceStatistics(context, true).getMaxVersion().getValue();
+        //TODO: TBD if readOnly is required beside version compare
+
+        long currentMaxVersion;
+        try{
+          currentMaxVersion = spaceStatistics(context, true).getMaxVersion().getValue();
+        }catch (IllegalArgumentException e){
+          // Happens only in JunitTest of JobExecutor
+          currentMaxVersion = 0;
+        }
 
         if(((ExportSpaceToFiles) other).getSpaceId().equals(getSpaceId())
-            && currentMaxVersion == statistics.getMaxVersion().getValue()
+            && currentMaxVersion == (statistics == null ? 0 : statistics.getMaxVersion().getValue())
             && ((ExportSpaceToFiles) other).format == format
             && ((ExportSpaceToFiles) other).context == context
             && (((ExportSpaceToFiles) other).versionRef == null || ((ExportSpaceToFiles) other).versionRef.equals(versionRef))

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/ExportSpaceToFiles.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/ExportSpaceToFiles.java
@@ -210,6 +210,11 @@ public class ExportSpaceToFiles extends SpaceBasedStep<ExportSpaceToFiles> {
   public boolean isEquivalentTo(StepExecution other) {
     if(other instanceof ExportSpaceToFiles) {
       try {
+        /**
+         * TODO:
+         * - only allow spaces which are readOnly
+         * - deal with compositeSpaces which have a readOnly Base-Layer
+         */
         if(((ExportSpaceToFiles) other).getSpaceId().equals(getSpaceId())
             && ((ExportSpaceToFiles) other).format == format
             && ((ExportSpaceToFiles) other).context == context

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/ExportSpaceToFiles.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/ExportSpaceToFiles.java
@@ -227,25 +227,8 @@ public class ExportSpaceToFiles extends SpaceBasedStep<ExportSpaceToFiles> {
   public boolean isEquivalentTo(StepExecution other) {
     if (other instanceof ExportSpaceToFiles otherExport) {
       try {
-        /**
-         * TODO:
-         * - deal with compositeSpaces which have a readOnly Base-Layer
-         */
-
-        //TODO: TBD if readOnly is required beside version compare
-
-        long currentMaxVersion;
-        try {
-          currentMaxVersion = spaceStatistics(context, true).getMaxVersion().getValue();
-        }
-        catch (IllegalArgumentException e) {
-          //Happens only in JunitTest of JobExecutor
-          currentMaxVersion = 0;
-        }
-
         if (Objects.equals(otherExport.getSpaceId(), getSpaceId())
             && Objects.equals(otherExport.versionRef, versionRef)
-            && currentMaxVersion == (statistics == null ? 0 : statistics.getMaxVersion().getValue()) //TODO: Remove that check once the versionRef gets updated in #prepare() to the resolved max version
             && otherExport.format == format
             && (otherExport.context == context || (space().getExtension() == null && otherExport.context == null && context == SUPER))
             && Objects.equals(otherExport.spatialFilter, spatialFilter)

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/ExportSpaceToFiles.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/ExportSpaceToFiles.java
@@ -371,8 +371,6 @@ public class ExportSpaceToFiles extends SpaceBasedStep<ExportSpaceToFiles> {
     if(addStatisticsToUserOutput)
       registerOutputs(List.of(statistics), true);
 
-    registerOutputs(List.of(new ResourceHint().withLayerName(getSpaceId()).withSpaceContext(context)), false);
-
     infoLog(STEP_ON_ASYNC_SUCCESS, this,"Cleanup temporary table");
     runWriteQuerySync(buildTemporaryJobTableDropStatement(getSchema(db()), getTemporaryJobTableName(getId())), db(), 0);
   }

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/ExportSpaceToFiles.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/ExportSpaceToFiles.java
@@ -283,6 +283,9 @@ public class ExportSpaceToFiles extends SpaceBasedStep<ExportSpaceToFiles> {
   public boolean validate() throws ValidationException {
     super.validate();
 
+    if(versionRef == null)
+      throw new ValidationException("Version ref is required.");
+
     if (versionRef.isAllVersions())
       throw new ValidationException("It is not supported to export all versions at once.");
 

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/ExportSpaceToFiles.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/ExportSpaceToFiles.java
@@ -87,8 +87,6 @@ public class ExportSpaceToFiles extends SpaceBasedStep<ExportSpaceToFiles> {
   @JsonView({Internal.class, Static.class})
   private boolean addStatisticsToUserOutput = true;
 
-  private Format format = Format.GEOJSON;
-
   @JsonView({Internal.class, Static.class})
   private SpatialFilter spatialFilter;
   @JsonView({Internal.class, Static.class})
@@ -106,12 +104,6 @@ public class ExportSpaceToFiles extends SpaceBasedStep<ExportSpaceToFiles> {
    *      private Integer targetLevel;
    *      private boolean clipOnPartitions;
    */
-
-  public enum Format {
-    CSV_JSON_WKB,
-    CSV_PARTITIONED_JSON_WKB,
-    GEOJSON;
-  }
 
   public SpatialFilter getSpatialFilter() {
     return spatialFilter;
@@ -229,7 +221,6 @@ public class ExportSpaceToFiles extends SpaceBasedStep<ExportSpaceToFiles> {
       try {
         if (Objects.equals(otherExport.getSpaceId(), getSpaceId())
             && Objects.equals(otherExport.versionRef, versionRef)
-            && otherExport.format == format
             && (otherExport.context == context || (space().getExtension() == null && otherExport.context == null && context == SUPER))
             && Objects.equals(otherExport.spatialFilter, spatialFilter)
             && Objects.equals(otherExport.propertyFilter, propertyFilter)
@@ -419,7 +410,8 @@ public class ExportSpaceToFiles extends SpaceBasedStep<ExportSpaceToFiles> {
     List<S3DataFile> urlList = new ArrayList<>();
 
     for (int i = 1; i <= calculatedThreadCount; i++) {
-      urlList.add(new DownloadUrl().withS3Key(outputS3Prefix(!isUseSystemOutput(),false) + "/" + i + "/" + UUID.randomUUID()));
+      urlList.add(new DownloadUrl().withS3Key(outputS3Prefix(!isUseSystemOutput(),false) + "/"
+              + i + "/" + UUID.randomUUID() + ".json"));
     }
 
     return urlList;
@@ -480,7 +472,7 @@ public class ExportSpaceToFiles extends SpaceBasedStep<ExportSpaceToFiles> {
                     "CALL execute_transfer(#{format}, '${{successQuery}}', '${{failureQuery}}', #{contentQuery});")
                     .withContext(getQueryContext())
                     .withAsyncProcedure(true)
-                    .withNamedParameter("format", format.toString())
+                    .withNamedParameter("format", "GEOJSON")
                     .withQueryFragment("successQuery", successQuery.substitute().text().replaceAll("'", "''"))
                     .withQueryFragment("failureQuery", failureQuery.substitute().text().replaceAll("'", "''"))
                     .withNamedParameter("contentQuery", exportSelectString);

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/ExportSpaceToFiles.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/ExportSpaceToFiles.java
@@ -213,9 +213,9 @@ public class ExportSpaceToFiles extends SpaceBasedStep<ExportSpaceToFiles> {
         if(((ExportSpaceToFiles) other).getSpaceId().equals(getSpaceId())
             && ((ExportSpaceToFiles) other).format == format
             && ((ExportSpaceToFiles) other).context == context
-            && ((ExportSpaceToFiles) other).versionRef == versionRef
-            && ((ExportSpaceToFiles) other).spatialFilter == spatialFilter
-            && ((ExportSpaceToFiles) other).propertyFilter == propertyFilter
+            && (((ExportSpaceToFiles) other).versionRef == null || ((ExportSpaceToFiles) other).versionRef.equals(versionRef))
+            && (((ExportSpaceToFiles) other).spatialFilter == null || ((ExportSpaceToFiles) other).spatialFilter.equals(spatialFilter))
+            && (((ExportSpaceToFiles) other).propertyFilter == null || ((ExportSpaceToFiles) other).propertyFilter.equals(propertyFilter))
             && ((ExportSpaceToFiles) other).isUseSystemOutput() == isUseSystemOutput())
           return true;
       }catch (Exception e){

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/ImportFilesToSpace.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/ImportFilesToSpace.java
@@ -178,7 +178,7 @@ public class ImportFilesToSpace extends SpaceBasedStep<ImportFilesToSpace> {
     if (targetTableFeatureCount == -1 && getSpaceId() != null) {
       StatisticsResponse statistics;
       try {
-        statistics = loadSpaceStatistics(getSpaceId(), EXTENSION);
+        statistics = loadSpaceStatistics(getSpaceId(), EXTENSION, true);
         targetTableFeatureCount = statistics.getCount().getValue();
       }
       catch (WebClientException e) {

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/outputs/ResourceHint.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/outputs/ResourceHint.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2017-2024 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.xyz.jobs.steps.outputs;
+
+import com.here.xyz.events.ContextAwareEvent.SpaceContext;
+
+public class ResourceHint extends ModelBasedOutput {
+    private String layerName;
+    private SpaceContext spaceContext;
+    private boolean isExtensionOutput;
+
+    public String getLayerName() {
+        return layerName;
+    }
+
+    public void setLayerName(String layerName) {
+        this.layerName = layerName;
+    }
+
+    public ResourceHint withLayerName(String layerName) {
+        setLayerName(layerName);
+        return this;
+    }
+
+    public void setSpaceContext(SpaceContext spaceContext) {
+        this.spaceContext = spaceContext;
+    }
+
+    public SpaceContext getSpaceContext() {
+        return spaceContext;
+    }
+
+    public ResourceHint withSpaceContext(SpaceContext spaceContext) {
+        setSpaceContext(spaceContext);
+        return this;
+    }
+}

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/util/test/StepTestBase.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/util/test/StepTestBase.java
@@ -163,6 +163,14 @@ public class StepTestBase {
     return null;
   }
 
+  protected void patchSpace(String spaceId, Map<String,Object> spaceUpdates) {
+    try {
+      hubWebClient.patchSpace(spaceId, spaceUpdates);
+    } catch (XyzWebClient.WebClientException e) {
+      System.out.println("Hub Error: " + e.getMessage());
+    }
+  }
+
   protected void createTag(String spaceId, Tag tag) {
     try {
       hubWebClient.postTag(spaceId, tag);

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/util/test/StepTestBase.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/util/test/StepTestBase.java
@@ -181,7 +181,7 @@ public class StepTestBase {
 
   protected StatisticsResponse getStatistics(String spaceId) {
     try {
-      return hubWebClient.loadSpaceStatistics(spaceId, SpaceContext.EXTENSION);
+      return hubWebClient.loadSpaceStatistics(spaceId, SpaceContext.EXTENSION, true);
     } catch (XyzWebClient.WebClientException e) {
       System.out.println("Hub Error: " + e.getMessage());
     }

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/util/test/StepTestBase.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/util/test/StepTestBase.java
@@ -82,7 +82,7 @@ import software.amazon.awssdk.services.lambda.model.InvokeRequest;
 public class StepTestBase {
   private static final Logger logger = LogManager.getLogger();
   protected String SPACE_ID =  getClass().getSimpleName() + "_" + randomAlpha(5);
-  protected String JOB_ID =  getClass().getSimpleName() + "_" + randomAlpha(5);
+  protected String JOB_ID =  generateJobId();
 
   protected static final String LAMBDA_ARN = "arn:aws:lambda:us-east-1:000000000000:function:job-step";
   private static final HubWebClient hubWebClient;
@@ -114,6 +114,10 @@ public class StepTestBase {
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
+  }
+
+  public String generateJobId(){
+    return getClass().getSimpleName() + "_" + randomAlpha(5);
   }
 
   public enum S3ContentType {

--- a/xyz-jobs/xyz-job-steps/src/main/resources/jobs/transport.sql
+++ b/xyz-jobs/xyz-job-steps/src/main/resources/jobs/transport.sql
@@ -189,7 +189,7 @@ BEGIN
                     work_item ->> 's3_path',
                     work_item ->> 's3_region',
                     format,
-                    (work_item -> 'filesize')::BIGINT);
+                    CASE WHEN (work_item -> 'filesize') = 'null'::jsonb THEN 0 ELSE (work_item -> 'filesize')::BIGINT END);
     ELSE
         PERFORM export_to_s3_perform(content_query, (work_item ->> 's3_bucket'), (work_item ->> 's3_path'), (work_item ->> 's3_region'));
     END IF;

--- a/xyz-jobs/xyz-job-steps/src/test/java/com/here/xyz/jobs/steps/impl/export/ExportStepValidationTest.java
+++ b/xyz-jobs/xyz-job-steps/src/test/java/com/here/xyz/jobs/steps/impl/export/ExportStepValidationTest.java
@@ -60,6 +60,7 @@ public class ExportStepValidationTest extends StepTest {
                 .withClip(true);
 
         LambdaBasedStep step = new ExportSpaceToFiles()
+                .withVersionRef(new Ref(5))
                 .withSpatialFilter(spatialFilter)
                 .withSpaceId(SPACE_ID)
                 .withJobId(JOB_ID);

--- a/xyz-models/src/main/java/com/here/xyz/events/PropertyQuery.java
+++ b/xyz-models/src/main/java/com/here/xyz/events/PropertyQuery.java
@@ -21,6 +21,8 @@ package com.here.xyz.events;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.here.xyz.XyzSerializable;
+
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.List;
@@ -29,7 +31,7 @@ import java.util.stream.Collectors;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeName(value = "PropertyQuery")
-public class PropertyQuery {
+public class PropertyQuery implements XyzSerializable {
 
   private String key;
   private QueryOperation operation;
@@ -173,7 +175,20 @@ public class PropertyQuery {
           if (!thisValue.equals(new BigDecimal((Long) otherValue))) {
             return false;
           }
-        } else if (!thisValue.equals(otherValue)) {
+        }
+        // Convert Integer to Long and BigDecimal
+        else if (thisValue instanceof Integer && otherValue instanceof BigDecimal) {
+          if (!new BigDecimal((Integer) thisValue).equals(otherValue)) {
+            return false;
+          }
+        }
+        // Convert BigDecimal to Integer and compare
+        else if (thisValue instanceof BigDecimal && otherValue instanceof Integer) {
+          if (!thisValue.equals(new BigDecimal((Integer) otherValue))) {
+            return false;
+          }
+        }
+        else if (!thisValue.equals(otherValue)) {
           return false; // If the values are not equal, return false
         }
       }

--- a/xyz-models/src/main/java/com/here/xyz/events/PropertyQuery.java
+++ b/xyz-models/src/main/java/com/here/xyz/events/PropertyQuery.java
@@ -21,6 +21,7 @@ package com.here.xyz.events;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
@@ -119,5 +120,67 @@ public class PropertyQuery {
     public static Set<String> inputRepresentations() {
       return Arrays.stream(values()).flatMap(operator -> operator.inputRepresentations.stream()).collect(Collectors.toSet());
     }
+
+  }
+
+  @Override
+  public int hashCode() {
+    int result = key != null ? key.hashCode() : 0;
+    result = 31 * result + (operation != null ? operation.hashCode() : 0);
+    result = 31 * result + (values != null ? values.hashCode() : 0);
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null || getClass() != obj.getClass()) {
+      return false;
+    }
+
+    PropertyQuery other = (PropertyQuery) obj;
+
+    // Compare key
+    if (this.key != null ? !this.key.equals(other.key) : other.key != null) {
+      return false;
+    }
+
+    // Compare operation
+    if (this.operation != other.operation) {
+      return false;
+    }
+
+    // Compare values
+    if (this.values != null && other.values != null) {
+      if (this.values.size() != other.values.size()) {
+        return false; // If the sizes are different, return false
+      }
+
+      for (int i = 0; i < this.values.size(); i++) {
+        Object thisValue = this.values.get(i);
+        Object otherValue = other.values.get(i);
+
+        // Convert Long to BigDecimal and compare
+        if (thisValue instanceof Long && otherValue instanceof BigDecimal) {
+          if (!new BigDecimal((Long) thisValue).equals(otherValue)) {
+            return false;
+          }
+        }
+        // Convert BigDecimal to Long and compare
+        else if (thisValue instanceof BigDecimal && otherValue instanceof Long) {
+          if (!thisValue.equals(new BigDecimal((Long) otherValue))) {
+            return false;
+          }
+        } else if (!thisValue.equals(otherValue)) {
+          return false; // If the values are not equal, return false
+        }
+      }
+    } else if (this.values != null || other.values != null) {
+      return false; // One is null and the other is not
+    }
+
+    return true;
   }
 }

--- a/xyz-models/src/main/java/com/here/xyz/events/SearchForFeaturesEvent.java
+++ b/xyz-models/src/main/java/com/here/xyz/events/SearchForFeaturesEvent.java
@@ -19,6 +19,7 @@
 
 package com.here.xyz.events;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
@@ -29,6 +30,7 @@ public class SearchForFeaturesEvent<T extends SearchForFeaturesEvent> extends Se
   private static final long MAX_LIMIT = 100_000L;
 
   private long limit = DEFAULT_LIMIT;
+  @JsonIgnore
   public boolean ignoreLimit = false;
 
   public long getLimit() {

--- a/xyz-models/src/main/java/com/here/xyz/events/SearchForFeaturesEvent.java
+++ b/xyz-models/src/main/java/com/here/xyz/events/SearchForFeaturesEvent.java
@@ -29,6 +29,7 @@ public class SearchForFeaturesEvent<T extends SearchForFeaturesEvent> extends Se
   private static final long MAX_LIMIT = 100_000L;
 
   private long limit = DEFAULT_LIMIT;
+  public boolean ignoreMaxLimit = false;
 
   public long getLimit() {
     return limit;
@@ -36,7 +37,7 @@ public class SearchForFeaturesEvent<T extends SearchForFeaturesEvent> extends Se
 
   @SuppressWarnings("WeakerAccess")
   public void setLimit(long limit) {
-    this.limit = Math.max(1L, Math.min(limit, MAX_LIMIT));
+    this.limit = ignoreMaxLimit ? Long.MAX_VALUE : Math.max(1L, Math.min(limit, MAX_LIMIT));
   }
 
   @SuppressWarnings("unused")

--- a/xyz-models/src/main/java/com/here/xyz/events/SearchForFeaturesEvent.java
+++ b/xyz-models/src/main/java/com/here/xyz/events/SearchForFeaturesEvent.java
@@ -29,15 +29,15 @@ public class SearchForFeaturesEvent<T extends SearchForFeaturesEvent> extends Se
   private static final long MAX_LIMIT = 100_000L;
 
   private long limit = DEFAULT_LIMIT;
-  public boolean ignoreMaxLimit = false;
+  public boolean ignoreLimit = false;
 
   public long getLimit() {
-    return limit;
+    return ignoreLimit ? Long.MAX_VALUE : limit;
   }
 
   @SuppressWarnings("WeakerAccess")
   public void setLimit(long limit) {
-    this.limit = ignoreMaxLimit ? Long.MAX_VALUE : Math.max(1L, Math.min(limit, MAX_LIMIT));
+    this.limit = Math.max(1L, Math.min(limit, MAX_LIMIT));
   }
 
   @SuppressWarnings("unused")

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetChangesetStatistics.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetChangesetStatistics.java
@@ -64,12 +64,12 @@ public class GetChangesetStatistics extends XyzQueryRunner<GetChangesetStatistic
     if(rs.next()){
       String maxV = rs.getString("max");
       String minV = rs.getString("min");
-      long maxVersion = (maxV == null ? -1 : Long.parseLong(maxV));
+      long maxVersion = (maxV == null ? 0 : Long.parseLong(maxV));
       //FIXME: Returned minVersion is not always correct for spaces with v2k=1
       long minVersion = (minV == null ? 0 : Long.parseLong(minV));
 
       csr.setMaxVersion(maxVersion);
-      csr.setMinVersion(maxVersion == -1 ? -1 : minVersion);
+      csr.setMinVersion(maxVersion == 0 ? 0 : minVersion);
       csr.setTagMinVersion(minTagVersion);
     }
     return csr;

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeaturesByGeometryBuilder.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeaturesByGeometryBuilder.java
@@ -51,6 +51,8 @@ public class GetFeaturesByGeometryBuilder extends XyzQueryBuilder<GetFeaturesByG
           .withRadius(input.radius)
           .withClip(input.clip);
 
+      event.ignoreMaxLimit = true;
+
       return new GetFeaturesByGeometryWithModifiedFilter(event)
           .<GetFeaturesByGeometry>withDataSourceProvider(getDataSourceProvider())
           .buildQuery(event);

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeaturesByGeometryBuilder.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeaturesByGeometryBuilder.java
@@ -51,7 +51,7 @@ public class GetFeaturesByGeometryBuilder extends XyzQueryBuilder<GetFeaturesByG
           .withRadius(input.radius)
           .withClip(input.clip);
 
-      event.ignoreMaxLimit = true;
+      event.ignoreLimit = true;
 
       return new GetFeaturesByGeometryWithModifiedFilter(event)
           .<GetFeaturesByGeometry>withDataSourceProvider(getDataSourceProvider())

--- a/xyz-util/pom.xml
+++ b/xyz-util/pom.xml
@@ -149,6 +149,10 @@
       <artifactId>gt-main</artifactId>
       <groupId>org.geotools</groupId>
     </dependency>
+    <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-epsg-hsql</artifactId>
+    </dependency>
 
     <!-- Cache -->
     <dependency>

--- a/xyz-util/src/main/java/com/here/xyz/util/web/HubWebClient.java
+++ b/xyz-util/src/main/java/com/here/xyz/util/web/HubWebClient.java
@@ -162,10 +162,11 @@ public class HubWebClient extends XyzWebClient {
             .uri(uri("/spaces/" + spaceId)));
   }
 
-  public StatisticsResponse loadSpaceStatistics(String spaceId, SpaceContext context) throws WebClientException {
+  public StatisticsResponse loadSpaceStatistics(String spaceId, SpaceContext context, boolean skipCache) throws WebClientException {
     try {
       return deserialize(request(HttpRequest.newBuilder()
-          .uri(uri("/spaces/" + spaceId + "/statistics" + (context == null ? "" : "?context=" + context)))).body(), StatisticsResponse.class);
+          .uri(uri("/spaces/" + spaceId + "/statistics?skipCache="+skipCache
+                  + (context == null ? "" : "&context=" + context)))).body(), StatisticsResponse.class);
     }
     catch (JsonProcessingException e) {
       throw new WebClientException("Error deserializing response", e);
@@ -197,7 +198,7 @@ public class HubWebClient extends XyzWebClient {
   }
 
   public StatisticsResponse loadSpaceStatistics(String spaceId) throws WebClientException {
-    return loadSpaceStatistics(spaceId, null);
+    return loadSpaceStatistics(spaceId, null, true);
   }
 
   public Connector loadConnector(String connectorId) throws WebClientException {

--- a/xyz-util/src/main/java/com/here/xyz/util/web/HubWebClient.java
+++ b/xyz-util/src/main/java/com/here/xyz/util/web/HubWebClient.java
@@ -99,6 +99,14 @@ public class HubWebClient extends XyzWebClient {
     }
   }
 
+  public String loadExtendedSpace(String spaceId) throws WebClientException {
+    Space space = loadSpace(spaceId);
+    if(space == null || space.getExtension() == null)
+      return null;
+    else
+      return space.getExtension().getSpaceId();
+  }
+
   public Space createSpace(String spaceId, String title) throws WebClientException {
     return createSpace(new Space().withId(spaceId).withTitle(title));
   }

--- a/xyz-util/src/main/java/com/here/xyz/util/web/HubWebClient.java
+++ b/xyz-util/src/main/java/com/here/xyz/util/web/HubWebClient.java
@@ -162,6 +162,10 @@ public class HubWebClient extends XyzWebClient {
             .uri(uri("/spaces/" + spaceId)));
   }
 
+  public StatisticsResponse loadSpaceStatistics(String spaceId, SpaceContext context) throws WebClientException {
+    return loadSpaceStatistics(spaceId, context, false);
+  }
+
   public StatisticsResponse loadSpaceStatistics(String spaceId, SpaceContext context, boolean skipCache) throws WebClientException {
     try {
       return deserialize(request(HttpRequest.newBuilder()

--- a/xyz-util/src/main/java/com/here/xyz/util/web/HubWebClientAsync.java
+++ b/xyz-util/src/main/java/com/here/xyz/util/web/HubWebClientAsync.java
@@ -55,12 +55,12 @@ public class HubWebClientAsync extends HubWebClient {
     });
   }
 
-  public Future<StatisticsResponse> loadSpaceStatisticsAsync(String spaceId, SpaceContext context) {
-    return ASYNC.run(() -> loadSpaceStatistics(spaceId, context));
+  public Future<StatisticsResponse> loadSpaceStatisticsAsync(String spaceId, SpaceContext context, boolean skipCache) {
+    return ASYNC.run(() -> loadSpaceStatistics(spaceId, context, skipCache));
   }
 
   public Future<StatisticsResponse> loadSpaceStatisticsAsync(String spaceId) {
-    return loadSpaceStatisticsAsync(spaceId, null);
+    return loadSpaceStatisticsAsync(spaceId, null, false);
   }
 
   public Future<Connector> loadConnectorAsync(String connectorId) {

--- a/xyz-util/src/main/java/com/here/xyz/util/web/XyzWebClient.java
+++ b/xyz-util/src/main/java/com/here/xyz/util/web/XyzWebClient.java
@@ -94,13 +94,20 @@ public abstract class XyzWebClient {
 
   public static class ErrorResponseException extends WebClientException {
     private HttpResponse<byte[]> errorResponse;
+    private int statusCode;
+
     public ErrorResponseException(HttpResponse<byte[]> errorResponse) {
       super("Received error response with status code " + errorResponse.statusCode() + " response body:\n" + new String(errorResponse.body()));
       this.errorResponse = errorResponse;
+      this.statusCode = errorResponse.statusCode();
     }
 
     public HttpResponse<byte[]> getErrorResponse() {
       return errorResponse;
+    }
+
+    public int getStatusCode() {
+      return statusCode;
     }
   }
 }


### PR DESCRIPTION
Refinements and Improvements:

    Added functionality to re-use Steps which are producing the same outputs.
    Renamed extendedResourceKey to secondaryResourceKey for better clarity.
    Allowed deletion of jobs with existing references.
    Pruned DelegateOutputSteps and forwarded outputMetadata to DelegateOutputsPseudoSteps.
    Ensured ExportSpaceToFiles#versionRef is always set to a valid resolved version, improving dataset reuse checks and logic in #isEquivalentTo().
    Implemented filter comparison (property and spatial filters).
    Shifted resolving versionRef into ExportSpaceToFiles#prepare() and enhanced validation logic.
    Added an area check for export validation (MAX_ALLOWED_SPATIALFILTER_AREA_IN_SQUARE_KM).
    Only support GeoJSON format and set file suffixes of outputs to .json.

Bug Fixes:

    Fixed run configuration in JobServiceRun.
    Resolved casting error in the perform_work_item SQL function.
    Other minor fixes.
    Fex GetChangesetStatistics QueryRunner to deliver 0 as versions for empty spaces

Minor Adjustments:

    Added logs for unregistered StateCheckTriggers.
    Included the missing gt-epsg-hsql library.
    Add logs for registration of StateCheckTriggers.