### PR TITLE
DS-1101: Implement named user input-sets for jobs

### DIFF
--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/Job.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/Job.java
@@ -37,6 +37,7 @@ import static com.here.xyz.util.Random.randomAlpha;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonView;
 import com.here.xyz.XyzSerializable;
 import com.here.xyz.jobs.RuntimeInfo.State;
@@ -89,6 +90,8 @@ public class Job implements XyzSerializable {
   private long updatedAt;
   @JsonView({Public.class, Static.class})
   private long keepUntil;
+  @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+  private Map<String, Input> inputs;
   //Caller defined properties:
   @JsonView(Static.class)
   private String owner;
@@ -637,6 +640,19 @@ public class Job implements XyzSerializable {
 
   public Job withKeepUntil(long keepUntil) {
     setKeepUntil(keepUntil);
+    return this;
+  }
+
+  public Map<String, Input> getInputs() {
+    return inputs;
+  }
+
+  public void setInputs(Map<String, Input> inputs) {
+    this.inputs = inputs;
+  }
+
+  public Job withInputs(Map<String, Input> inputs) {
+    setInputs(inputs);
     return this;
   }
 

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/Job.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/Job.java
@@ -29,6 +29,7 @@ import static com.here.xyz.jobs.RuntimeInfo.State.RESUMING;
 import static com.here.xyz.jobs.RuntimeInfo.State.RUNNING;
 import static com.here.xyz.jobs.RuntimeInfo.State.SUBMITTED;
 import static com.here.xyz.jobs.RuntimeInfo.State.SUCCEEDED;
+import static com.here.xyz.jobs.steps.Step.InputSet.DEFAULT_INPUT_SET_NAME;
 import static com.here.xyz.jobs.steps.inputs.Input.inputS3Prefix;
 import static com.here.xyz.jobs.steps.resources.Load.addLoads;
 import static com.here.xyz.util.Random.randomAlpha;
@@ -488,9 +489,13 @@ public class Job implements XyzSerializable {
   }
 
   public UploadUrl createUploadUrl(boolean compressed) {
+    return createUploadUrl(compressed, DEFAULT_INPUT_SET_NAME);
+  }
+
+  public UploadUrl createUploadUrl(boolean compressed, String setName) {
     return new UploadUrl()
         .withCompressed(compressed)
-        .withS3Key(inputS3Prefix(getId()) + "/" + UUID.randomUUID() + (compressed ? ".gz" : ""));
+        .withS3Key(inputS3Prefix(getId(), setName) + "/" + UUID.randomUUID() + (compressed ? ".gz" : ""));
   }
 
   public Future<Void> consumeInput(ModelBasedInput input) {
@@ -508,8 +513,8 @@ public class Job implements XyzSerializable {
     return Future.succeededFuture();
   }
 
-  public Future<List<Input>> loadInputs() {
-    return ASYNC.run(() -> Input.loadInputs(getId()));
+  public Future<List<Input>> loadInputs(String setName) {
+    return ASYNC.run(() -> Input.loadInputs(getId(), setName));
   }
 
   public Future<List<Output>> loadOutputs() {

--- a/xyz-jobs/xyz-job-service/src/main/resources/openapi.yaml
+++ b/xyz-jobs/xyz-job-service/src/main/resources/openapi.yaml
@@ -77,7 +77,7 @@ paths:
     post:
       tags:
         - "Manage Jobs"
-      summary: "Create job input"
+      summary: "Create a job input"
       description: "Creates a new input for a job"
       operationId: "postJobInputs"
       parameters:
@@ -99,6 +99,41 @@ paths:
       operationId: "getJobInputs"
       parameters:
         - $ref: "#/components/parameters/JobId"
+      responses:
+        "200":
+          $ref: "#/components/responses/JobInputsResponse"
+        "400":
+          $ref: "#/components/responses/ErrorResponse400"
+        "404":
+          $ref: "#/components/responses/ErrorResponse404"
+  /jobs/{jobId}/inputs/{setName}:
+    post:
+      tags:
+        - "Manage Jobs"
+      summary: "Create a named job input"
+      description: "Creates a new input for a job"
+      operationId: "postNamedJobInputs"
+      parameters:
+        - $ref: "#/components/parameters/JobId"
+        - $ref: "#/components/parameters/PayloadSetName"
+      requestBody:
+        $ref: "#/components/requestBodies/JobInputRequest"
+      responses:
+        "201":
+          $ref: "#/components/responses/JobInputResponse"
+        "400":
+          $ref: "#/components/responses/ErrorResponse400"
+        "404":
+          $ref: "#/components/responses/ErrorResponse404"
+    get:
+      tags:
+        - "Manage Jobs"
+      summary: "List job inputs of a named set"
+      description: "Lists the available inputs of a named set of a job"
+      operationId: "getNamedJobInputs"
+      parameters:
+        - $ref: "#/components/parameters/JobId"
+        - $ref: "#/components/parameters/PayloadSetName"
       responses:
         "200":
           $ref: "#/components/responses/JobInputsResponse"
@@ -177,6 +212,13 @@ components:
       name: jobId
       in: path
       description: The unique identifier of the job.
+      required: true
+      schema:
+        type: string
+    PayloadSetName:
+      name: setName
+      in: path
+      description: The name of a set of payloads.
       required: true
       schema:
         type: string

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/Step.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/Step.java
@@ -19,7 +19,6 @@
 
 package com.here.xyz.jobs.steps;
 
-import static com.here.xyz.jobs.steps.Step.InputSet.USER_INPUTS;
 import static com.here.xyz.jobs.steps.Step.InputSet.USER_PROVIDER;
 import static com.here.xyz.jobs.steps.Step.Visibility.USER;
 import static com.here.xyz.jobs.steps.inputs.Input.defaultBucket;
@@ -601,7 +600,7 @@ public abstract class Step<T extends Step> implements Typed, StepExecution {
 
   @JsonIgnore
   protected boolean isUserInputsExpected() {
-    return getInputSets().stream().anyMatch(inputSet -> USER_INPUTS.get().equals(inputSet));
+    return getInputSets().stream().anyMatch(inputSet -> USER_PROVIDER.equals(inputSet.stepId));
   }
 
   @JsonIgnore

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/execution/RunEmrJob.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/execution/RunEmrJob.java
@@ -53,8 +53,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 public class RunEmrJob extends LambdaBasedStep<RunEmrJob> {
-
-  public static final String USER_REF = "USER";
   public static final String EMR_JOB_NAME_PREFIX = "step:";
   private static final Logger logger = LogManager.getLogger();
   private static final String INPUT_SET_REF_PREFIX = "${inputSet:";
@@ -477,16 +475,12 @@ public class RunEmrJob extends LambdaBasedStep<RunEmrJob> {
   }
 
   private static String toReferenceIdentifier(InputSet inputSet) {
-    return inputSet.name() == null ? USER_REF : (inputSet.stepId() + "." + inputSet.name());
+    return inputSet.stepId() + "." + inputSet.name();
   }
 
   InputSet fromReferenceIdentifier(String referenceIdentifier) {
-    if (USER_REF.equals(referenceIdentifier))
-      return getInputSet(null, null);
-    else {
-      ReferenceIdentifier ref = ReferenceIdentifier.fromString(referenceIdentifier);
-      return getInputSet(ref.stepId(), ref.name());
-    }
+    ReferenceIdentifier ref = ReferenceIdentifier.fromString(referenceIdentifier);
+    return getInputSet(ref.stepId(), ref.name());
   }
 
   protected InputSet getInputSet(String stepId, String name) {
@@ -497,8 +491,7 @@ public class RunEmrJob extends LambdaBasedStep<RunEmrJob> {
           .get();
     }
     catch (NoSuchElementException e) {
-      throw new IllegalArgumentException("No input set \"" + (name == null ? "<USER-INPUTS>" : stepId + "." + name) + "\" exists in step \""
-          + getId() + "\"");
+      throw new IllegalArgumentException("No input set \"" + stepId + "." + name + "\" exists in step \"" + getId() + "\"");
     }
   }
 

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/inputs/Input.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/inputs/Input.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2024 HERE Europe B.V.
+ * Copyright (C) 2017-2025 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,8 +70,16 @@ public abstract class Input <T extends Input> extends StepPayload<T> {
     return jobId + "/inputs";
   }
 
-  private static String inputMetaS3Key(String jobId) {
-    return jobId + "/meta/inputs.json";
+  public static String inputS3Prefix(String jobId, String setName) {
+    return jobId + "/inputs/" + setName;
+  }
+
+  private static String inputMetaS3Prefix(String jobId) {
+    return jobId + "/meta";
+  }
+
+  private static String inputMetaS3Key(String jobId, String setName) {
+    return inputMetaS3Prefix(jobId) + "/" + setName + ".json";
   }
 
   public static String defaultBucket() {
@@ -106,22 +114,22 @@ public abstract class Input <T extends Input> extends StepPayload<T> {
       return (T) this;
   }
 
-  public static List<Input> loadInputs(String jobId) {
+  public static List<Input> loadInputs(String jobId, String setName) {
     //Only cache inputs of jobs which are submitted already
     if (inputsCacheActive.contains(jobId)) {
       List<Input> inputs = inputsCache.get(jobId);
       if (inputs == null) {
-        inputs = loadInputsAndWriteMetadata(jobId, -1, Input.class);
+        inputs = loadInputsAndWriteMetadata(jobId, setName, -1, Input.class);
         inputsCache.put(jobId, inputs);
       }
       return inputs;
     }
-    return loadInputsAndWriteMetadata(jobId, -1, Input.class);
+    return loadInputsAndWriteMetadata(jobId, setName, -1, Input.class);
   }
 
-  private static <T extends Input> List<T> loadInputsAndWriteMetadata(String jobId, int maxReturnSize, Class<T> inputType) {
+  private static <T extends Input> List<T> loadInputsAndWriteMetadata(String jobId, String setName, int maxReturnSize, Class<T> inputType) {
     try {
-      InputsMetadata metadata = loadMetadata(jobId);
+      InputsMetadata metadata = loadMetadata(jobId, setName);
       Stream<T> inputs = metadata.inputs.entrySet().stream()
           .filter(input -> input.getValue().byteSize > 0)
           .map(metaEntry -> {
@@ -139,38 +147,44 @@ public abstract class Input <T extends Input> extends StepPayload<T> {
     }
     catch (IOException | AmazonS3Exception ignore) {}
 
-    final List<T> inputs = loadInputsInParallel(defaultBucket(), inputS3Prefix(jobId), maxReturnSize, inputType);
+    final List<T> inputs = loadInputsInParallel(defaultBucket(), inputS3Prefix(jobId, setName), maxReturnSize, inputType);
     //Only write metadata of jobs which are submitted already
     if (inputs != null && inputs.size() > 0 && inputsCacheActive.contains(jobId))
-      storeMetadata(jobId, (List<Input>) inputs);
+      storeMetadata(jobId, (List<Input>) inputs, setName);
 
     return inputs;
   }
 
-  public static final S3Uri loadResolvedUserInputPrefixUri(String jobId) {
-    Optional<InputsMetadata> userInputsMetadata = loadMetadataIfExists(jobId);
+  public static final S3Uri loadResolvedUserInputPrefixUri(String jobId, String setName) {
+    Optional<InputsMetadata> userInputsMetadata = loadMetadataIfExists(jobId, setName);
     if (userInputsMetadata.isPresent())
       return userInputsMetadata.get().scannedFrom;
-    return new S3Uri(defaultBucket(), inputS3Prefix(jobId));
+    return new S3Uri(defaultBucket(), inputS3Prefix(jobId, setName));
   }
 
-  static final Optional<InputsMetadata> loadMetadataIfExists(String jobId) {
+  static List<String> loadAllInputSetNames(String jobId) {
+    return S3Client.getInstance().scanFolder(inputMetaS3Prefix(jobId)).stream()
+        .map(s3ObjectSummary -> s3ObjectSummary.getKey().substring(0, s3ObjectSummary.getKey().lastIndexOf(".json")))
+        .toList();
+  }
+
+  private static Optional<InputsMetadata> loadMetadataIfExists(String jobId, String setName) {
     try {
-      return Optional.of(loadMetadata(jobId));
+      return Optional.of(loadMetadata(jobId, setName));
     }
     catch (IOException | AmazonS3Exception e) {
       return Optional.empty();
     }
   }
 
-  static final InputsMetadata loadMetadata(String jobId) throws IOException, AmazonS3Exception {
+  static final InputsMetadata loadMetadata(String jobId, String setName) throws IOException, AmazonS3Exception {
     InputsMetadata metadata = metadataCache.get(jobId);
     if (metadata != null)
       return metadata;
 
     logger.info("Loading metadata from S3 for job {} ...", jobId);
     long t1 = Core.currentTimeMillis();
-    metadata = XyzSerializable.deserialize(S3Client.getInstance().loadObjectContent(inputMetaS3Key(jobId)),
+    metadata = XyzSerializable.deserialize(S3Client.getInstance().loadObjectContent(inputMetaS3Key(jobId, setName)),
         InputsMetadata.class);
     logger.info("Loaded metadata for job {}. Took {}ms ...", jobId, Core.currentTimeMillis() - t1);
     if (inputsCacheActive.contains(jobId))
@@ -179,11 +193,19 @@ public abstract class Input <T extends Input> extends StepPayload<T> {
     return metadata;
   }
 
-  static final void storeMetadata(String jobId, InputsMetadata metadata) {
+  static final void addInputReferences(String referencedJobId, String referencingJobId, String setName) throws IOException,
+      AmazonS3Exception {
+    InputsMetadata referencedMetadata = loadMetadata(referencedJobId, setName);
+    //Add the referencing job to the list of jobs referencing the metadata
+    referencedMetadata.referencingJobs().add(referencingJobId);
+    storeMetadata(referencedJobId, referencedMetadata, setName);
+  }
+
+  static final void storeMetadata(String jobId, InputsMetadata metadata, String setName) {
     try {
       if (inputsCacheActive.contains(jobId))
         metadataCache.put(jobId, metadata);
-      S3Client.getInstance().putObject(inputMetaS3Key(jobId), "application/json", metadata.serialize());
+      S3Client.getInstance().putObject(inputMetaS3Key(jobId, setName), "application/json", metadata.serialize());
     }
     catch (IOException e) {
       logger.error("Error writing inputs metadata file for job {}.", jobId, e);
@@ -191,20 +213,20 @@ public abstract class Input <T extends Input> extends StepPayload<T> {
     }
   }
 
-  private static void storeMetadata(String jobId, List<Input> inputs) {
-    storeMetadata(jobId, inputs, null);
+  private static void storeMetadata(String jobId, List<Input> inputs, String setName) {
+    storeMetadata(jobId, inputs, null, setName);
   }
 
-  static final void storeMetadata(String jobId, List<Input> inputs, String referencedJobId) {
-    storeMetadata(jobId, inputs, referencedJobId, new S3Uri(defaultBucket(), inputS3Prefix(jobId)));
+  static final void storeMetadata(String jobId, List<Input> inputs, String referencedJobId, String setName) {
+    storeMetadata(jobId, inputs, referencedJobId, new S3Uri(defaultBucket(), inputS3Prefix(jobId, setName)), setName);
   }
 
-  static final void storeMetadata(String jobId, List<Input> inputs, String referencedJobId, S3Uri scannedFrom) {
+  static final void storeMetadata(String jobId, List<Input> inputs, String referencedJobId, S3Uri scannedFrom, String setName) {
     logger.info("Storing inputs metadata for job {} ...", jobId);
     Map<String, InputMetadata> metadata = inputs.stream()
         .collect(Collectors.toMap(input -> (input.s3Bucket == null ? "" : "s3://" + input.s3Bucket + "/") + input.s3Key,
             input -> new InputMetadata(input.byteSize, input.compressed)));
-    storeMetadata(jobId, new InputsMetadata(metadata, new HashSet<>(Set.of(jobId)), referencedJobId, scannedFrom));
+    storeMetadata(jobId, new InputsMetadata(metadata, new HashSet<>(Set.of(jobId)), referencedJobId, scannedFrom), setName);
   }
 
   static final List<Input> loadInputsInParallel(String bucketName, String inputS3Prefix) {
@@ -233,12 +255,12 @@ public abstract class Input <T extends Input> extends StepPayload<T> {
     return inputs;
   }
 
-  public static int currentInputsCount(String jobId, Class<? extends Input> inputType) {
-    return (int) loadInputs(jobId).stream().filter(input -> inputType.isAssignableFrom(input.getClass())).count();
+  public static int currentInputsCount(String jobId, Class<? extends Input> inputType, String setName) {
+    return (int) loadInputs(jobId, setName).stream().filter(input -> inputType.isAssignableFrom(input.getClass())).count();
   }
 
-  public static <T extends Input> List<T> loadInputsSample(String jobId, int maxSampleSize, Class<T> inputType) {
-    return loadInputsAndWriteMetadata(jobId, maxSampleSize, inputType);
+  public static <T extends Input> List<T> loadInputsSample(String jobId, String setName, int maxSampleSize, Class<T> inputType) {
+    return loadInputsAndWriteMetadata(jobId, setName, maxSampleSize, inputType);
   }
 
   private static <T extends Input> List<T> loadAndTransformInputs(String bucketName, String inputS3Prefix, int maxReturnSize, Class<T> inputType) {
@@ -266,9 +288,14 @@ public abstract class Input <T extends Input> extends StepPayload<T> {
   }
 
   private static void deleteInputs(String owningJobId, String referencingJob) {
+    //TODO: Parallelize
+    loadAllInputSetNames(owningJobId).forEach(setName -> deleteInputs(owningJobId, referencingJob, setName));
+  }
+
+  private static void deleteInputs(String owningJobId, String referencingJob, String setName) {
     InputsMetadata metadata = null;
     try {
-      metadata = loadMetadata(owningJobId);
+      metadata = loadMetadata(owningJobId, setName);
       metadata.referencingJobs().remove(referencingJob);
     }
     catch (AmazonS3Exception | IOException ignore) {}
@@ -282,10 +309,10 @@ public abstract class Input <T extends Input> extends StepPayload<T> {
          */
         deleteInputs(metadata.referencedJob(), owningJobId);
 
-      S3Client.getInstance().deleteFolder(inputS3Prefix(owningJobId));
+      S3Client.getInstance().deleteFolder(inputS3Prefix(owningJobId, setName));
     }
     else if (metadata != null)
-      storeMetadata(owningJobId, metadata);
+      storeMetadata(owningJobId, metadata, setName);
   }
 
   private static Input createInput(String s3Bucket, String s3Key, long byteSize, boolean compressed) {

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/inputs/InputsFromS3.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/inputs/InputsFromS3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2024 HERE Europe B.V.
+ * Copyright (C) 2017-2025 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,11 +54,11 @@ public class InputsFromS3 extends Input<InputsFromS3> {
     return this;
   }
 
-  public void dereference(String forJob) {
+  public void dereference(String forJob, String setName) {
     //First load the inputs from the (foreign) bucket
     List<Input> inputs = loadInputsInParallel(getBucket(), getPrefix());
     inputs.forEach(input -> input.setS3Bucket(getBucket()));
     //Store the metadata for the job that accesses the bucket
-    storeMetadata(forJob, inputs, null, new S3Uri(getBucket(), getPrefix()));
+    storeMetadata(forJob, inputs, null, new S3Uri(getBucket(), getPrefix()), setName);
   }
 }

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/util/test/StepTestBase.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/util/test/StepTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2024 HERE Europe B.V.
+ * Copyright (C) 2017-2025 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 package com.here.xyz.jobs.util.test;
 
 import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
+import static com.here.xyz.jobs.steps.Step.InputSet.DEFAULT_INPUT_SET_NAME;
 import static com.here.xyz.jobs.steps.execution.LambdaBasedStep.LambdaStepRequest.RequestType.START_EXECUTION;
 import static com.here.xyz.jobs.steps.execution.LambdaBasedStep.LambdaStepRequest.RequestType.SUCCESS_CALLBACK;
 import static com.here.xyz.jobs.steps.impl.transport.TransportTools.getTemporaryJobTableName;
@@ -84,8 +85,6 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.checkerframework.checker.units.qual.C;
-
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.SdkBytes;
@@ -345,7 +344,7 @@ public class StepTestBase {
 
     DataSourceProvider dsp = getDataSourceProvider();
 
-    if(   step instanceof ExportSpaceToFiles 
+    if(   step instanceof ExportSpaceToFiles
        || step instanceof CountSpace ){
       waitTillTaskItemsAreFinalized(step);
     }else{
@@ -428,7 +427,7 @@ public class StepTestBase {
   }
 
   public void uploadInputFile(String jobId, byte[] bytes, S3ContentType contentType) throws IOException {
-    uploadFileToS3(inputS3Prefix(jobId) + "/" + UUID.randomUUID(), contentType, bytes, false);
+    uploadFileToS3(inputS3Prefix(jobId, DEFAULT_INPUT_SET_NAME) + "/" + UUID.randomUUID(), contentType, bytes, false);
   }
 
   protected void uploadFileToS3(String s3Key, S3ContentType contentType, byte[] data, boolean gzip) throws IOException {


### PR DESCRIPTION
This change enables the user to define multiple input sets that are distinguishable by names. Depending on the expectations of the job, the different input sets can be assigned to be used for different purposes by the job compiler.

The change is backwards compatible. If the user provides an "unnamed" input-set it has the default name "inputs".

- Also support passing inputs of type InputsFromS3 directly within the job payload