### PR TITLE
DS-1475: Further streamlining of IterateChangesets

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/task/SpaceConnectorBasedHandler.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/task/SpaceConnectorBasedHandler.java
@@ -127,9 +127,10 @@ public class SpaceConnectorBasedHandler {
                 getChangesetStatisticsEvent.setMinTagVersion(minTag.getVersion());
                 getChangesetStatisticsEvent.setMinVersion(Math.min(minTag.getVersion(), space.getMinVersion()));
               }
-              else if (event instanceof IterateChangesetsEvent iterateChangesetsEvent && minTag != null) {
-                iterateChangesetsEvent.setMinVersion(minTag.getVersion());
+              else if (event instanceof IterateChangesetsEvent iterateChangesetsEvent) {
                 iterateChangesetsEvent.setVersionsToKeep(space.getVersionsToKeep());
+                if (minTag != null)
+                  iterateChangesetsEvent.setMinVersion(minTag.getVersion());
               }
               return Future.succeededFuture(space);
             });

--- a/xyz-hub-service/src/main/resources/openapi.yaml
+++ b/xyz-hub-service/src/main/resources/openapi.yaml
@@ -206,10 +206,14 @@ paths:
       summary: Get Changesets
       description: >-
         Retrieves a subset of existing Changesets from the space's history.
-        The subset is defined by a "startVersion" and an "endVersion".
+        The subset can be defined either by a "startVersion" and an "endVersion"
+        or by providing a version ref that references a version range
+        e.g., "5..6" or "0..HEAD"
+        
 
         Each successful write transaction to the space is stored as one single Changeset,
         which can contain modifications applied to one or more features.
+
 
         The response payload may be split in multiple pages. The next page token is written in the
         property 'nextPageToken', which then can be used to retrieve the next page using the
@@ -217,6 +221,7 @@ paths:
       operationId: getChangesets
       parameters:
         - $ref: '#/components/parameters/SpaceId'
+        - $ref: '#/components/parameters/VersionRef'
         - $ref: '#/components/parameters/StartVersion'
         - $ref: '#/components/parameters/EndVersion'
         - $ref: '#/components/parameters/PageToken'
@@ -1765,7 +1770,7 @@ components:
            "p.myNumber1": 5,
            "p.myNumber2=gte":7
           }
-          
+
     PropertiesSelection:
       name: selection
       in: query

--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/ChangesetCollectionApiIT.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/ChangesetCollectionApiIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2023 HERE Europe B.V.
+ * Copyright (C) 2017-2025 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,20 +20,16 @@
 package com.here.xyz.hub.rest;
 
 import static com.here.xyz.util.service.BaseHttpServerVerticle.HeaderValues.APPLICATION_JSON;
-import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
-import static io.netty.handler.codec.http.HttpResponseStatus.NO_CONTENT;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
 import com.here.xyz.models.geojson.implementation.Feature;
 import com.here.xyz.models.geojson.implementation.FeatureCollection;
 import com.here.xyz.models.geojson.implementation.Properties;
-import java.util.ArrayList;
 import java.util.Arrays;
 import org.junit.After;
 import org.junit.Before;
@@ -42,8 +38,8 @@ import org.junit.Test;
 
 public class ChangesetCollectionApiIT extends TestSpaceWithFeature {
 
-  private static String cleanUpSpaceId = "space1";
   protected static final String AUTHOR_1 = "XYZ-01234567-89ab-cdef-0123-456789aUSER1";
+  private static String cleanUpSpaceId = "space1";
 
   @BeforeClass
   public static void setupClass() {
@@ -65,141 +61,141 @@ public class ChangesetCollectionApiIT extends TestSpaceWithFeature {
   }
 
   private void addChangeSets() {
-	  FeatureCollection featureCollection = new FeatureCollection().withFeatures(
-		        Arrays.asList(
-		            new Feature().withId("A").withProperties(new Properties().with("name", "A1")),
-		            new Feature().withId("B").withProperties(new Properties().with("name", "B1"))
-		        )
-		    );
+    //Changeset 0 is the empty space
 
-			FeatureCollection featureCollection1 = new FeatureCollection().withFeatures(
-			        Arrays.asList(
-			            new Feature().withId("A").withProperties(new Properties().with("name", "A2")),
-			            new Feature().withId("C").withProperties(new Properties().with("name", "C1"))
-			        )
-			    );
-			FeatureCollection featureCollection2 = new FeatureCollection().withFeatures(
-			        Arrays.asList(
-			            new Feature().withId("B").withProperties(new Properties().with("name", "B2")),
-			            new Feature().withId("C").withProperties(new Properties().with("name", "C2"))
-			        )
-			    );
-			FeatureCollection featureCollection3 = new FeatureCollection().withFeatures(
-			        Arrays.asList(
-			            new Feature().withId("A").withProperties(new Properties().with("name", "A3")),
-			            new Feature().withId("C").withProperties(new Properties().with("name", "C3"))
-			        )
-			    );
-		    postFeatureCollection(AuthProfile.ACCESS_OWNER_1_ADMIN, featureCollection);
-		    postFeatureCollection(AuthProfile.ACCESS_OWNER_1_ADMIN, featureCollection1);
-		    postFeatureCollection(AuthProfile.ACCESS_OWNER_1_ADMIN, featureCollection2);
-		    postFeatureCollection(AuthProfile.ACCESS_OWNER_1_ADMIN, featureCollection3);
+    //Changeset 1
+    FeatureCollection featureCollection1 = new FeatureCollection().withFeatures(
+        Arrays.asList(
+            new Feature().withId("A").withProperties(new Properties().with("name", "A1")),
+            new Feature().withId("B").withProperties(new Properties().with("name", "B1"))
+        )
+    );
 
+    //Changeset 2
+    FeatureCollection featureCollection2 = new FeatureCollection().withFeatures(
+        Arrays.asList(
+            new Feature().withId("A").withProperties(new Properties().with("name", "A2")),
+            new Feature().withId("C").withProperties(new Properties().with("name", "C1"))
+        )
+    );
+
+    //Changeset 3
+    FeatureCollection featureCollection3 = new FeatureCollection().withFeatures(
+        Arrays.asList(
+            new Feature().withId("B").withProperties(new Properties().with("name", "B2")),
+            new Feature().withId("C").withProperties(new Properties().with("name", "C2"))
+        )
+    );
+
+    //Changeset 4
+    FeatureCollection featureCollection4 = new FeatureCollection().withFeatures(
+        Arrays.asList(
+            new Feature().withId("A").withProperties(new Properties().with("name", "A3")),
+            new Feature().withId("C").withProperties(new Properties().with("name", "C3"))
+        )
+    );
+    postFeatureCollection(AuthProfile.ACCESS_OWNER_1_ADMIN, featureCollection1);
+    postFeatureCollection(AuthProfile.ACCESS_OWNER_1_ADMIN, featureCollection2);
+    postFeatureCollection(AuthProfile.ACCESS_OWNER_1_ADMIN, featureCollection3);
+    postFeatureCollection(AuthProfile.ACCESS_OWNER_1_ADMIN, featureCollection4);
   }
+
   private void postFeatureCollection(AuthProfile authProfile, FeatureCollection featureCollection) {
     given()
-            .contentType(APPLICATION_JSON)
-            .headers(getAuthHeaders(authProfile))
-            .body(featureCollection.toString())
-            .post("/spaces/" + cleanUpSpaceId + "/features")
-            .then()
-            .statusCode(OK.code());
+        .contentType(APPLICATION_JSON)
+        .headers(getAuthHeaders(authProfile))
+        .body(featureCollection.toString())
+        .post("/spaces/" + cleanUpSpaceId + "/features")
+        .then()
+        .statusCode(OK.code());
   }
 
   @Test
   public void validateAllCollection() {
-   
-	addChangeSets();
-	
+    addChangeSets();
+
     given()
-            .get("/spaces/" + cleanUpSpaceId + "/changesets")
-            .then()
-            .statusCode(OK.code())
-            .body("startVersion", equalTo(1))
-            .body("endVersion", equalTo(4))
+        .get("/spaces/" + cleanUpSpaceId + "/changesets")
+        .then()
+        .statusCode(OK.code())
+        .body("startVersion", equalTo(1))
+        .body("endVersion", equalTo(4))
 
-            .body("versions.1.inserted.features.size()", equalTo(2))
-            .body("versions.1.updated.features.size()", equalTo(0))
-            .body("versions.1.deleted.features.size()", equalTo(0))
-            .body("versions.1.author", equalTo(AUTHOR_1))
-            .body("versions.1.createdAt", notNullValue())
+        .body("versions.1.inserted.features.size()", equalTo(2))
+        .body("versions.1.updated.features.size()", equalTo(0))
+        .body("versions.1.deleted.features.size()", equalTo(0))
+        .body("versions.1.author", equalTo(AUTHOR_1))
+        .body("versions.1.createdAt", notNullValue())
 
-            .body("nextPageToken", nullValue());
+        .body("nextPageToken", nullValue());
   }
-  
-  
+
   @Test
   public void validateCollectionWithVersionParams() {
-   
-	addChangeSets();
-	
+    addChangeSets();
+
     given()
-            .get("/spaces/" + cleanUpSpaceId + "/changesets?startVersion=0&endVersion=4")
-            .then()
-            .statusCode(OK.code())
-            .body("startVersion", equalTo(1))
-            .body("endVersion", equalTo(4))
+        .get("/spaces/" + cleanUpSpaceId + "/changesets?startVersion=0&endVersion=4")
+        .then()
+        .statusCode(OK.code())
+        .body("startVersion", equalTo(1))
+        .body("endVersion", equalTo(4))
 
-            .body("versions.1.inserted.features.size()", equalTo(2))
-            .body("versions.1.updated.features.size()", equalTo(0))
-            .body("versions.1.deleted.features.size()", equalTo(0))
-            .body("versions.1.author", equalTo(AUTHOR_1))
-            .body("versions.1.createdAt", notNullValue())
+        .body("versions.1.inserted.features.size()", equalTo(2))
+        .body("versions.1.updated.features.size()", equalTo(0))
+        .body("versions.1.deleted.features.size()", equalTo(0))
+        .body("versions.1.author", equalTo(AUTHOR_1))
+        .body("versions.1.createdAt", notNullValue())
 
-            .body("nextPageToken", nullValue());
+        .body("nextPageToken", nullValue());
   }
-  
+
   @Test
   public void validateCollectionWithStartVersionParam() {
-   
-	addChangeSets();
-	
+    addChangeSets();
+
     given()
-            .get("/spaces/" + cleanUpSpaceId + "/changesets?startVersion=2")
-            .then()
-            .statusCode(OK.code())
-            .body("startVersion", equalTo(2))
-            .body("endVersion", equalTo(4))
+        .get("/spaces/" + cleanUpSpaceId + "/changesets?startVersion=2")
+        .then()
+        .statusCode(OK.code())
+        .body("startVersion", equalTo(2))
+        .body("endVersion", equalTo(4))
 
-            .body("versions.2.inserted.features.size()", equalTo(1))
-            .body("versions.2.updated.features.size()", equalTo(1))
-            .body("versions.2.deleted.features.size()", equalTo(0))
-            .body("versions.2.author", equalTo(AUTHOR_1))
-            .body("versions.2.createdAt", notNullValue())
+        .body("versions.2.inserted.features.size()", equalTo(1))
+        .body("versions.2.updated.features.size()", equalTo(1))
+        .body("versions.2.deleted.features.size()", equalTo(0))
+        .body("versions.2.author", equalTo(AUTHOR_1))
+        .body("versions.2.createdAt", notNullValue())
 
-            .body("nextPageToken", nullValue());
+        .body("nextPageToken", nullValue());
   }
-  
+
   @Test
   public void validateCollectionWithEndVersionParam() {
-   
-	addChangeSets();
-	
+    addChangeSets();
+
     given()
-            .get("/spaces/" + cleanUpSpaceId + "/changesets?endVersion=2")
-            .then()
-            .log().all()
-            .statusCode(OK.code())
-            .body("startVersion", equalTo(1))
-            .body("endVersion", equalTo(2))
+        .get("/spaces/" + cleanUpSpaceId + "/changesets?endVersion=2")
+        .then()
+        .log().all()
+        .statusCode(OK.code())
+        .body("startVersion", equalTo(1))
+        .body("endVersion", equalTo(2))
 
-            .body("versions.2.inserted.features.size()", equalTo(1))
-            .body("versions.2.updated.features.size()", equalTo(1))
-            .body("versions.2.deleted.features.size()", equalTo(0))
-            .body("versions.2.author", equalTo(AUTHOR_1))
-            .body("versions.2.createdAt", notNullValue())
+        .body("versions.2.inserted.features.size()", equalTo(1))
+        .body("versions.2.updated.features.size()", equalTo(1))
+        .body("versions.2.deleted.features.size()", equalTo(0))
+        .body("versions.2.author", equalTo(AUTHOR_1))
+        .body("versions.2.createdAt", notNullValue())
 
-            .body("nextPageToken", nullValue());
+        .body("nextPageToken", nullValue());
   }
-
 
   @Test
   public void validateCollectionWhenNoChangetsetPresent() {
-   
-	
     given()
-            .get("/spaces/" + cleanUpSpaceId + "/changesets")
-            .then()
-            .statusCode(NOT_FOUND.code());
+        .get("/spaces/" + cleanUpSpaceId + "/changesets")
+        .then()
+        .statusCode(NOT_FOUND.code());
   }
 }

--- a/xyz-models/src/main/java/com/here/xyz/events/IterateChangesetsEvent.java
+++ b/xyz-models/src/main/java/com/here/xyz/events/IterateChangesetsEvent.java
@@ -20,40 +20,10 @@
 package com.here.xyz.events;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeName(value = "IterateChangesetsEvent")
 public final class IterateChangesetsEvent extends IterateFeaturesEvent<IterateChangesetsEvent> {
-  @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-  private long startVersion;
-  @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-  private long endVersion = -1;
 
-  public long getStartVersion() {
-    return startVersion;
-  }
-
-  public void setStartVersion(long startVersion) {
-    this.startVersion = startVersion;
-  }
-
-  public IterateChangesetsEvent withStartVersion(long startVersion) {
-    setStartVersion(startVersion);
-    return this;
-  }
-
-  public long getEndVersion() {
-    return endVersion;
-  }
-
-  public void setEndVersion(long endVersion) {
-    this.endVersion = endVersion;
-  }
-
-  public IterateChangesetsEvent withEndVersion(long endVersion) {
-    setEndVersion(endVersion);
-    return this;
-  }
 }

--- a/xyz-models/src/main/java/com/here/xyz/models/hub/Ref.java
+++ b/xyz-models/src/main/java/com/here/xyz/models/hub/Ref.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2024 HERE Europe B.V.
+ * Copyright (C) 2017-2025 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,8 +61,12 @@ public class Ref implements XyzSerializable {
   }
 
   public Ref(long startVersion, long endVersion) {
-    start = new Ref(startVersion);
-    end = new Ref(endVersion);
+    this(new Ref(startVersion), new Ref(endVersion));
+  }
+
+  public Ref(Ref startRef, Ref endRef) {
+    start = startRef;
+    end = endRef;
     validateRange();
   }
 

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeatures.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeatures.java
@@ -159,7 +159,7 @@ public abstract class GetFeatures<E extends ContextAwareEvent, R extends XyzResp
         "requestedVersion");
   }
 
-  private SQLQuery buildNextVersionFragment(Ref ref, boolean historyEnabled, String versionParamName) {
+  protected SQLQuery buildNextVersionFragment(Ref ref, boolean historyEnabled, String versionParamName) {
     if (!historyEnabled || ref.isAllVersions())
       return new SQLQuery("");
 

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/helpers/versioning/GetMinVersion.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/helpers/versioning/GetMinVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2023 HERE Europe B.V.
+ * Copyright (C) 2017-2025 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,6 @@ import com.here.xyz.connectors.ErrorResponseException;
 import com.here.xyz.events.Event;
 import com.here.xyz.psql.query.XyzEventBasedQueryRunner;
 import com.here.xyz.util.db.SQLQuery;
-
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
@@ -39,15 +38,14 @@ public class GetMinVersion<E extends Event> extends XyzEventBasedQueryRunner<E, 
   @Override
   protected SQLQuery buildQuery(E event) throws SQLException, ErrorResponseException {
     return new SQLQuery("SELECT min(version) FROM ${schema}.${table}")
-            .withVariable(SCHEMA, getSchema())
-            .withVariable(TABLE, getDefaultTable(event));
+        .withVariable(SCHEMA, getSchema())
+        .withVariable(TABLE, getDefaultTable(event));
   }
 
   @Override
   public Long handle(ResultSet rs) throws SQLException {
-    if (rs.next()){
+    if (rs.next())
       return rs.getLong("min");
-    }
-    throw new SQLException("Unable to retrieve minVersion from space.");
+    return 0l;
   }
 }


### PR DESCRIPTION
**Replace start- & end-version by a range-ref in IterateChangesets QR**

- Remove redundant fields startVersion & endVersion from IterateChangesetsEvent
- Change IterateChangesets QR to accept only a range ref instead of the two former event params "startVersion" & "endVersion"
- Allow to directly pass a "versionRef" query param in ChangesetApi & update OAS accordingly
- Improve performance of IterateChangesets QR by only fetching the minVersion from the DB in the cases where it's really necessary
- Streamline IterateChangesets QR to not use a custom "filterWhereClause" but simply passing a ref to the parent super QR
- Simplify SpaceConnectorBasedHandler#injectEventParameters() to use a future rather than a promise