### PR TITLE
DS-1184: Fix issue in IterateChangesets QR when minTagVersion was set

### DIFF
--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/TagApiIT.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/TagApiIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2024 HERE Europe B.V.
+ * Copyright (C) 2017-2025 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,25 +49,21 @@ public class TagApiIT extends TestSpaceWithFeature {
 
   @BeforeClass
   public static void setupClass() {
-      removeSpace(getSpaceId());
-      createdSpaces.forEach(TagApiIT::removeSpace);
+    removeSpace(getSpaceId());
+    createdSpaces.forEach(TagApiIT::removeSpace);
   }
 
   @Before
   public void setup() {
-      createSpaceWithVersionsToKeep(getSpaceId(), 2);
+    createSpaceWithVersionsToKeep(getSpaceId(), 2);
   }
 
   @After
   public void teardown() {
-      removeSpace(getSpaceId());
-      removeSpace(SECOND_SPACE);
-      createdSpaces.forEach(TagApiIT::removeSpace);
-      _deleteSubscription();
-  }
-
-  private ValidatableResponse _createTag() {
-      return _createTagForId(getSpaceId(), "XYZ_1", false);
+    removeSpace(getSpaceId());
+    removeSpace(SECOND_SPACE);
+    createdSpaces.forEach(TagApiIT::removeSpace);
+    _deleteSubscription();
   }
 
   private ValidatableResponse _deleteSubscription() {
@@ -78,44 +74,44 @@ public class TagApiIT extends TestSpaceWithFeature {
         .then();
   }
 
-  private ValidatableResponse _createTagForId(String spaceId, String tagId, boolean system) {
-      return given()
-          .headers(getAuthHeaders(AuthProfile.ACCESS_ALL))
-          .contentType(ContentType.JSON)
-          .body(new Tag().withId(tagId).withSystem(system))
-          .post("/spaces/" + spaceId + "/tags")
-          .then().statusCode(OK.code());
-  }
-
-  private void _addOneFeature() {
-    addFeature(getSpaceId(), new Feature().withProperties(new Properties().with("name", "abc")));
-  }
-
   @Test
   public void testDeleteSpace() {
-      _createTag();
-      removeSpace(getSpaceId());
-      createSpace();
+    _createTag();
+    removeSpace(getSpaceId());
+    createSpace();
 
-      given()
-              .headers(getAuthHeaders(AuthProfile.ACCESS_ALL))
-              .get("/spaces/" + getSpaceId() + "/tags/XYZ_1")
-              .then()
-              .statusCode(NOT_FOUND.code());
+    given()
+        .headers(getAuthHeaders(AuthProfile.ACCESS_ALL))
+        .get("/spaces/" + getSpaceId() + "/tags/XYZ_1")
+        .then()
+        .statusCode(NOT_FOUND.code());
+  }
+
+  private ValidatableResponse _createTag() {
+    return _createTagForId(getSpaceId(), "XYZ_1", false);
+  }
+
+  private ValidatableResponse _createTagForId(String spaceId, String tagId, boolean system) {
+    return given()
+        .headers(getAuthHeaders(AuthProfile.ACCESS_ALL))
+        .contentType(ContentType.JSON)
+        .body(new Tag().withId(tagId).withSystem(system))
+        .post("/spaces/" + spaceId + "/tags")
+        .then().statusCode(OK.code());
   }
 
   @Test
   public void createTag() {
-      _createTag()
-              .statusCode(OK.code())
-              .body("id", equalTo("XYZ_1"))
-              .body("version", equalTo(0));
+    _createTag()
+        .statusCode(OK.code())
+        .body("id", equalTo("XYZ_1"))
+        .body("version", equalTo(0));
 
-      given()
-              .headers(getAuthHeaders(AuthProfile.ACCESS_ALL))
-              .get("/spaces/" + getSpaceId() + "/tags/XYZ_1")
-              .then()
-              .statusCode(OK.code());
+    given()
+        .headers(getAuthHeaders(AuthProfile.ACCESS_ALL))
+        .get("/spaces/" + getSpaceId() + "/tags/XYZ_1")
+        .then()
+        .statusCode(OK.code());
   }
 
   @Test
@@ -138,99 +134,99 @@ public class TagApiIT extends TestSpaceWithFeature {
         .then().statusCode(BAD_REQUEST.code());
   }
 
-    @Test
+  @Test
   public void deleteTag() {
-      _createTag();
+    _createTag();
 
-      given()
-              .headers(getAuthHeaders(AuthProfile.ACCESS_ALL))
-              .delete("/spaces/" + getSpaceId() + "/tags/XYZ_1")
-              .then()
-              .statusCode(OK.code());
+    given()
+        .headers(getAuthHeaders(AuthProfile.ACCESS_ALL))
+        .delete("/spaces/" + getSpaceId() + "/tags/XYZ_1")
+        .then()
+        .statusCode(OK.code());
 
-      given()
-              .headers(getAuthHeaders(AuthProfile.ACCESS_ALL))
-              .delete("/spaces/" + getSpaceId() + "/tags/XYZ_1")
-              .then()
-              .statusCode(NOT_FOUND.code());
+    given()
+        .headers(getAuthHeaders(AuthProfile.ACCESS_ALL))
+        .delete("/spaces/" + getSpaceId() + "/tags/XYZ_1")
+        .then()
+        .statusCode(NOT_FOUND.code());
   }
 
   @Test
   public void getTagVersion() {
-      _createTag();
+    _createTag();
 
-      given()
-              .headers(getAuthHeaders(AuthProfile.ACCESS_ALL))
-              .get("/spaces/" + getSpaceId() + "/tags/XYZ_1")
-              .then()
-              .statusCode(OK.code())
-              .body("version", equalTo(0));
+    given()
+        .headers(getAuthHeaders(AuthProfile.ACCESS_ALL))
+        .get("/spaces/" + getSpaceId() + "/tags/XYZ_1")
+        .then()
+        .statusCode(OK.code())
+        .body("version", equalTo(0));
   }
 
   @Test
   public void updateTagVersion() {
-      _createTag();
+    _createTag();
 
-      given()
-              .headers(getAuthHeaders(AuthProfile.ACCESS_ALL))
-              .contentType(ContentType.JSON)
-              .body(new Tag().withVersion(999).serialize())
-              .patch("/spaces/" + getSpaceId() + "/tags/XYZ_1")
-              .then()
-              .statusCode(OK.code());
+    given()
+        .headers(getAuthHeaders(AuthProfile.ACCESS_ALL))
+        .contentType(ContentType.JSON)
+        .body(new Tag().withVersion(999).serialize())
+        .patch("/spaces/" + getSpaceId() + "/tags/XYZ_1")
+        .then()
+        .statusCode(OK.code());
 
-      given()
-              .headers(getAuthHeaders(AuthProfile.ACCESS_ALL))
-              .get("/spaces/" + getSpaceId() + "/tags/XYZ_1")
-              .then()
-              .statusCode(OK.code())
-              .body("version", equalTo(999));
+    given()
+        .headers(getAuthHeaders(AuthProfile.ACCESS_ALL))
+        .get("/spaces/" + getSpaceId() + "/tags/XYZ_1")
+        .then()
+        .statusCode(OK.code())
+        .body("version", equalTo(999));
   }
 
   @Test
   public void testSubscriptions() {
-      given()
-              .accept(APPLICATION_JSON)
-              .contentType(APPLICATION_JSON)
-              .headers(getAuthHeaders(AuthProfile.ACCESS_ALL))
-              .body(content("/xyz/hub/createSubscription.json"))
-              .post("/spaces/" + getSpaceId() + "/subscriptions");
+    given()
+        .accept(APPLICATION_JSON)
+        .contentType(APPLICATION_JSON)
+        .headers(getAuthHeaders(AuthProfile.ACCESS_ALL))
+        .body(content("/xyz/hub/createSubscription.json"))
+        .post("/spaces/" + getSpaceId() + "/subscriptions");
 
-      given()
-              .headers(getAuthHeaders(AuthProfile.ACCESS_ALL))
-              .get("/spaces/" + getSpaceId() + "/tags/xyz_ntf")
-              .then()
-              .statusCode(OK.code());
+    given()
+        .headers(getAuthHeaders(AuthProfile.ACCESS_ALL))
+        .get("/spaces/" + getSpaceId() + "/tags/xyz_ntf")
+        .then()
+        .statusCode(OK.code());
 
-      given()
-              .accept(APPLICATION_JSON)
-              .headers(getAuthHeaders(AuthProfile.ACCESS_ALL))
-              .delete("/spaces/" + getSpaceId() + "/subscriptions/test-subscription-1")
-              .then()
-              .statusCode(OK.code());
+    given()
+        .accept(APPLICATION_JSON)
+        .headers(getAuthHeaders(AuthProfile.ACCESS_ALL))
+        .delete("/spaces/" + getSpaceId() + "/subscriptions/test-subscription-1")
+        .then()
+        .statusCode(OK.code());
   }
 
   @Test
   public void testRemoveSubscriptions() {
-      given()
-              .accept(APPLICATION_JSON)
-              .contentType(APPLICATION_JSON)
-              .headers(getAuthHeaders(AuthProfile.ACCESS_ALL))
-              .body(content("/xyz/hub/createSubscription.json"))
-              .post("/spaces/" + getSpaceId() + "/subscriptions");
+    given()
+        .accept(APPLICATION_JSON)
+        .contentType(APPLICATION_JSON)
+        .headers(getAuthHeaders(AuthProfile.ACCESS_ALL))
+        .body(content("/xyz/hub/createSubscription.json"))
+        .post("/spaces/" + getSpaceId() + "/subscriptions");
 
-      given()
-              .accept(APPLICATION_JSON)
-              .headers(getAuthHeaders(AuthProfile.ACCESS_ALL))
-              .delete("/spaces/" + getSpaceId() + "/subscriptions/test-subscription-1")
-              .then()
-              .statusCode(OK.code());
+    given()
+        .accept(APPLICATION_JSON)
+        .headers(getAuthHeaders(AuthProfile.ACCESS_ALL))
+        .delete("/spaces/" + getSpaceId() + "/subscriptions/test-subscription-1")
+        .then()
+        .statusCode(OK.code());
 
-      given()
-              .headers(getAuthHeaders(AuthProfile.ACCESS_ALL))
-              .get("/spaces/" + getSpaceId() + "/tags/xyz_ntf")
-              .then()
-              .statusCode(NOT_FOUND.code());
+    given()
+        .headers(getAuthHeaders(AuthProfile.ACCESS_ALL))
+        .get("/spaces/" + getSpaceId() + "/tags/xyz_ntf")
+        .then()
+        .statusCode(NOT_FOUND.code());
   }
 
   @Test
@@ -250,29 +246,29 @@ public class TagApiIT extends TestSpaceWithFeature {
         .get("/spaces?tag=XYZ_1")
         .then()
         .body("size()", is(1))
-        .body( "[0].tags.XYZ_1.id", equalTo("XYZ_1"))
-        .body( "[0].tags.XYZ_1.version", equalTo(0));
+        .body("[0].tags.XYZ_1.id", equalTo("XYZ_1"))
+        .body("[0].tags.XYZ_1.version", equalTo(0));
   }
 
   @Ignore("Disabled. Takes too long")
   @Test
   public void testBigListSpacesFilterByTagId() {
-      for (int i = 0; i < 250; i++)
-       createdSpaces.add(createSpaceWithRandomId());
+    for (int i = 0; i < 250; i++)
+      createdSpaces.add(createSpaceWithRandomId());
 
-      given()
-              .headers(getAuthHeaders(AuthProfile.ACCESS_ALL))
-              .get("/spaces?tag=XYZ_1")
-              .then()
-              .body("size()", is(0));
+    given()
+        .headers(getAuthHeaders(AuthProfile.ACCESS_ALL))
+        .get("/spaces?tag=XYZ_1")
+        .then()
+        .body("size()", is(0));
 
-      createdSpaces.stream().forEach(spaceId -> _createTagForId(spaceId, "XYZ_1", false));
+    createdSpaces.stream().forEach(spaceId -> _createTagForId(spaceId, "XYZ_1", false));
 
-      given()
-              .headers(getAuthHeaders(AuthProfile.ACCESS_ALL))
-              .get("/spaces?tag=XYZ_1")
-              .then()
-              .body("size()", is(createdSpaces.size()));
+    given()
+        .headers(getAuthHeaders(AuthProfile.ACCESS_ALL))
+        .get("/spaces?tag=XYZ_1")
+        .then()
+        .body("size()", is(createdSpaces.size()));
   }
 
   @Test
@@ -299,6 +295,10 @@ public class TagApiIT extends TestSpaceWithFeature {
         .post("/spaces/" + getSpaceId() + "/tags")
         .then()
         .body("version", equalTo(2));
+  }
+
+  private void _addOneFeature() {
+    addFeature(getSpaceId(), new Feature().withProperties(new Properties().with("name", "abc")));
   }
 
   @Test
@@ -513,18 +513,18 @@ public class TagApiIT extends TestSpaceWithFeature {
   @Test
   public void createTagAndCheckForAuthorAndCreatedAtAndDescription() {
     _createTag()
-            .statusCode(OK.code())
-            .body("id", equalTo("XYZ_1"))
-            .body("version", equalTo(0));
+        .statusCode(OK.code())
+        .body("id", equalTo("XYZ_1"))
+        .body("version", equalTo(0));
 
     given()
-            .headers(getAuthHeaders(AuthProfile.ACCESS_ALL))
-            .get("/spaces/" + getSpaceId() + "/tags/XYZ_1")
-            .then()
-            .statusCode(OK.code())
-            .body("$", hasKey("author"))
-            .body("$", hasKey("createdAt"))
-            .body("$", hasKey("description"));
+        .headers(getAuthHeaders(AuthProfile.ACCESS_ALL))
+        .get("/spaces/" + getSpaceId() + "/tags/XYZ_1")
+        .then()
+        .statusCode(OK.code())
+        .body("$", hasKey("author"))
+        .body("$", hasKey("createdAt"))
+        .body("$", hasKey("description"));
   }
 
   @Test
@@ -532,13 +532,13 @@ public class TagApiIT extends TestSpaceWithFeature {
     _createTag();
 
     given()
-            .headers(getAuthHeaders(AuthProfile.ACCESS_ALL))
-            .contentType(ContentType.JSON)
-            .body(new Tag().withId("XYZ_1").withVersion(1).withDescription("description"))
-            .patch("/spaces/" + getSpaceId() + "/tags/XYZ_1")
-            .then()
-            .statusCode(OK.code())
-            .body("description", equalTo("description"));
+        .headers(getAuthHeaders(AuthProfile.ACCESS_ALL))
+        .contentType(ContentType.JSON)
+        .body(new Tag().withId("XYZ_1").withVersion(1).withDescription("description"))
+        .patch("/spaces/" + getSpaceId() + "/tags/XYZ_1")
+        .then()
+        .statusCode(OK.code())
+        .body("description", equalTo("description"));
   }
 
   @Test
@@ -548,12 +548,25 @@ public class TagApiIT extends TestSpaceWithFeature {
     _createTagForId(getSpaceId(), "XYZ_2", false);
 
     given()
-            .headers(getAuthHeaders(AuthProfile.ACCESS_ALL))
-            .get("/spaces/" + getSpaceId() + "/tags")
-            .then()
-            .statusCode(OK.code())
-            .body("size()", is(2))
-            .body("id[0]", equalTo("XYZ_2"))
-            .body("id[1]", equalTo("XYZ_1"));
+        .headers(getAuthHeaders(AuthProfile.ACCESS_ALL))
+        .get("/spaces/" + getSpaceId() + "/tags")
+        .then()
+        .statusCode(OK.code())
+        .body("size()", is(2))
+        .body("id[0]", equalTo("XYZ_2"))
+        .body("id[1]", equalTo("XYZ_1"));
+  }
+
+  @Test
+  public void getChangesetsAfterTagCreation() {
+    _addOneFeature();
+    _createTag();
+
+    given()
+        .get("/spaces/" + getSpaceId() + "/changesets?startVersion=0&endVersion=1")
+        .then()
+        .statusCode(OK.code())
+        .body("startVersion", equalTo(1))
+        .body("endVersion", equalTo(1));
   }
 }


### PR DESCRIPTION
- The IterateChangesets QR now takes into account the "versionsToKeep" setting of the space. That way the minTagVersion (being sent through the event's minVersion property as a workaround for NTF polling) is now only relevant if the available version range is less than the requested one
- Add test TagApiIT#getChangesetsAfterTagCreation() to verify that behavior