### PR TITLE
DS-1357: Add workaround for issue with parallel index-creation in Postgres

### DIFF
--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/compiler/ImportFromFiles.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/compiler/ImportFromFiles.java
@@ -163,7 +163,7 @@ public class ImportFromFiles implements JobCompilationInterceptor {
   private static CompilationStepGraph compileOnDemandIndexSteps(String spaceId) throws CompilationError {
 
     Map<String, Boolean> activatedSearchableProperties = getActiveSearchableProperties(spaceId);
-    CompilationStepGraph onDemandIndicesGraph = (CompilationStepGraph) new CompilationStepGraph().withParallel(false);
+    CompilationStepGraph onDemandIndicesGraph = (CompilationStepGraph) new CompilationStepGraph().withParallel(true);
 
     for(String property : activatedSearchableProperties.keySet()) {
       if (activatedSearchableProperties.get(property)) {

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/CreateIndex.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/CreateIndex.java
@@ -23,14 +23,18 @@ import static com.here.xyz.util.db.pg.IndexHelper.buildAsyncOnDemandIndexQuery;
 import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.buildSpaceTableIndexQuery;
 
 import com.fasterxml.jackson.annotation.JsonView;
+import com.here.xyz.jobs.steps.execution.StepException;
 import com.here.xyz.jobs.steps.impl.tools.ResourceAndTimeCalculator;
 import com.here.xyz.jobs.steps.resources.Load;
 import com.here.xyz.jobs.steps.resources.TooManyResourcesClaimed;
+import com.here.xyz.util.db.SQLQuery;
 import com.here.xyz.util.db.pg.XyzSpaceTableHelper.Index;
 import com.here.xyz.util.db.pg.XyzSpaceTableHelper.OnDemandIndex;
 import com.here.xyz.util.db.pg.XyzSpaceTableHelper.SystemIndex;
+import com.here.xyz.util.service.BaseHttpServerVerticle.ValidationException;
 import com.here.xyz.util.web.XyzWebClient.WebClientException;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import org.apache.logging.log4j.LogManager;
@@ -45,7 +49,7 @@ public class CreateIndex extends SpaceBasedStep<CreateIndex> {
 
   @Override
   public List<Load> getNeededResources() {
-    try{
+    try {
       double acus = ResourceAndTimeCalculator.getInstance().calculateNeededIndexAcus(getUncompressedUploadBytesEstimation(), index);
       logger.info("[{}] {} neededACUs {}", getGlobalStepId(), index, acus);
 
@@ -69,7 +73,8 @@ public class CreateIndex extends SpaceBasedStep<CreateIndex> {
   @Override
   public int getEstimatedExecutionSeconds() {
     if (estimatedSeconds < 0) {
-      estimatedSeconds = ResourceAndTimeCalculator.getInstance().calculateIndexCreationTimeInSeconds(getSpaceId(), getUncompressedUploadBytesEstimation() , index);
+      estimatedSeconds = ResourceAndTimeCalculator.getInstance()
+          .calculateIndexCreationTimeInSeconds(getSpaceId(), getUncompressedUploadBytesEstimation(), index);
       logger.info("[{}] {} estimatedSeconds {}", getGlobalStepId(), index, estimatedSeconds);
     }
     return estimatedSeconds;
@@ -81,20 +86,67 @@ public class CreateIndex extends SpaceBasedStep<CreateIndex> {
   }
 
   @Override
+  public boolean validate() throws ValidationException {
+    if (!(index instanceof SystemIndex || index instanceof OnDemandIndex))
+      throw new StepException("Creating index " + index + " is not supported. Invalid index-type: " + index.getClass().getSimpleName());
+    return super.validate();
+  }
+
+  @Override
   public void execute(boolean resume) throws SQLException, TooManyResourcesClaimed, WebClientException {
     /*
     NOTE: In case of resume, no cleanup needed, in any case, sending the index creation query again will work
     as it is using the "CREATE INDEX IF NOT EXISTS" semantics
      */
-    logger.info("Creating the index " +  index + " for space " + getSpaceId() + " ...");
-    if(index instanceof SystemIndex) {
-      runWriteQueryAsync(buildSpaceTableIndexQuery(getSchema(db()), getRootTableName(space()), index), db(),
-              ResourceAndTimeCalculator.getInstance().calculateNeededIndexAcus(getUncompressedUploadBytesEstimation(), index));
-    }else if (index instanceof OnDemandIndex onDemandIndex) {
-      runWriteQueryAsync(buildAsyncOnDemandIndexQuery(getSchema(db()), getRootTableName(space()), onDemandIndex.getPropertyPath()),
-              db(),
-              ResourceAndTimeCalculator.getInstance().calculateNeededIndexAcus(getUncompressedUploadBytesEstimation(), index));
-    }
+    logger.info("[{}] Creating the index {} for space {} ...", getGlobalStepId(), index, getSpaceId());
+    SQLQuery indexCreationQuery = null;
+    if (index instanceof SystemIndex)
+      indexCreationQuery = buildSpaceTableIndexQuery(getSchema(db()), getRootTableName(space()), index);
+    else if (index instanceof OnDemandIndex onDemandIndex)
+      indexCreationQuery = buildOnDemandIndexCreationQuery(onDemandIndex);
+
+    runWriteQueryAsync(indexCreationQuery, db(), ResourceAndTimeCalculator.getInstance().calculateNeededIndexAcus(getUncompressedUploadBytesEstimation(), index));
+  }
+
+  private SQLQuery buildOnDemandIndexCreationQuery(OnDemandIndex onDemandIndex) throws WebClientException, SQLException,
+      TooManyResourcesClaimed {
+    //return buildAsyncOnDemandIndexQuery(getSchema(db()), getRootTableName(space()), onDemandIndex.getPropertyPath());
+    /*
+    TODO: Remove the following workaround once the following PostgreSQL bug was fixed:
+     https://postgrespro.com/list/id/18959-f63b53b864bb1417@postgresql.org
+     */
+    String rootTableName = getRootTableName(space());
+    String schema = getSchema(db());
+    List<SQLQuery> indexCreationQueries = new ArrayList<>();
+
+    indexCreationQueries.addAll(loadPartitionNamesOf(rootTableName).stream()
+        .map(partitionTableName -> new SQLQuery(buildAsyncOnDemandIndexQuery(schema, partitionTableName, onDemandIndex.getPropertyPath()).toExecutableQueryString()))
+        .toList());
+    indexCreationQueries.add(new SQLQuery(buildAsyncOnDemandIndexQuery(schema, rootTableName, onDemandIndex.getPropertyPath()).toExecutableQueryString()));
+
+    return SQLQuery.join(indexCreationQueries, ";");
+  }
+
+  private List<String> loadPartitionNamesOf(String rootTableName) throws WebClientException, SQLException, TooManyResourcesClaimed {
+    return runReadQuerySync(new SQLQuery("""
+        SELECT
+          c.relname AS partition_name
+        FROM
+          pg_class c
+        JOIN
+          pg_namespace n ON n.oid = c.relnamespace
+        WHERE
+          c.oid IN (SELECT inhrelid::regclass
+                FROM pg_inherits
+                WHERE inhparent = '${schema}.${rootTableName}'::regclass);
+        """)
+        .withVariable("schema", getSchema(db()))
+        .withVariable("rootTableName", rootTableName), db(), 0, rs -> {
+      List<String> partitionNames = new ArrayList<>();
+      while (rs.next())
+        partitionNames.add(rs.getString("partition_name"));
+      return partitionNames;
+    });
   }
 
   public Index getIndex() {


### PR DESCRIPTION
- Add workaround to CreateIndex step to first create indices on all partitions and then on the root table
- Also re-activate parallel on-demand index creation in ImportFromFiles compiler See: https://postgrespro.com/list/id/18959-f63b53b864bb1417@postgresql.org