### PR TITLE
MMSUP-61: Fixed issue with inconsistent feature history versions for composite spaces

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/httpconnector/config/query/ExportSpaceByGeometry.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/httpconnector/config/query/ExportSpaceByGeometry.java
@@ -24,8 +24,6 @@ import static com.here.xyz.events.ContextAwareEvent.SpaceContext.COMPOSITE_EXTEN
 import com.here.xyz.connectors.ErrorResponseException;
 import com.here.xyz.events.ContextAwareEvent;
 import com.here.xyz.events.GetFeaturesByGeometryEvent;
-import com.here.xyz.events.SelectiveEvent;
-import com.here.xyz.models.hub.Ref;
 import com.here.xyz.psql.query.GetFeaturesByGeometry;
 import com.here.xyz.util.db.SQLQuery;
 import java.sql.SQLException;
@@ -104,19 +102,5 @@ public class ExportSpaceByGeometry extends GetFeaturesByGeometry implements Expo
   @Override
   public String buildOuterOrderByFragment(ContextAwareEvent event) {
     return super.buildOuterOrderByFragment(event);
-  }
-
-  @Override
-  public SQLQuery buildVersionComparison(SelectiveEvent event) {
-    if (event.getRef().isRange())
-      return buildVersionComparisonForRange(event);
-    return super.buildVersionComparison(event);
-  }
-
-  @Override
-  public SQLQuery buildNextVersionFragment(Ref ref, boolean historyEnabled, String versionParamName) {
-    if (ref.isRange())
-      return buildNextVersionFragmentForRange(ref, historyEnabled, versionParamName);
-    return super.buildNextVersionFragment(ref, historyEnabled, versionParamName);
   }
 }

--- a/xyz-hub-service/src/main/java/com/here/xyz/httpconnector/config/query/ExportSpaceByProperties.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/httpconnector/config/query/ExportSpaceByProperties.java
@@ -25,9 +25,7 @@ import com.here.xyz.connectors.ErrorResponseException;
 import com.here.xyz.events.ContextAwareEvent;
 import com.here.xyz.events.GetFeaturesByGeometryEvent;
 import com.here.xyz.events.SearchForFeaturesEvent;
-import com.here.xyz.events.SelectiveEvent;
 import com.here.xyz.models.geojson.implementation.FeatureCollection;
-import com.here.xyz.models.hub.Ref;
 import com.here.xyz.psql.query.SearchForFeatures;
 import com.here.xyz.util.db.SQLQuery;
 import java.sql.SQLException;
@@ -107,19 +105,5 @@ public class ExportSpaceByProperties extends SearchForFeatures<SearchForFeatures
   @Override
   public String buildOuterOrderByFragment(ContextAwareEvent event) {
     return super.buildOuterOrderByFragment(event);
-  }
-
-  @Override
-  public SQLQuery buildVersionComparison(SelectiveEvent event) {
-    if (event.getRef().isRange())
-      return buildVersionComparisonForRange(event);
-    return super.buildVersionComparison(event);
-  }
-
-  @Override
-  public SQLQuery buildNextVersionFragment(Ref ref, boolean historyEnabled, String versionParamName) {
-    if (ref.isRange())
-      return buildNextVersionFragmentForRange(ref, historyEnabled, versionParamName);
-    return super.buildNextVersionFragment(ref, historyEnabled, versionParamName);
   }
 }

--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/TestSpaceWithFeature.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/TestSpaceWithFeature.java
@@ -19,25 +19,19 @@
 
 package com.here.xyz.hub.rest;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import static com.here.xyz.hub.auth.TestAuthenticator.AuthProfile.ACCESS_ALL;
+import com.here.xyz.models.geojson.coordinates.PointCoordinates;
+import com.here.xyz.models.geojson.implementation.Feature;
+import com.here.xyz.models.geojson.implementation.FeatureCollection;
+import com.here.xyz.models.geojson.implementation.Point;
+import com.here.xyz.models.geojson.implementation.Properties;
 import static com.here.xyz.util.service.BaseHttpServerVerticle.HeaderValues.APPLICATION_GEO_JSON;
 import static com.here.xyz.util.service.BaseHttpServerVerticle.HeaderValues.APPLICATION_JSON;
 import static com.here.xyz.util.service.BaseHttpServerVerticle.HeaderValues.APPLICATION_VND_HERE_FEATURE_MODIFICATION_LIST;
 import static io.netty.handler.codec.http.HttpResponseStatus.NO_CONTENT;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static io.restassured.RestAssured.given;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.everyItem;
-import static org.hamcrest.Matchers.isIn;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.here.xyz.models.geojson.coordinates.PointCoordinates;
-import com.here.xyz.models.geojson.implementation.Feature;
-import com.here.xyz.models.geojson.implementation.FeatureCollection;
-import com.here.xyz.models.geojson.implementation.Point;
-import com.here.xyz.models.geojson.implementation.Properties;
 import io.restassured.response.ValidatableResponse;
 import io.vertx.core.json.JsonObject;
 import java.util.ArrayList;
@@ -53,6 +47,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.RandomStringUtils;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.isIn;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 public class TestSpaceWithFeature extends TestWithSpaceCleanup {
   protected static String embeddedStorageId = "psql";
@@ -396,6 +395,10 @@ public class TestSpaceWithFeature extends TestWithSpaceCleanup {
     validateGetFeatureResponse(statusCode, null, null, getFeature(spaceId, featureId, version, context));
   }
 
+  protected ValidatableResponse getAllFeatureVersions(String spaceId, String featureId, String context) {
+    return getFeature(spaceId, featureId, "*", context);
+  }
+
   private static void validateGetFeatureResponse(Integer statusCode, String path, String value, ValidatableResponse response) {
     if (statusCode != null)
       response.statusCode(statusCode);
@@ -424,12 +427,16 @@ public class TestSpaceWithFeature extends TestWithSpaceCleanup {
   }
 
   protected ValidatableResponse getFeature(String spaceId, String featureId, String context) {
-    return getFeature(spaceId, featureId, -1, context);
+    return getFeature(spaceId, featureId, null, context);
   }
 
   protected ValidatableResponse getFeature(String spaceId, String featureId, long version, String context) {
+    return getFeature(spaceId, featureId, version != -1 ? "" + version : null, context);
+  }
+
+  private ValidatableResponse getFeature(String spaceId, String featureId, String versionRef, String context) {
     Map<String, Object> queryParams = new HashMap<>() {{
-      put("version", version != -1 ? version : null);
+      put("version", versionRef);
       put("context", context);
     }};
     return given()

--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/VersioningCompositeGetFeaturesIT.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/VersioningCompositeGetFeaturesIT.java
@@ -21,7 +21,6 @@ package com.here.xyz.hub.rest;
 
 import static com.here.xyz.hub.auth.TestAuthenticator.AuthProfile.ACCESS_ALL;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
-import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 
 import com.here.xyz.models.geojson.coordinates.PointCoordinates;
@@ -54,8 +53,8 @@ public class VersioningCompositeGetFeaturesIT extends VersioningGetFeaturesIT {
 
     postFeature(DELTA, newFeature(), ACCESS_ALL);
     postFeature(DELTA, newFeature()
-            .withGeometry(new Point().withCoordinates(new PointCoordinates(50,50)))
-            .withProperties(new Properties().with("key2", "value2")), ACCESS_ALL);
+        .withGeometry(new Point().withCoordinates(new PointCoordinates(50, 50)))
+        .withProperties(new Properties().with("key2", "value2")), ACCESS_ALL);
   }
 
   @After
@@ -116,16 +115,55 @@ public class VersioningCompositeGetFeaturesIT extends VersioningGetFeaturesIT {
 
   @Test
   public void testGetFeatureVersionStar() {
-    given()
-        .headers(getAuthHeaders(ACCESS_ALL))
-        .when()
-        .get(getSpacesPath() + "/" + DELTA + "/features/f1?version=*")
-        .then()
+    getAllFeatureVersions(BASE, "f1", "DEFAULT")
         .statusCode(OK.code())
+        .body("features.size()",equalTo(1))
+        .body("features[0].id", equalTo("f1"))
+        .body("features[0].properties.@ns:com:here:xyz.version", equalTo(1));
+
+    getAllFeatureVersions(DELTA, "f1", "SUPER")
+        .statusCode(OK.code())
+        .body("features.size()", equalTo(1))
+        .body("features[0].id", equalTo("f1"))
+        .body("features[0].properties.@ns:com:here:xyz.version", equalTo(1));
+
+    getAllFeatureVersions(DELTA, "f1", "DEFAULT")
+        .statusCode(OK.code())
+        .body("features.size()", equalTo(3))
         .body("features[0].id", equalTo("f1"))
         .body("features[1].id", equalTo("f1"))
+        .body("features[2].id", equalTo("f1"))
+        .body("features[0].properties.@ns:com:here:xyz.version", equalTo(0))
+        .body("features[1].properties.@ns:com:here:xyz.version", equalTo(1))
+        .body("features[2].properties.@ns:com:here:xyz.version", equalTo(2));
+  }
 
-        .body("features[0].properties.@ns:com:here:xyz.version", equalTo(1))
-        .body("features[1].properties.@ns:com:here:xyz.version", equalTo(2));
+  @Test
+  public void testGetFeatureVersionStarCompositeVersionsBeforeAndAfterEdit() {
+    final String fId = "otherFeature";
+
+    postFeature(BASE, newFeature().withId(fId), ACCESS_ALL);
+
+    getAllFeatureVersions(BASE, fId, "DEFAULT")
+        .statusCode(OK.code())
+        .body("features.size()", equalTo(1))
+        .body("features[0].id", equalTo(fId))
+        .body("features[0].properties.@ns:com:here:xyz.version", equalTo(2));
+
+    getAllFeatureVersions(DELTA, fId, "DEFAULT")
+        .statusCode(OK.code())
+        .body("features.size()", equalTo(1))
+        .body("features[0].id", equalTo(fId))
+        .body("features[0].properties.@ns:com:here:xyz.version", equalTo(0));
+
+    postFeature(DELTA, newFeature().withId(fId), ACCESS_ALL);
+
+    getAllFeatureVersions(DELTA, fId, "DEFAULT")
+        .statusCode(OK.code())
+        .body("features.size()", equalTo(2))
+        .body("features[0].id", equalTo(fId))
+        .body("features[1].id", equalTo(fId))
+        .body("features[0].properties.@ns:com:here:xyz.version", equalTo(0))
+        .body("features[1].properties.@ns:com:here:xyz.version", equalTo(3));
   }
 }

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/ExportChangedTiles.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/ExportChangedTiles.java
@@ -45,6 +45,7 @@ import com.here.xyz.models.hub.Ref;
 import com.here.xyz.psql.query.GetFeaturesByGeometryBuilder;
 import com.here.xyz.psql.query.GetFeaturesByGeometryBuilder.GetFeaturesByGeometryInput;
 import com.here.xyz.psql.query.GetFeaturesByIdsBuilder;
+import com.here.xyz.psql.query.GetFeaturesByIdsBuilder.GetFeaturesByIdsInput;
 import com.here.xyz.psql.query.QueryBuilder.QueryBuildingException;
 import com.here.xyz.util.db.SQLQuery;
 import com.here.xyz.util.service.BaseHttpServerVerticle.ValidationException;
@@ -386,29 +387,19 @@ public class ExportChangedTiles extends ExportSpaceToFiles {
             .withQueryFragment("contentQuery", contentQuery);
   }
 
-  private SQLQuery generateGetFeaturesByIdsQuery(List<String> ids, SpaceContext context, Ref versionRef)
-          throws WebClientException, TooManyResourcesClaimed, QueryBuildingException {
-
+  private SQLQuery generateGetFeaturesByIdsQuery(List<String> ids, SpaceContext context, Ref versionRef) throws WebClientException,
+      TooManyResourcesClaimed, QueryBuildingException {
     GetFeaturesByIdsBuilder queryBuilder = new GetFeaturesByIdsBuilder()
-            .withDataSourceProvider(requestResource(dbReader(), 0));
-    GetFeaturesByIdsBuilder.GetFeaturesByIdsInput input = createGetFeaturesByIdsInput(ids, context, versionRef);
+        .withDataSourceProvider(requestResource(dbReader(), 0));
 
-    return queryBuilder
-            .withSelectClauseOverride(new SQLQuery("id,geo"))
-            .buildQuery(input);
-  }
-
-  private GetFeaturesByIdsBuilder.GetFeaturesByIdsInput createGetFeaturesByIdsInput(List<String> ids,
-                                                                                    SpaceContext context, Ref versionRef)
-          throws WebClientException {
-    return new GetFeaturesByIdsBuilder.GetFeaturesByIdsInput(
-            space().getId(),
-            hubWebClient().loadConnector(space().getStorage().getId()).params,
-            space().getExtension() != null ? space().resolveCompositeParams(superSpace()) : null,
-            context,
-            space().getVersionsToKeep(),
-            versionRef,
-            ids
-    );
+    return queryBuilder.buildQuery(new GetFeaturesByIdsInput(
+        space().getId(),
+        hubWebClient().loadConnector(space().getStorage().getId()).params,
+        space().getExtension() != null ? space().resolveCompositeParams(superSpace()) : null,
+        context,
+        space().getVersionsToKeep(),
+        versionRef,
+        ids
+    ));
   }
 }

--- a/xyz-models/src/main/java/com/here/xyz/events/SearchForFeaturesEvent.java
+++ b/xyz-models/src/main/java/com/here/xyz/events/SearchForFeaturesEvent.java
@@ -31,7 +31,7 @@ public class SearchForFeaturesEvent<T extends SearchForFeaturesEvent> extends Se
 
   private long limit = DEFAULT_LIMIT;
   @JsonIgnore
-  public boolean ignoreLimit = false;
+  public boolean ignoreLimit = false; //TODO: Remove after refactoring
 
   public long getLimit() {
     return ignoreLimit ? Long.MAX_VALUE : limit;

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeaturesByBBox.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeaturesByBBox.java
@@ -84,7 +84,7 @@ public class GetFeaturesByBBox<E extends GetFeaturesByBBoxEvent, R extends XyzRe
     return buildGeoFilterFromBbox(event.getBbox());
   }
 
-  protected SQLQuery buildGeoFilterFromBbox(BBox bbox) {
+  protected static SQLQuery buildGeoFilterFromBbox(BBox bbox) {
     SQLQuery geoFilter = new SQLQuery("ST_MakeEnvelope(#{minLon}, #{minLat}, #{maxLon}, #{maxLat}, 4326)")
         .withNamedParameter("minLon", bbox.minLon())
         .withNamedParameter("minLat", bbox.minLat())

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeaturesByBBoxTweaked.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeaturesByBBoxTweaked.java
@@ -206,7 +206,7 @@ public class GetFeaturesByBBoxTweaked<E extends GetFeaturesByBBoxEvent, R extend
         .withVariable(SCHEMA, getSchema())
         .withVariable("headTable", getDefaultTable((E) event) + HEAD_TABLE_SUFFIX);
 
-    query.setQueryFragment("jsonData", buildJsonDataFragment(event));
+    query.setQueryFragment("jsonData", buildJsonDataFragment(event, 0));
     query.setQueryFragment("geo", buildGeoFragment((E) event));
     query.setQueryFragment("tableSample", ""); //Can be overridden by caller
 
@@ -546,7 +546,7 @@ public class GetFeaturesByBBoxTweaked<E extends GetFeaturesByBBoxEvent, R extend
             +") "
             +"select jsondata, ${{tweaksGeo}} as geo from finaldata LIMIT #{limit}")
             .withQueryFragment("geo", "geo") //(event.getClip() ? clipProjGeom(bbox,"geo") : "geo")
-            .withQueryFragment("jsonData", buildJsonDataFragment(event))
+            .withQueryFragment("jsonData", buildJsonDataFragment(event, 0))
             .withNamedParameter("minGeoHashLenForLineMerge", minGeoHashLenForLineMerge);
 
       }
@@ -568,7 +568,7 @@ public class GetFeaturesByBBoxTweaked<E extends GetFeaturesByBBoxEvent, R extend
     final SQLQuery query = new SQLQuery("SELECT * FROM (SELECT ${{jsonData}}, ${{geo}} AS geo FROM ${schema}.${table} ${{sampling}} WHERE ${{indexedQuery}} ${{searchQuery}} ${{orderBy}}) tw ${{outerWhereClause}} LIMIT #{limit}")
         .withVariable(SCHEMA, getSchema())
         .withVariable(TABLE, readTableFromEvent(event) + HEAD_TABLE_SUFFIX)
-        .withQueryFragment("jsonData", buildJsonDataFragment(event))
+        .withQueryFragment("jsonData", buildJsonDataFragment(event, 0))
         .withQueryFragment("geo", tweaksgeo)
         .withQueryFragment("sampling", "")
         .withQueryFragment("indexedQuery", indexedQuery)

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeaturesByGeometryBuilder.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeaturesByGeometryBuilder.java
@@ -20,6 +20,7 @@
 package com.here.xyz.psql.query;
 
 import static com.here.xyz.models.hub.Ref.HEAD;
+import static com.here.xyz.psql.query.GetFeaturesByBBox.buildGeoFilterFromBbox;
 
 import com.here.xyz.connectors.ErrorResponseException;
 import com.here.xyz.events.ContextAwareEvent.SpaceContext;
@@ -122,16 +123,14 @@ public class GetFeaturesByGeometryBuilder extends XyzQueryBuilder<GetFeaturesByG
       return patchGeoFilter(super.buildGeoFilter(event));
     }
 
-    protected SQLQuery patchGeoFilter(SQLQuery geoFilterClause) {
+    //TODO: Check why this patch is necessary
+    private SQLQuery patchGeoFilter(SQLQuery geoFilterClause) {
       if(bbox != null)
-        return new SQLQuery("ST_MakeEnvelope(#{minLon}, #{minLat}, #{maxLon}, #{maxLat}, 4326)")
-              .withNamedParameter("minLon", bbox.minLon())
-              .withNamedParameter("minLat", bbox.minLat())
-              .withNamedParameter("maxLon", bbox.maxLon())
-              .withNamedParameter("maxLat", bbox.maxLat());
+        return buildGeoFilterFromBbox(bbox);
       return geoFilterClause;
     }
 
+    //TODO: Check why this patch is necessary
     private SQLQuery patchWhereClause(SQLQuery filterWhereClause, SQLQuery additionalFilterFragment) {
       if (additionalFilterFragment != null)
         return new SQLQuery("${{innerFilterWhereClause}} AND ${{customWhereClause}}")
@@ -140,6 +139,7 @@ public class GetFeaturesByGeometryBuilder extends XyzQueryBuilder<GetFeaturesByG
       return filterWhereClause;
     }
 
+    //TODO: Check why this override is necessary
     private SQLQuery overrideSelectClause(SQLQuery selectClause, SQLQuery selectClauseOverride) {
       if (selectClauseOverride != null)
         return new SQLQuery("${{selectClause}}")


### PR DESCRIPTION
- Also fix API response type to be always FEATURE_COLLECTION when requesting multiple versions of a feature
- Updated existing tests accordingly
- Add test to verify version 0 is always used for all features originating from the space that has been extended. If being overridden in the extension space, the default version-numbering system of extension space is used.