### PR TITLE
DS-1184: Fix FeatureWriter to not perform an update (on upsert) if the feature content was not modified

### DIFF
--- a/xyz-util/src/main/resources/sql/FeatureWriter.js
+++ b/xyz-util/src/main/resources/sql/FeatureWriter.js
@@ -332,7 +332,7 @@ class FeatureWriter {
           return null;
 
         let execution = this._upsertRow(execution => {
-          if (execution.action != ExecutionAction.UPDATED && this.onNotExists == "ERROR")
+          if (execution?.action != ExecutionAction.UPDATED && this.onNotExists == "ERROR")
             this._throwFeatureNotExistsError();
           return execution;
         });
@@ -814,7 +814,8 @@ class FeatureWriter {
     if (execution != null) {
       if (execution.action != ExecutionAction.DELETED)
         result.features.push(execution.feature);
-      result[execution.action].push(execution.feature.id);
+      if (execution.action != ExecutionAction.NONE)
+        result[execution.action].push(execution.feature.id);
     }
   }
 
@@ -852,6 +853,7 @@ class ExecutionAction {
   static INSERTED = "inserted";
   static UPDATED = "updated";
   static DELETED = "deleted";
+  static NONE = "none"; //To choose if no change was executed, but the feature should be still part of the result (e.g., for features for which an update was requested but the content was not differing from the existing version)
 
   static fromOperation = {
     "I": this.INSERTED,


### PR DESCRIPTION
- Adjust upsert-query, to perform the UPDATE only if the content would change (while ignoring XYZ-namespace properties)
- Introduce new ExecutionAction "NONE" to indicate that the FeatureWriter was actually not performing any action for a provided feature
- Enhance test UpdateFeatureApiIT#updateFeatureById_putNonModified() to also check the timestamps that actually have been written. Also check the written versions to ensure that actually no action was performed if the feature content of the feature did not change.
- Also fix issue with missing createdAt TS in upsert-result