### PR TITLE
Reduce concurrent db request for storage stats

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/statistics/StorageStatisticsProvider.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/statistics/StorageStatisticsProvider.java
@@ -49,7 +49,7 @@ import org.apache.logging.log4j.Marker;
 
 public class StorageStatisticsProvider {
 
-  private static final int MAX_CONCURRENT_REQUEST_COUNT = 100;
+  private static final int MAX_CONCURRENT_REQUEST_COUNT = 20;
   private static final int MAX_SPACE_BATCH_SIZE = 50;
 
   public static Future<StorageStatistics> provideStorageStatistics(Marker marker, long includeChangesSince) {
@@ -112,7 +112,8 @@ public class StorageStatisticsProvider {
 
   private static Future<StorageStatistics> fetchFromStorage(Marker marker, String storageId, List<String> spaceIds) {
     return Space.resolveConnector(marker, storageId)
-        .compose(storage -> storage.capabilities.storageUtilizationReporting ?            //Ignore if the connector can not be resolved
+        //Ignore if the connector is not active or can not be resolved
+        .compose(storage -> storage.active && storage.capabilities.storageUtilizationReporting ?
               fetchFromStorage(marker, storage, spaceIds) : Future.succeededFuture(null), t -> Future.succeededFuture(null));
   }
 

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetStorageStatistics.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetStorageStatistics.java
@@ -68,7 +68,8 @@ public class GetStorageStatistics extends XyzQueryRunner<GetStorageStatisticsEve
                             + " AND relname LIKE ANY (array[" + tableNames
                                                       .stream()
                                                       .map(tableName -> "'" + tableName + "_%'")
-                                                      .collect(Collectors.joining(",")) + "])");
+                                                      .collect(Collectors.joining(",")) + "])")
+            .withTimeout(15);
   }
 
   private String resolveTableName(Event event, String spaceId) {


### PR DESCRIPTION
- Skip storage stats for inactive connectors
- Set query timeout to 15s to allow at least one retry