### PR TITLE
Improve HubWebClient's statistics caching

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/models/Space.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/models/Space.java
@@ -70,12 +70,6 @@ public class Space extends com.here.xyz.models.hub.Space implements Cloneable {
       - TimeUnit.SECONDS.toMillis((long) (Math.random() * 20));
 
   private final static long MAX_SLIDING_WINDOW = TimeUnit.DAYS.toMillis(10);
-  /**
-   * Indicates the last time the content of a space was updated.
-   */
-  @JsonInclude(Include.NON_DEFAULT)
-  @JsonView({Public.class, Static.class})
-  public long contentUpdatedAt = 0;
 
   @JsonInclude(Include.NON_DEFAULT)
   @JsonView({Public.class, Static.class})
@@ -259,22 +253,6 @@ public class Space extends com.here.xyz.models.hub.Space implements Cloneable {
     //For all other responses of a space which was not changed for longer time -> cache in the service *and* in the browser / CDN
     return new CacheProfile(TimeUnit.MINUTES.toMillis(3), TimeUnit.HOURS.toMillis(24), CacheProfile.MAX_SERVICE_TTL, staticTTL,
         getContentUpdatedAt());
-  }
-
-  public long getContentUpdatedAt() {
-    if (contentUpdatedAt == 0) {
-      contentUpdatedAt = getCreatedAt();
-    }
-    return contentUpdatedAt;
-  }
-
-  public void setContentUpdatedAt(long contentUpdatedAt) {
-    this.contentUpdatedAt = contentUpdatedAt;
-  }
-
-  public Space withContentUpdatedAt(long contentUpdatedAt) {
-    setContentUpdatedAt(contentUpdatedAt);
-    return this;
   }
 
   public String getRegion() {

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/task/FeatureTask.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/task/FeatureTask.java
@@ -57,10 +57,10 @@ import com.here.xyz.hub.task.TaskPipeline.C2;
 import com.here.xyz.hub.task.TaskPipeline.Callback;
 import com.here.xyz.models.geojson.implementation.Feature;
 import com.here.xyz.models.geojson.implementation.FeatureCollection;
+import com.here.xyz.models.geojson.implementation.Geometry;
 import com.here.xyz.models.hub.FeatureModificationList.ConflictResolution;
 import com.here.xyz.models.hub.FeatureModificationList.IfExists;
 import com.here.xyz.models.hub.FeatureModificationList.IfNotExists;
-import com.here.xyz.models.geojson.implementation.Geometry;
 import com.here.xyz.responses.XyzResponse;
 import com.here.xyz.util.geo.GeometryValidator;
 import com.here.xyz.util.service.HttpException;
@@ -155,7 +155,7 @@ public abstract class FeatureTask<T extends Event<?>, X extends FeatureTask<T, ?
           .putString(responseType.toString(), Charset.defaultCharset());
 
       if (!readOnlyAccess) {
-        hasher.putLong(space.contentUpdatedAt);
+        hasher.putLong(space.getContentUpdatedAt());
         if (space.getExtension() != null && extendedSpaces != null)
           extendedSpaces.forEach(extendedSpace -> hasher.putLong(extendedSpace.getContentUpdatedAt()));
       }

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/ExportSpaceToFiles.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/ExportSpaceToFiles.java
@@ -38,7 +38,6 @@ import static com.here.xyz.jobs.steps.impl.transport.TransportTools.getTemporary
 import static com.here.xyz.jobs.steps.impl.transport.TransportTools.infoLog;
 import static com.here.xyz.util.web.XyzWebClient.WebClientException;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonView;
 import com.here.xyz.events.ContextAwareEvent.SpaceContext;
 import com.here.xyz.events.PropertiesQuery;
@@ -174,13 +173,10 @@ public class ExportSpaceToFiles extends SpaceBasedStep<ExportSpaceToFiles> {
     return this;
   }
 
-  @JsonIgnore
-  private StatisticsResponse statistics = null; //TODO: Move caching into HubWebClient
-
   @Override
   public List<Load> getNeededResources() {
     try {
-      statistics = spaceStatistics(context, true);
+      StatisticsResponse statistics = spaceStatistics(context, true);
       overallNeededAcus = overallNeededAcus != -1 ?
               overallNeededAcus : ResourceAndTimeCalculator.getInstance().calculateNeededExportAcus(statistics.getDataSize().getValue());
 
@@ -296,7 +292,7 @@ public class ExportSpaceToFiles extends SpaceBasedStep<ExportSpaceToFiles> {
       throw new ValidationException("It is currently not supported to export changesets.");
 
     try {
-      statistics = statistics != null ? statistics : loadSpaceStatistics(getSpaceId(), context, true);
+      StatisticsResponse statistics = loadSpaceStatistics(getSpaceId(), context, true);
 
       //Validate input Geometry
       if (this.spatialFilter != null) {
@@ -353,7 +349,7 @@ public class ExportSpaceToFiles extends SpaceBasedStep<ExportSpaceToFiles> {
 
   @Override
   public void execute() throws Exception {
-    statistics = statistics != null ? statistics : loadSpaceStatistics(getSpaceId(), context, true);
+    StatisticsResponse statistics = loadSpaceStatistics(getSpaceId(), context, true);
     calculatedThreadCount = statistics.getCount().getValue() > PARALLELIZTATION_MIN_THRESHOLD ? PARALLELIZTATION_THREAD_COUNT : 1;
 
     List<S3DataFile> s3FileNames = generateS3FileNames(calculatedThreadCount);

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/util/test/StepTestBase.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/util/test/StepTestBase.java
@@ -81,20 +81,18 @@ import software.amazon.awssdk.services.lambda.LambdaClient;
 import software.amazon.awssdk.services.lambda.model.InvokeRequest;
 
 public class StepTestBase {
-  private static final Logger logger = LogManager.getLogger();
-  protected String SPACE_ID =  getClass().getSimpleName() + "_" + randomAlpha(5);
-  protected String JOB_ID =  generateJobId();
 
+  public static final Config config = new Config();
   protected static final String LAMBDA_ARN = "arn:aws:lambda:us-east-1:000000000000:function:job-step";
+  private static final Logger logger = LogManager.getLogger();
   private static final HubWebClient hubWebClient;
   private static final S3Client s3Client;
-  private static LambdaClient lambdaClient;
   private static final String PG_HOST = "localhost";
   private static final String PG_DB = "postgres";
   private static final String PG_USER = "postgres";
   private static final String PG_PW = "password";
   private static final String SCHEMA = "public";
-  public static final Config config = new Config();
+  private static LambdaClient lambdaClient;
 
   static {
     try {
@@ -105,42 +103,28 @@ public class StepTestBase {
       Config.instance.HUB_ENDPOINT = "http://localhost:8080/hub";
       Config.instance.LOCALSTACK_ENDPOINT = new URI("http://localhost:4566");
       Config.instance.JOB_API_ENDPOINT = new URL("http://localhost:7070");
+      HubWebClient.STATISTICS_CACHE_TTL_SECONDS = 0;
       hubWebClient = HubWebClient.getInstance("http://localhost:8080/hub");
       s3Client = S3Client.getInstance();
       lambdaClient = LambdaClient.builder()
-              .region(Region.of(Config.instance.AWS_REGION))
-              .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("localstack", "localstack")))
-              .endpointOverride(Config.instance.LOCALSTACK_ENDPOINT)
-              .build();
-    } catch (Exception e) {
+          .region(Region.of(Config.instance.AWS_REGION))
+          .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("localstack", "localstack")))
+          .endpointOverride(Config.instance.LOCALSTACK_ENDPOINT)
+          .build();
+    }
+    catch (Exception e) {
       throw new RuntimeException(e);
     }
   }
 
-  public String generateJobId(){
+  protected String SPACE_ID = getClass().getSimpleName() + "_" + randomAlpha(5);
+  protected String JOB_ID = generateJobId();
+
+  public String generateJobId() {
     return getClass().getSimpleName() + "_" + randomAlpha(5);
   }
 
-  public enum S3ContentType {
-    APPLICATION_JSON("application/json"),
-    TEXT_CSV("text/csv");
-
-    private final String value;
-    S3ContentType(String value) { this.value = value; }
-  }
-
-  private DataSourceProvider getDataSourceProvider() {
-    return new PooledDataSources(
-            new DatabaseSettings("testSteps")
-            .withApplicationName(StepTestBase.class.getSimpleName())
-            .withHost(PG_HOST)
-            .withDb(PG_DB)
-            .withUser(PG_USER)
-            .withPassword(PG_PW)
-            .withDbMaxPoolSize(2));
-  }
-
-  protected Space createSpace(String spaceId){
+  protected Space createSpace(String spaceId) {
     return createSpace(new Space().withId(spaceId), false);
   }
 
@@ -158,16 +142,18 @@ public class StepTestBase {
       else {
         System.out.println("Hub Error: " + e.getMessage());
       }
-    } catch (XyzWebClient.WebClientException e) {
+    }
+    catch (XyzWebClient.WebClientException e) {
       System.out.println("Hub Error: " + e.getMessage());
     }
     return null;
   }
 
-  protected void patchSpace(String spaceId, Map<String,Object> spaceUpdates) {
+  protected void patchSpace(String spaceId, Map<String, Object> spaceUpdates) {
     try {
       hubWebClient.patchSpace(spaceId, spaceUpdates);
-    } catch (XyzWebClient.WebClientException e) {
+    }
+    catch (XyzWebClient.WebClientException e) {
       System.out.println("Hub Error: " + e.getMessage());
     }
   }
@@ -175,7 +161,8 @@ public class StepTestBase {
   protected void createTag(String spaceId, Tag tag) {
     try {
       hubWebClient.postTag(spaceId, tag);
-    } catch (XyzWebClient.WebClientException e) {
+    }
+    catch (XyzWebClient.WebClientException e) {
       System.out.println("Hub Error: " + e.getMessage());
     }
   }
@@ -183,7 +170,8 @@ public class StepTestBase {
   protected void deleteSpace(String spaceId) {
     try {
       hubWebClient.deleteSpace(spaceId);
-    } catch (XyzWebClient.WebClientException e) {
+    }
+    catch (XyzWebClient.WebClientException e) {
       System.out.println("Hub Error: " + e.getMessage());
     }
   }
@@ -191,25 +179,29 @@ public class StepTestBase {
   protected StatisticsResponse getStatistics(String spaceId) {
     try {
       return hubWebClient.loadSpaceStatistics(spaceId, SpaceContext.DEFAULT, true);
-    } catch (XyzWebClient.WebClientException e) {
+    }
+    catch (XyzWebClient.WebClientException e) {
       System.out.println("Hub Error: " + e.getMessage());
     }
     return null;
   }
 
-  protected FeatureCollection getFeaturesFromSmallSpace(String spaceId ,String propertyFilter, boolean force2D) {
+  protected FeatureCollection getFeaturesFromSmallSpace(String spaceId, String propertyFilter, boolean force2D) {
     try {
       return hubWebClient.getFeaturesFromSmallSpace(spaceId, SpaceContext.DEFAULT, propertyFilter, force2D);
-    } catch (XyzWebClient.WebClientException e) {
+    }
+    catch (XyzWebClient.WebClientException e) {
       System.out.println("Hub Error: " + e.getMessage());
     }
     return null;
   }
 
-  protected FeatureCollection getFeaturesFromSmallSpace(String spaceId, ContextAwareEvent.SpaceContext context, String propertyFilter, boolean force2D) {
+  protected FeatureCollection getFeaturesFromSmallSpace(String spaceId, ContextAwareEvent.SpaceContext context, String propertyFilter,
+      boolean force2D) {
     try {
       return hubWebClient.getFeaturesFromSmallSpace(spaceId, context, propertyFilter, force2D);
-    } catch (XyzWebClient.WebClientException e) {
+    }
+    catch (XyzWebClient.WebClientException e) {
       System.out.println("Hub Error: " + e.getMessage());
     }
     return null;
@@ -218,7 +210,8 @@ public class StepTestBase {
   protected FeatureCollection customReadFeaturesQuery(String spaceId, String customPath) {
     try {
       return hubWebClient.customReadFeaturesQuery(spaceId, customPath);
-    } catch (XyzWebClient.WebClientException e) {
+    }
+    catch (XyzWebClient.WebClientException e) {
       System.out.println("Hub Error: " + e.getMessage());
     }
     return null;
@@ -227,7 +220,8 @@ public class StepTestBase {
   protected void putFeatureCollectionToSpace(String spaceId, FeatureCollection fc) {
     try {
       hubWebClient.putFeaturesWithoutResponse(spaceId, fc);
-    } catch (XyzWebClient.WebClientException e) {
+    }
+    catch (XyzWebClient.WebClientException e) {
       System.out.println("Hub Error: " + e.getMessage());
     }
   }
@@ -235,7 +229,8 @@ public class StepTestBase {
   protected void deleteFeaturesInSpace(String spaceId, List<String> ids) {
     try {
       hubWebClient.deleteFeatures(spaceId, ids);
-    } catch (XyzWebClient.WebClientException e) {
+    }
+    catch (XyzWebClient.WebClientException e) {
       System.out.println("Hub Error: " + e.getMessage());
     }
   }
@@ -243,30 +238,20 @@ public class StepTestBase {
   protected void putRandomFeatureCollectionToSpace(String spaceId, int featureCount) {
     try {
       hubWebClient.putFeaturesWithoutResponse(spaceId, ContentCreator.generateRandomFeatureCollection(featureCount));
-    } catch (XyzWebClient.WebClientException e) {
+    }
+    catch (XyzWebClient.WebClientException e) {
       System.out.println("Hub Error: " + e.getMessage());
     }
   }
 
-  protected void putRandomFeatureCollectionToSpace(String spaceId, int featureCount ,float xmin, float ymin, float xmax, float ymax)
-  {
+  protected void putRandomFeatureCollectionToSpace(String spaceId, int featureCount, float xmin, float ymin, float xmax, float ymax) {
     try {
-      hubWebClient.putFeaturesWithoutResponse(spaceId, ContentCreator.generateRandomFeatureCollection(featureCount,xmin,ymin,xmax,ymax));
-    } catch (XyzWebClient.WebClientException e) {
+      hubWebClient.putFeaturesWithoutResponse(spaceId,
+          ContentCreator.generateRandomFeatureCollection(featureCount, xmin, ymin, xmax, ymax));
+    }
+    catch (XyzWebClient.WebClientException e) {
       System.out.println("Hub Error: " + e.getMessage());
     }
-  }
-
-  protected List<String> listExistingIndexes(String spaceId) throws SQLException {
-    return new SQLQuery("SELECT * FROM xyz_index_list_all_available(#{schema}, #{table});")
-            .withNamedParameter("schema", SCHEMA)
-            .withNamedParameter("table", spaceId)
-            .run(getDataSourceProvider(), rs -> {
-              List<String> result = new ArrayList<>();
-              while(rs.next())
-                result.add(rs.getString(1));
-              return result;
-            });
   }
 
   protected void deleteAllExistingIndexes(String spaceId) throws SQLException {
@@ -275,42 +260,55 @@ public class StepTestBase {
     SQLQuery.join(dropQueries, ";").write(getDataSourceProvider());
   }
 
+  protected List<String> listExistingIndexes(String spaceId) throws SQLException {
+    return new SQLQuery("SELECT * FROM xyz_index_list_all_available(#{schema}, #{table});")
+        .withNamedParameter("schema", SCHEMA)
+        .withNamedParameter("table", spaceId)
+        .run(getDataSourceProvider(), rs -> {
+          List<String> result = new ArrayList<>();
+          while (rs.next())
+            result.add(rs.getString(1));
+          return result;
+        });
+  }
+
+  private DataSourceProvider getDataSourceProvider() {
+    return new PooledDataSources(
+        new DatabaseSettings("testSteps")
+            .withApplicationName(StepTestBase.class.getSimpleName())
+            .withHost(PG_HOST)
+            .withDb(PG_DB)
+            .withUser(PG_USER)
+            .withPassword(PG_PW)
+            .withDbMaxPoolSize(2));
+  }
+
   protected void deleteAllJobTables(List<String> stepIds) throws SQLException {
     List<SQLQuery> dropQueries = new ArrayList<>();
     for (String stepId : stepIds) {
       dropQueries.add(new SQLQuery("DROP TABLE IF EXISTS ${schema}.${table};")
-                      .withVariable("schema", SCHEMA)
-                      .withVariable("table", TransportTools.getTemporaryJobTableName(stepId))
+          .withVariable("schema", SCHEMA)
+          .withVariable("table", TransportTools.getTemporaryJobTableName(stepId))
       );
       dropQueries.add(
-              new SQLQuery("DROP TABLE IF EXISTS ${schema}.${table};")
-                      .withVariable("schema", SCHEMA)
-                      .withVariable("table", TransportTools.getTemporaryTriggerTableName(stepId))
+          new SQLQuery("DROP TABLE IF EXISTS ${schema}.${table};")
+              .withVariable("schema", SCHEMA)
+              .withVariable("table", TransportTools.getTemporaryTriggerTableName(stepId))
       );
     }
     SQLQuery.join(dropQueries, ";").write(getDataSourceProvider());
-  }
-
-  protected void uploadFileToS3(String s3Key, S3ContentType contentType, byte[] data, boolean gzip) throws IOException {
-    s3Client.putObject(s3Key, contentType.value, data, gzip);
   }
 
   protected void cleanS3Files(String s3Prefix) {
     s3Client.deleteFolder(s3Prefix);
   }
 
-  private void invokeLambda(String lambdaArn, byte[] payload) {
-    lambdaClient.invoke(InvokeRequest.builder()
-            .functionName(lambdaArn)
-            .payload(SdkBytes.fromByteArray(payload))
-            .build());
-  }
-
   protected void sendLambdaStepRequestBlock(LambdaBasedStep step, boolean simulate) throws IOException, InterruptedException {
     try {
       step.prepare(null, null);
       if (!step.validate())
-        throw new IllegalStateException("The step " + step.getGlobalStepId() + " of type " + step.getClass().getSimpleName() + " is not ready for execution yet");
+        throw new IllegalStateException(
+            "The step " + step.getGlobalStepId() + " of type " + step.getClass().getSimpleName() + " is not ready for execution yet");
     }
     catch (ValidationException e) {
       throw new RuntimeException("Validation exception: " + e.getMessage(), e);
@@ -323,18 +321,20 @@ public class StepTestBase {
       Thread.sleep(500);
       try {
         boolean running = SQLQuery.isRunning(dsp, false, "jobId", step.getJobId());
-        if(!running)
+        if (!running)
           break;
-      }catch (SQLException e) {
+      }
+      catch (SQLException e) {
         break;
       }
     }
 
-    if(simulate)
+    if (simulate)
       sendLambdaStepRequest(step, SUCCESS_CALLBACK, true);
   }
 
-  protected void sendLambdaStepRequest(LambdaBasedStep step, LambdaBasedStep.LambdaStepRequest.RequestType requestType, boolean simulate) throws IOException {
+  protected void sendLambdaStepRequest(LambdaBasedStep step, LambdaBasedStep.LambdaStepRequest.RequestType requestType, boolean simulate)
+      throws IOException {
     Map<String, Object> stepMap = step.toMap();
     stepMap.put("taskToken.$", "test123");
     stepMap.put("jobId", JOB_ID);
@@ -343,29 +343,40 @@ public class StepTestBase {
 
     logger.info("sendLambdaStepRequest with job-id: {}", JOB_ID);
 
-    if(!simulate)
+    if (!simulate)
       invokeLambda(LAMBDA_ARN, request.toByteArray());
-    else{
+    else {
       OutputStream os = new ByteArrayOutputStream();
       Context ctx = new SimulatedContext("localLambda", null);
       new LambdaBasedStep.LambdaBasedStepExecutor().handleRequest(new ByteArrayInputStream(request.toByteArray()), os, ctx);
     }
   }
 
+  private void invokeLambda(String lambdaArn, byte[] payload) {
+    lambdaClient.invoke(InvokeRequest.builder()
+        .functionName(lambdaArn)
+        .payload(SdkBytes.fromByteArray(payload))
+        .build());
+  }
+
   //TODO: find a central place to avoid double implementation from JobPlayground
   public void uploadFiles(String jobId, int uploadFileCount, int featureCountPerFile, ImportFilesToSpace.Format format)
-          throws IOException {
+      throws IOException {
     //Generate N Files with M features
     for (int i = 0; i < uploadFileCount; i++)
       uploadInputFile(jobId, ContentCreator.generateImportFileContent(format, featureCountPerFile), S3ContentType.APPLICATION_JSON);
   }
 
-  public void uploadInputFile(String jobId , byte[] bytes, S3ContentType contentType) throws IOException {
+  public void uploadInputFile(String jobId, byte[] bytes, S3ContentType contentType) throws IOException {
     uploadFileToS3(inputS3Prefix(jobId) + "/" + UUID.randomUUID(), contentType, bytes, false);
   }
 
+  protected void uploadFileToS3(String s3Key, S3ContentType contentType, byte[] data, boolean gzip) throws IOException {
+    s3Client.putObject(s3Key, contentType.value, data, gzip);
+  }
+
   protected List<Feature> downloadFileAndSerializeFeatures(DownloadUrl output) throws IOException {
-    logger.info("Check file: {}",output.getS3Key());
+    logger.info("Check file: {}", output.getS3Key());
     List<Feature> features = new ArrayList<>();
 
     InputStream dataStream = S3Client.getInstance().streamObjectContent(output.getS3Key());
@@ -383,17 +394,18 @@ public class StepTestBase {
     return features;
   }
 
-  protected List<String> downloadFileAsText(URL url, boolean isCompressed, MediaType mediaType) throws IOException, URISyntaxException, InterruptedException {
+  protected List<String> downloadFileAsText(URL url, boolean isCompressed, MediaType mediaType)
+      throws IOException, URISyntaxException, InterruptedException {
     List<String> fileInLines = new ArrayList<>();
 
     logger.info("Check file: {}", url);
     InputStream dataStream;
     HttpRequest request = HttpRequest.newBuilder()
-            .uri(url.toURI())
-            .header(CONTENT_TYPE, mediaType.toString())
-            .method("GET", HttpRequest.BodyPublishers.noBody())
-            .version(HttpClient.Version.HTTP_1_1)
-            .build();
+        .uri(url.toURI())
+        .header(CONTENT_TYPE, mediaType.toString())
+        .method("GET", HttpRequest.BodyPublishers.noBody())
+        .version(HttpClient.Version.HTTP_1_1)
+        .build();
 
     HttpClient client = HttpClient.newBuilder().followRedirects(NORMAL).build();
     HttpResponse<InputStream> response = client.send(request, HttpResponse.BodyHandlers.ofInputStream());
@@ -416,6 +428,18 @@ public class StepTestBase {
   }
 
   protected FeatureCollection readTestFeatureCollection(String filePath) throws IOException {
-    return XyzSerializable.deserialize( new String(ByteStreams.toByteArray(this.getClass().getResourceAsStream(filePath))).trim(), FeatureCollection.class);
+    return XyzSerializable.deserialize(new String(ByteStreams.toByteArray(this.getClass().getResourceAsStream(filePath))).trim(),
+        FeatureCollection.class);
+  }
+
+  public enum S3ContentType {
+    APPLICATION_JSON("application/json"),
+    TEXT_CSV("text/csv");
+
+    private final String value;
+
+    S3ContentType(String value) {
+      this.value = value;
+    }
   }
 }

--- a/xyz-models/src/main/java/com/here/xyz/models/hub/Space.java
+++ b/xyz-models/src/main/java/com/here/xyz/models/hub/Space.java
@@ -234,6 +234,12 @@ public class Space {
   @JsonInclude(value = Include.CUSTOM, valueFilter = IncludeFalse.class)
   @JsonView({Internal.class, Static.class})
   private boolean active = true;
+  /**
+   * Indicates the last time the content of a space was updated.
+   */
+  @JsonInclude(Include.NON_DEFAULT)
+  @JsonView({Public.class, Static.class})
+  private long contentUpdatedAt = 0;
 
   public String getId() {
     return id;
@@ -571,6 +577,21 @@ public class Space {
 
   public Space withActive(final boolean active) {
     setActive(active);
+    return this;
+  }
+
+  public long getContentUpdatedAt() {
+    if (contentUpdatedAt == 0)
+      contentUpdatedAt = getCreatedAt();
+    return contentUpdatedAt;
+  }
+
+  public void setContentUpdatedAt(long contentUpdatedAt) {
+    this.contentUpdatedAt = contentUpdatedAt;
+  }
+
+  public Space withContentUpdatedAt(long contentUpdatedAt) {
+    setContentUpdatedAt(contentUpdatedAt);
     return this;
   }
 

--- a/xyz-util/src/main/java/com/here/xyz/util/web/HubWebClient.java
+++ b/xyz-util/src/main/java/com/here/xyz/util/web/HubWebClient.java
@@ -50,6 +50,7 @@ import net.jodah.expiringmap.ExpirationPolicy;
 import net.jodah.expiringmap.ExpiringMap;
 
 public class HubWebClient extends XyzWebClient {
+  public static int STATISTICS_CACHE_TTL_SECONDS = 30;
   private static Map<InstanceKey, HubWebClient> instances = new ConcurrentHashMap<>();
   private ExpiringMap<String, Connector> connectorCache = ExpiringMap.builder()
       .expirationPolicy(ExpirationPolicy.CREATED)
@@ -57,7 +58,7 @@ public class HubWebClient extends XyzWebClient {
       .build();
   private ExpiringMap<String, StatisticsResponse> statisticsCache = ExpiringMap.builder()
       .expirationPolicy(ExpirationPolicy.CREATED)
-      .expiration(30, TimeUnit.SECONDS)
+      .expiration(STATISTICS_CACHE_TTL_SECONDS, TimeUnit.SECONDS)
       .build();
 
   protected HubWebClient(String baseUrl) {
@@ -179,7 +180,7 @@ public class HubWebClient extends XyzWebClient {
 
   public StatisticsResponse loadSpaceStatistics(String spaceId, SpaceContext context, boolean skipCache) throws WebClientException {
     try {
-      String cacheKey = spaceId + ":" + context;
+      String cacheKey = spaceId + ":" + context + "_" + loadSpace(spaceId).getContentUpdatedAt();
       StatisticsResponse statistics = statisticsCache.get(cacheKey);
       if (statistics != null)
         return statistics;


### PR DESCRIPTION
- Pull up Space#contentUpdatedAt (and adapt usages to use the getter instead)
- Add contentUpdatedAt field of the space config to the cache-key
- Remove obsolete field ExportSpaceToFiles#statistics
- Deactivate client side statistics caching for CopySpaceStepsTest (for now until copy steps impl has been consolidated)