### PR TITLE
DS-1184: Improve FeatureWriter to execute only one loadFeature-query …

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/task/FeatureHandler.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/task/FeatureHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2024 HERE Europe B.V.
+ * Copyright (C) 2017-2025 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,8 +25,6 @@ import static io.netty.handler.codec.http.HttpResponseStatus.BAD_GATEWAY;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.FORBIDDEN;
 import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
-import static io.netty.handler.codec.http.HttpResponseStatus.METHOD_NOT_ALLOWED;
-import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 import static io.netty.handler.codec.http.HttpResponseStatus.PRECONDITION_REQUIRED;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
@@ -224,7 +222,8 @@ public class FeatureHandler {
 
   public static void checkIsActive(Space space) throws HttpException {
     if (!space.isActive())
-      throw new DetailedHttpException("E318451", Map.of("resourceId", space.getId()));
+      throw new HttpException(PRECONDITION_REQUIRED,
+          "The method is not allowed, because the resource \"" + space.getId() + "\" is not active.");
   }
 
   public static Future<Void> resolveExtendedSpaces(Marker marker, Space compositeSpace) {

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/SpaceBasedStep.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/SpaceBasedStep.java
@@ -248,6 +248,8 @@ public abstract class SpaceBasedStep<T extends SpaceBasedStep> extends DatabaseB
   }
 
   protected Space superSpace() throws WebClientException {
+    if (space().getExtension() == null)
+      return null;
     return space(space().getExtension().getSpaceId());
   }
 

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/ImportFilesToSpace.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/ImportFilesToSpace.java
@@ -19,6 +19,7 @@
 
 package com.here.xyz.jobs.steps.impl.transport;
 
+import static com.here.xyz.events.ContextAwareEvent.SpaceContext.DEFAULT;
 import static com.here.xyz.events.ContextAwareEvent.SpaceContext.EXTENSION;
 import static com.here.xyz.events.UpdateStrategy.DEFAULT_UPDATE_STRATEGY;
 import static com.here.xyz.jobs.steps.Step.Visibility.USER;
@@ -34,12 +35,12 @@ import static com.here.xyz.jobs.steps.impl.transport.TransportTools.Phase.STEP_E
 import static com.here.xyz.jobs.steps.impl.transport.TransportTools.Phase.STEP_ON_ASYNC_SUCCESS;
 import static com.here.xyz.jobs.steps.impl.transport.TransportTools.Phase.STEP_ON_STATE_CHECK;
 import static com.here.xyz.jobs.steps.impl.transport.TransportTools.buildTemporaryJobTableDropStatement;
-import static com.here.xyz.jobs.steps.impl.transport.TransportTools.createQueryContext;
 import static com.here.xyz.jobs.steps.impl.transport.TransportTools.errorLog;
 import static com.here.xyz.jobs.steps.impl.transport.TransportTools.getTemporaryJobTableName;
 import static com.here.xyz.jobs.steps.impl.transport.TransportTools.infoLog;
 import static com.here.xyz.util.web.XyzWebClient.WebClientException;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.here.xyz.events.UpdateStrategy;
@@ -61,6 +62,8 @@ import com.here.xyz.jobs.util.S3Client;
 import com.here.xyz.models.hub.Space;
 import com.here.xyz.responses.StatisticsResponse;
 import com.here.xyz.util.db.SQLQuery;
+import com.here.xyz.util.db.pg.FeatureWriterQueryBuilder;
+import com.here.xyz.util.db.pg.FeatureWriterQueryBuilder.FeatureWriterQueryContextBuilder;
 import com.here.xyz.util.service.BaseHttpServerVerticle.ValidationException;
 import com.here.xyz.util.service.Core;
 import io.vertx.core.json.JsonObject;
@@ -600,6 +603,8 @@ public class ImportFilesToSpace extends SpaceBasedStep<ImportFilesToSpace> {
     String triggerFunction = "import_from_s3_trigger_for_non_empty_layer";
     String superTable = space().getExtension() != null ? getRootTableName(superSpace()) : null;
 
+    List<String> tables = superTable == null ? List.of(getRootTableName(space())) : List.of(superTable, getRootTableName(space()));
+
     //TODO: Check if we can forward the whole transaction to the FeatureWriter rather than doing it for each row
     return new SQLQuery("""
         CREATE OR REPLACE TRIGGER insertTrigger BEFORE INSERT ON ${schema}.${table} 
@@ -613,10 +618,9 @@ public class ImportFilesToSpace extends SpaceBasedStep<ImportFilesToSpace> {
              ${{onMergeConflict}},
              ${{historyEnabled}},
              ${{context}},
-             ${{extendedTable}},
+             ${{tables}},
              '${{format}}',
-             '${{entityPerLine}}',
-             '${{targetTable}}'
+             '${{entityPerLine}}'
              )
         """)
         .withQueryFragment("spaceVersion", Long.toString(newVersion))
@@ -629,10 +633,9 @@ public class ImportFilesToSpace extends SpaceBasedStep<ImportFilesToSpace> {
             updateStrategy.onMergeConflict() == null ? "NULL" : "'" + updateStrategy.onMergeConflict() + "'")
         .withQueryFragment("historyEnabled", "" + (space().getVersionsToKeep() > 1))
         .withQueryFragment("context", superTable == null ? "NULL" : "'DEFAULT'")
-        .withQueryFragment("extendedTable", superTable == null ? "NULL" : "'" + superTable + "'")
+        .withQueryFragment("tables", String.join(",", tables.stream().map(table -> "'" + table + "'").toList()))
         .withQueryFragment("format", format.toString())
         .withQueryFragment("entityPerLine", entityPerLine.toString())
-        .withQueryFragment("targetTable", getRootTableName(space()))
         .withVariable("schema", getSchema(db()))
         .withVariable("triggerFunction", triggerFunction)
         .withVariable("table", getTemporaryTriggerTableName(getId()));
@@ -659,7 +662,6 @@ public class ImportFilesToSpace extends SpaceBasedStep<ImportFilesToSpace> {
   }
 
   private SQLQuery buildImportQuery() throws WebClientException {
-
     SQLQuery successQuery = buildSuccessCallbackQuery();
     SQLQuery failureQuery = buildFailureCallbackQuery();
 
@@ -677,35 +679,35 @@ public class ImportFilesToSpace extends SpaceBasedStep<ImportFilesToSpace> {
     return new SQLQuery("PERFORM pg_sleep(5)");
   }
 
+  @JsonIgnore
   private Map<String, Object> getQueryContext() throws WebClientException {
-    String superTable = space().getExtension() != null ? getRootTableName(superSpace()) : null;
-    return createQueryContext(getId(), getSchema(db()), getRootTableName(space()), (space().getVersionsToKeep() > 1), superTable);
+    Space superSpace = superSpace();
+    List<String> tables = new ArrayList<>();
+    if (superSpace != null)
+      tables.add(getRootTableName(superSpace));
+    tables.add(getRootTableName(space()));
+
+    return new FeatureWriterQueryContextBuilder()
+        .withSchema(getSchema(db()))
+        .withTables(tables)
+        .withSpaceContext(DEFAULT)
+        .withHistoryEnabled(space().getVersionsToKeep() > 1)
+        .withBatchMode(true)
+        .with("stepId", getId())
+        .build();
   }
 
   private SQLQuery buildFeatureWriterQuery(String featureList, long targetVersion) throws WebClientException, JsonProcessingException {
-    return new SQLQuery("""
-        SELECT (write_features::JSONB->>'count')::INT AS count FROM write_features(
-          #{featureList},
-          'Features',
-          #{author},
-          #{returnResult},
-          #{version},
-          #{onExists},
-          #{onNotExists},
-          #{onVersionConflict},
-          #{onMergeConflict},
-          #{isPartial}
-        );""")
-          .withNamedParameter("featureList", featureList)
-          .withNamedParameter("author", space().getOwner())
-          .withNamedParameter("returnResult", false)
-          .withNamedParameter("version", targetVersion)
-          .withNamedParameter("onExists", updateStrategy.onExists())
-          .withNamedParameter("onNotExists", updateStrategy.onNotExists())
-          .withNamedParameter("onVersionConflict", updateStrategy.onVersionConflict())
-          .withNamedParameter("onMergeConflict", updateStrategy.onMergeConflict())
-          .withNamedParameter("isPartial", false)
-          .withContext(getQueryContext());
+    return new SQLQuery("SELECT (write_features::JSONB->>'count')::INT AS count FROM ${{writeFeaturesQuery}};")
+        .withQueryFragment("writeFeaturesQuery", new FeatureWriterQueryBuilder()
+            .withInput(featureList, "Features")
+            .withAuthor(space().getOwner())
+            .withReturnResult(false)
+            .withVersion(targetVersion)
+            .withUpdateStrategy(updateStrategy)
+            .withIsPartial(false)
+            .withQueryContext(getQueryContext())
+            .build());
   }
 
   private SQLQuery buildProgressQuery(String schema, ImportFilesToSpace step) {

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/TransportTools.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/TransportTools.java
@@ -22,8 +22,6 @@ package com.here.xyz.jobs.steps.impl.transport;
 import com.here.xyz.jobs.steps.Step;
 import com.here.xyz.jobs.steps.impl.SpaceBasedStep;
 import com.here.xyz.util.db.SQLQuery;
-import java.util.HashMap;
-import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -42,27 +40,6 @@ public class TransportTools {
     return new SQLQuery("DROP TABLE IF EXISTS ${schema}.${table};")
         .withVariable("table", tableName)
         .withVariable("schema", schema);
-  }
-
-  protected static Map<String, Object> createQueryContext(String stepId, String schema, String table,
-      boolean historyEnabled, String superTable) {
-
-    Map<String, Object> queryContext = new HashMap<>(Map.of(
-        "stepId", stepId,
-        "schema", schema,
-        "table", table,
-        "historyEnabled", historyEnabled,
-        "batchMode", true
-    ));
-
-    if (superTable == null)
-      queryContext.put("context", null);
-    else {
-      queryContext.put("context", "DEFAULT");
-      queryContext.put("extendedTable", superTable);
-    }
-
-    return queryContext;
   }
 
   //TODO: Introduce proper logging methods at parent Step class level

--- a/xyz-jobs/xyz-job-steps/src/main/resources/jobs/transport.sql
+++ b/xyz-jobs/xyz-job-steps/src/main/resources/jobs/transport.sql
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2024 HERE Europe B.V.
+ * Copyright (C) 2017-2025 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -442,11 +442,10 @@ DECLARE
     onVersionConflict TEXT := TG_ARGV[5];
     onMergeConflict TEXT := TG_ARGV[6];
     historyEnabled BOOLEAN := TG_ARGV[7]::BOOLEAN;
-    context TEXT := TG_ARGV[8];
-    extendedTable TEXT := TG_ARGV[9];
+    spaceContext TEXT := TG_ARGV[8];
+    tables TEXT := TG_ARGV[9];
     format TEXT := TG_ARGV[10];
     entityPerLine TEXT := TG_ARGV[11];
-    targetTable TEXT := TG_ARGV[12];
     featureCount INT := 0;
     input TEXT;
     inputType TEXT;
@@ -481,10 +480,9 @@ BEGIN
         jsonb_build_object(
             'stepId', get_stepid_from_work_table(TG_TABLE_NAME::REGCLASS) ,
             'schema', TG_TABLE_SCHEMA,
-            'table', targetTable,
+            'tables', string_to_array(tables, ','),
             'historyEnabled', historyEnabled,
-            'context', CASE WHEN context = 'null' THEN null ELSE context END,
-            'extendedTable', CASE WHEN extendedTable = 'null' THEN null ELSE extendedTable END,
+            'context', CASE WHEN spaceContext = 'null' THEN null ELSE spaceContext END,
             'batchMode', inputType != 'Feature'
         )
     );
@@ -615,7 +613,7 @@ BEGIN
     RETURN NEXT;
 END
 $BODY$
-    LANGUAGE plpgsql IMMUTABLE;
+LANGUAGE plpgsql IMMUTABLE;
 
 -- ####################################################################################################################
 -- Export related:

--- a/xyz-util/src/main/java/com/here/xyz/util/db/pg/FeatureWriterQueryBuilder.java
+++ b/xyz-util/src/main/java/com/here/xyz/util/db/pg/FeatureWriterQueryBuilder.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright (C) 2017-2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.xyz.util.db.pg;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+
+import com.here.xyz.XyzSerializable;
+import com.here.xyz.events.ContextAwareEvent.SpaceContext;
+import com.here.xyz.events.UpdateStrategy;
+import com.here.xyz.events.WriteFeaturesEvent.Modification;
+import com.here.xyz.models.geojson.implementation.Feature;
+import com.here.xyz.models.geojson.implementation.FeatureCollection;
+import com.here.xyz.util.db.SQLQuery;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class FeatureWriterQueryBuilder {
+
+  private Object input;
+  private String inputType;
+  private String author;
+  private boolean returnResult = false;
+  private long version = -1;
+  private UpdateStrategy updateStrategy = null;
+  private boolean isPartial = false;
+  private Map<String, Object> queryContext;
+
+  public FeatureWriterQueryBuilder() {}
+
+  public FeatureWriterQueryBuilder withInput(String input, String inputType) {
+    this.input = input;
+    this.inputType = inputType;
+    return this;
+  }
+
+  public FeatureWriterQueryBuilder withInput(Modification input) {
+    return withModifications(List.of(input));
+  }
+
+  public FeatureWriterQueryBuilder withModifications(List<Modification> input) {
+    this.input = input;
+    return this;
+  }
+
+  public FeatureWriterQueryBuilder withInput(FeatureCollection input) {
+    this.input = input;
+    return this;
+  }
+
+  public FeatureWriterQueryBuilder withInput(List<Feature> input) {
+    this.input = input;
+    return this;
+  }
+
+  public FeatureWriterQueryBuilder withInput(Feature input) {
+    this.input = input;
+    return this;
+  }
+
+  public FeatureWriterQueryBuilder withAuthor(String author) {
+    this.author = author;
+    return this;
+  }
+
+  public FeatureWriterQueryBuilder withReturnResult(boolean returnResult) {
+    this.returnResult = returnResult;
+    return this;
+  }
+
+  public FeatureWriterQueryBuilder withVersion(long version) {
+    this.version = version;
+    return this;
+  }
+
+  public FeatureWriterQueryBuilder withUpdateStrategy(UpdateStrategy updateStrategy) {
+    this.updateStrategy = updateStrategy;
+    return this;
+  }
+
+  public FeatureWriterQueryBuilder withIsPartial(boolean isPartial) {
+    this.isPartial = isPartial;
+    return this;
+  }
+
+  public FeatureWriterQueryBuilder withQueryContext(Map<String, Object> queryContext) {
+    this.queryContext = queryContext;
+    return this;
+  }
+
+  public SQLQuery build() {
+    if (input == null)
+      throw new IllegalArgumentException("No input has been set for the FeatureWriter.");
+
+    if (input instanceof String && isNullOrEmpty(inputType))
+      throw new IllegalArgumentException("No input type has been set for the FeatureWriter.");
+
+    if (author == null)
+      throw new IllegalArgumentException("No author has been set for the FeatureWriter.");
+
+    if (queryContext == null)
+      throw new IllegalArgumentException("No queryContext has been set for the FeatureWriter.");
+
+    if (input instanceof List inputList && inputList.get(0) instanceof Modification) {
+      return new SQLQuery("write_features(#{jsonInput}, 'Modifications', #{author}, #{returnResult}, #{version})")
+          .withContext(queryContext)
+          .withNamedParameter("jsonInput", XyzSerializable.serialize(inputList))
+          .withNamedParameter("author", author)
+          .withNamedParameter("returnResult", returnResult)
+          .withNamedParameter("version", version <= 0 ? null : version);
+    }
+
+    return new SQLQuery("""
+        write_features(
+          #{jsonInput}, #{inputType}, #{author}, #{returnResult}, #{version},
+          #{onExists}, #{onNotExists}, #{onVersionConflict}, #{onMergeConflict}, #{isPartial}
+        )
+        """)
+        .withContext(queryContext)
+        .withNamedParameter("jsonInput", input instanceof String ? input : XyzSerializable.serialize(input))
+        .withNamedParameter("inputType", input instanceof String ? inputType : input instanceof List ? "Features" : input.getClass().getSimpleName())
+        .withNamedParameter("author", author)
+        .withNamedParameter("returnResult", returnResult)
+        .withNamedParameter("version", version <= 0 ? null : version)
+        .withNamedParameter("onExists", updateStrategy == null ? null : updateStrategy.onExists())
+        .withNamedParameter("onNotExists", updateStrategy == null ? null : updateStrategy.onNotExists())
+        .withNamedParameter("onVersionConflict", updateStrategy == null ? null : updateStrategy.onVersionConflict())
+        .withNamedParameter("onMergeConflict", updateStrategy == null ? null : updateStrategy.onMergeConflict())
+        .withNamedParameter("isPartial", isPartial);
+  }
+
+  public static class FeatureWriterQueryContextBuilder {
+
+    private Map<String, Object> queryContext = new HashMap<>();
+
+    public FeatureWriterQueryContextBuilder withSchema(String schema) {
+      queryContext.put("schema", schema);
+      return this;
+    }
+
+    public FeatureWriterQueryContextBuilder withTable(String table) {
+      return withTables(List.of(table));
+    }
+
+    public FeatureWriterQueryContextBuilder withTables(List<String> tables) {
+      queryContext.put("tables", tables);
+      return this;
+    }
+
+    public FeatureWriterQueryContextBuilder withSpaceContext(SpaceContext spaceContext) {
+      queryContext.put("context", spaceContext);
+      return this;
+    }
+
+    public FeatureWriterQueryContextBuilder withHistoryEnabled(boolean historyEnabled) {
+      queryContext.put("historyEnabled", historyEnabled);
+      return this;
+    }
+
+    public FeatureWriterQueryContextBuilder withBatchMode(boolean batchMode) {
+      queryContext.put("batchMode", batchMode);
+      return this;
+    }
+
+    public FeatureWriterQueryContextBuilder with(String key, Object value) {
+      queryContext.put(key, value);
+      return this;
+    }
+
+    public Map<String, Object> build() {
+      if (!queryContext.containsKey("schema"))
+        throw new IllegalArgumentException("No schema has been set for the queryContext.");
+
+      if (!queryContext.containsKey("table") && (!queryContext.containsKey("tables") || ((List<String>) queryContext.get("tables")).isEmpty()))
+        throw new IllegalArgumentException("No table has been set for the queryContext.");
+
+      return queryContext;
+    }
+  }
+}

--- a/xyz-util/src/main/resources/sql/FeatureWriter.js
+++ b/xyz-util/src/main/resources/sql/FeatureWriter.js
@@ -30,9 +30,7 @@ class FeatureWriter {
 
   //Context input fields
   schema;
-  table;
-  extendedTable;
-  extendedTableL2;
+  tables;
   context;
   historyEnabled;
 
@@ -69,9 +67,7 @@ class FeatureWriter {
     //   throw new IllegalArgumentException("onNotExists must not be \"CREATE\" for partial writes.");
 
     this.schema = queryContext().schema;
-    this.table = queryContext().table;
-    this.extendedTable = queryContext().extendedTable;
-    this.extendedTableL2 = queryContext().extendedTableL2;
+    this.tables = queryContext().tables;
     this.context = queryContext().context;
     this.historyEnabled = queryContext().historyEnabled;
 
@@ -511,15 +507,8 @@ class FeatureWriter {
     if (id == null)
       return null;
 
-    let res = this._loadFeature(id, version, this._targetTable(context));
-    if (context == "DEFAULT" && !res.length) {
-      res = this._loadFeature(id, version, this.extendedTable);
-      if (!res.length && this.extendedTableL2)
-        res = this._loadFeature(id, version, this.extendedTableL2);
-    }
-    else if (context == "SUPER" && !res.length && this.extendedTableL2)
-      res = this._loadFeature(id, version, this.extendedTableL2);
-
+    let tables = context == "EXTENSION" ? this.tables.slice(-1) : context == "SUPER" ? this.tables.slice(0, -1) : this.tables;
+    let res = this._loadFeature(id, version, tables);
 
     if (!res.length)
       return null;
@@ -705,21 +694,38 @@ class FeatureWriter {
   }
 
   static _targetTable(context = queryContext().context) {
-    return context == "SUPER" ? queryContext().extendedTable : queryContext().table;
+    return queryContext().tables[queryContext().tables.length - (context == "SUPER" ? 2 : 1)];
   }
 
   _targetTable(context = this.context) {
     return FeatureWriter._targetTable(context);
   }
 
-  _loadFeature(id, version, table) {
-    let sql = `SELECT id, version, author, jsondata, ST_AsGeojson(geo)::JSONB FROM "${this.schema}"."${table}"`;
+  _loadFeature(id, version, tables) {
+    let tableAliases = tables.map((table, i) => "t" + (tables.length - i - 1));
+    let whereCondition = `WHERE id = $1 AND ${version == "HEAD" ? "next_version" : "version"} = $2 AND operation != $3`;
 
-    let res = version == "HEAD"
-        //next_version + operation supports head retrieval if we have multiple versions
-        ? plv8.execute(sql + "WHERE id = $1 AND next_version = $2::BIGINT AND operation != $3", [id, MAX_BIG_INT, "D"])
-        : plv8.execute(sql + "WHERE id = $1 AND version = $2 AND operation != $3", [id, version, "D"]);
-    return res;
+    let sql = `
+        SELECT
+            id_array[index] AS id,
+            version_array[index] AS version,
+            author_array[index] AS author,
+            jsondata_array[index] AS jsondata,
+            ST_AsGeojson(geo_array[index])::JSONB AS geo
+        FROM (
+            SELECT
+                ARRAY[${tableAliases.map(alias => alias + ".id").join(", ")}] AS id_array,
+                ARRAY[${tableAliases.map(alias => alias + ".version").join(", ")}] AS version_array,
+                ARRAY[${tableAliases.map(alias => alias + ".author").join(", ")}] AS author_array,
+                ARRAY[${tableAliases.map(alias => alias + ".jsondata").join(", ")}] AS jsondata_array,
+                ARRAY[${tableAliases.map(alias => alias + ".geo").join(", ")}] AS geo_array,
+                coalesce_subscript(ARRAY[${tableAliases.map(alias => alias + ".id").join(", ")}]) AS index
+            FROM (SELECT * FROM "${this.schema}"."${tables[tables.length - 1]}" ${whereCondition}) AS ${tableAliases[0]}
+                ${tables.slice(0, -1).reverse().map((baseTable, i) => `FULL JOIN (SELECT * FROM "${this.schema}"."${baseTable}" ${whereCondition}) AS ${tableAliases[i + 1]} USING (id) `).join("\n")}
+        );
+    `;
+
+    return plv8.execute(sql, [id, version == "HEAD" ? MAX_BIG_INT : version, "D"]);
   }
 
   /**

--- a/xyz-util/src/test/java/com/here/xyz/test/featurewriter/sql/SQLSpaceWriter.java
+++ b/xyz-util/src/test/java/com/here/xyz/test/featurewriter/sql/SQLSpaceWriter.java
@@ -37,9 +37,9 @@ import com.here.xyz.test.SQLITBase;
 import com.here.xyz.test.featurewriter.SpaceWriter;
 import com.here.xyz.util.db.SQLQuery;
 import com.here.xyz.util.db.datasource.DataSourceProvider;
+import com.here.xyz.util.db.pg.FeatureWriterQueryBuilder.FeatureWriterQueryContextBuilder;
 import com.here.xyz.util.db.pg.SQLError;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -115,15 +115,13 @@ public class SQLSpaceWriter extends SpaceWriter {
   private SQLQuery generateWriteFeatureQuery(List<Feature> featureList, String author, OnExists onExists, OnNotExists onNotExists,
       OnVersionConflict onVersionConflict, OnMergeConflict onMergeConflict, boolean isPartial, SpaceContext spaceContext,
       boolean historyEnabled) {
-    final Map<String, Object> queryContext = new HashMap<>(Map.of(
-        "schema", getDataSourceProvider().getDatabaseSettings().getSchema(),
-        "table", spaceId(),
-        "context", spaceContext,
-        "historyEnabled", historyEnabled,
-        "batchMode", batchMode
-    ));
-    if (composite)
-      queryContext.put("extendedTable", superSpaceId());
+    final Map<String, Object> queryContext = new FeatureWriterQueryContextBuilder()
+        .withSchema(getDataSourceProvider().getDatabaseSettings().getSchema())
+        .withTables(composite ? List.of(superSpaceId(), spaceId()): List.of(spaceId()))
+        .withSpaceContext(spaceContext)
+        .withHistoryEnabled(historyEnabled)
+        .withBatchMode(batchMode)
+        .build();
 
     WriteFeaturesEvent.Modification modification = new
             WriteFeaturesEvent.Modification()

--- a/xyz-util/src/test/js/db/featurewriter/JsSpaceWriter.js
+++ b/xyz-util/src/test/js/db/featurewriter/JsSpaceWriter.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2024 HERE Europe B.V.
+ * Copyright (C) 2017-2025 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,12 +64,10 @@ class JsSpaceWriter {
   writeFeatureModification(modification, author, spaceContext, historyActive, expectedError) {
     let queryContext = {
       schema: this.schema,
-      table: this.spaceId,
+      tables: this.composite ? [this.superSpaceId, this.spaceId] : [this.spaceId],
       context: spaceContext,
       historyEnabled: historyActive
     };
-    if (this.composite)
-      queryContext.extendedTable = this.superSpaceId;
     global.queryContext = () => queryContext;
 
     try {

--- a/xyz-util/src/test/js/db/featurewriter/TestFeatureWriter.js
+++ b/xyz-util/src/test/js/db/featurewriter/TestFeatureWriter.js
@@ -27,9 +27,7 @@ const DatabaseWriter = plv8.DatabaseWriter;
 
 global.queryContext = () => ({
   schema: "public",
-  table: "composite-export-space-ext-ext",
-  extendedTable: "composite-export-space-ext",
-  extendedTableL2: "composite-export-space",
+  tables: ["composite-export-space", "composite-export-space-ext", "composite-export-space-ext-ext"],
   context: "DEFAULT",
   historyEnabled: false
 });


### PR DESCRIPTION
…for all involved tables

- Streamline FutureWriter to accept a list of tables (new field "tables") instead of the three composite standard tables only ("table", "extendedTable", "extendedTableL2")
- Also remove obsolete FeatureWriter fields "table", "extendedTable", "extendedTableL2" and adjust all calls to the FeatureWriter to specify the new "tables" parameter correctly
- Improve SpaceBasedStep#superSpace() to return null if the space has no super space instead of throwing an NPE
- Implement FeatureWriterQueryBuilder that helps to use the FeatureWriter
- Adjust ImportFilesToSpace to use new FeatureWriterQueryBuilder
- Remove obsolete method TransportTools#createQueryContext() as the new FeatureWriterQueryContextBuilder may be used from now on instead
- Fix FeatureHandler#checkIsActive() to respond with the correct status code