### PR TITLE
DS-1184: Some S3 resource utilization improvements

### DIFF
--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/util/S3Client.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/util/S3Client.java
@@ -34,7 +34,6 @@ public class S3Client extends com.here.xyz.util.service.aws.s3.S3Client {
 
   protected S3Client(String bucketName) {
     super(bucketName);
-
   }
 
   @Override
@@ -58,7 +57,7 @@ public class S3Client extends com.here.xyz.util.service.aws.s3.S3Client {
     return getInstance(Config.instance.JOBS_S3_BUCKET);
   }
 
-  public static S3Client getInstance(String bucketName) {
+  public synchronized static S3Client getInstance(String bucketName) {
     if (!instances.containsKey(bucketName))
       instances.put(bucketName, new S3Client(bucketName));
     return instances.get(bucketName);

--- a/xyz-util/src/main/java/com/here/xyz/util/service/aws/AwsClientFactoryBase.java
+++ b/xyz-util/src/main/java/com/here/xyz/util/service/aws/AwsClientFactoryBase.java
@@ -23,6 +23,7 @@ import com.here.xyz.util.service.BaseConfig;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
@@ -54,7 +55,8 @@ public class AwsClientFactoryBase {
   }
 
   public static S3ClientBuilder s3(String region) {
-    S3ClientBuilder builder = prepareClient(S3Client.builder());
+    S3ClientBuilder builder = prepareClient(S3Client.builder()
+        .httpClientBuilder(ApacheHttpClient.builder().maxConnections(200)));
     if (isLocal())
       builder.forcePathStyle(true);
     return builder;

--- a/xyz-util/src/main/java/com/here/xyz/util/service/aws/s3/S3Client.java
+++ b/xyz-util/src/main/java/com/here/xyz/util/service/aws/s3/S3Client.java
@@ -93,8 +93,8 @@ public class S3Client {
 
   protected String identifyBucketRegion(String bucketName) {
     String bucketRegion = Regions.US_EAST_1.getName();
-    try {
-      s3(bucketRegion).build().headBucket(HeadBucketRequest.builder().bucket(bucketName).build());
+    try (software.amazon.awssdk.services.s3.S3Client awsS3Client = s3(bucketRegion).build()) {
+      awsS3Client.headBucket(HeadBucketRequest.builder().bucket(bucketName).build());
     }
     catch (S3Exception e) {
       SdkHttpResponse httpResponse = e.awsErrorDetails().sdkHttpResponse();
@@ -106,7 +106,7 @@ public class S3Client {
     return bucketRegion;
   }
 
-  public static S3Client getInstance(String bucketName) {
+  public synchronized static S3Client getInstance(String bucketName) {
     if (!instances.containsKey(bucketName))
       instances.put(bucketName, new S3Client(bucketName));
     return instances.get(bucketName);


### PR DESCRIPTION
- Ensure that only one (shared) S3Client is created per bucket. If the bucket region is unknown it could take a bit longer to create the S3Client. In that case, the synchronization of #getInstance() ensures that the S3Client will not be created multiple times for the bucket to not block too many HTTP connections
- Increase the default max. number of S3 connections
- Ensure to close the temporary S3 client in S3Client#identifyBucketRegion()