### PR TITLE
DS-1184: Fix minor issue in IterateChangesets for spaces without history

### DIFF
--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/ImportFilesToSpace.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/ImportFilesToSpace.java
@@ -374,6 +374,7 @@ public class ImportFilesToSpace extends SpaceBasedStep<ImportFilesToSpace> {
 
         infoLog(STEP_EXECUTE, this,"Create TriggerTable and Trigger");
         //Create Temp-ImportTable to avoid deserialization of JSON and fix missing row count
+        //FIXME: Use job owner as author
         runBatchWriteQuerySync(buildTemporaryTriggerTableBlock(space().getOwner(), newVersion), db(), 0);
       }
 
@@ -495,6 +496,7 @@ public class ImportFilesToSpace extends SpaceBasedStep<ImportFilesToSpace> {
     if (isResume()) {
       infoLog(STEP_EXECUTE, this, "Reset SuccessMarker");
       runWriteQuerySync(buildResetJobTableItemsForResumeStatement(), db(), 0);
+      return true;
     }
     else {
       infoLog(STEP_EXECUTE, this, "Create temporary job table");
@@ -508,7 +510,6 @@ public class ImportFilesToSpace extends SpaceBasedStep<ImportFilesToSpace> {
       //If no Inputs are present return 0
       return inputs.size() != 0;
     }
-    return true;
   }
 
   @Override

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeatures.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeatures.java
@@ -190,7 +190,7 @@ public abstract class GetFeatures<E extends ContextAwareEvent, R extends XyzResp
           .withNamedParameter("minVersion", event.getMinVersion())
           .withNamedParameter("requestedVersion", requestedVersion);
 
-    return isHeadOrAllVersions ? new SQLQuery("") : new SQLQuery("AND #{requestedVersion} = (SELECT max(version) AS HEAD FROM ${schema}.${table})")
+    return isHeadOrAllVersions || ref.isRange() ? new SQLQuery("") : new SQLQuery("AND #{requestedVersion} = (SELECT max(version) AS HEAD FROM ${schema}.${table})")
         .withNamedParameter("requestedVersion", requestedVersion);
   }
 


### PR DESCRIPTION
- Recovered the previous behavior of IterateChangesets to actually return changesets for previous versions even if the space has no history
- Recovered the previous behavior of IterateChangesets to return changesets for version ranges that exceed the HEAD version of the space that has no history