### PR TITLE
DS-1184: Fix error handling in SpaceTaskHandler

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/task/SpaceTaskHandler.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/task/SpaceTaskHandler.java
@@ -76,7 +76,6 @@ import io.vertx.core.Promise;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.jackson.DatabindCodec;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -788,12 +787,13 @@ public class SpaceTaskHandler {
     Promise<Void> p = Promise.promise();
     Space.resolveConnector(marker, space.getStorage().getId())
         .onSuccess(connector -> RpcClient.getInstanceFor(connector).execute(marker, event, ar -> {
-          ChangesetsStatisticsResponse response = (ChangesetsStatisticsResponse) ar.result();
-          if( response != null )
-          { space.setReadOnlyHeadVersion(response.getMaxVersion());
-            p.complete();
+          if (ar.failed()) {
+            p.fail(ar.cause());
+            return;
           }
-          else p.fail("failed to get Changeset statistics");
+          ChangesetsStatisticsResponse changesetStatistics = (ChangesetsStatisticsResponse) ar.result();
+          space.setReadOnlyHeadVersion(changesetStatistics.getMaxVersion());
+          p.complete();
         }))
         .onFailure(p::fail);
     return p.future();


### PR DESCRIPTION
- Fix issue that `NoStackTraceThrowable` was used e.g., `p.fail("...")`
- Fix issue that original exceptions were masqueraded