### PR TITLE
DS-1184: FeatureWriter enhancements & fixes

### DIFF
--- a/.run/HubService.run.xml
+++ b/.run/HubService.run.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (C) 2017-2024 HERE Europe B.V.
+  ~ Copyright (C) 2017-2025 HERE Europe B.V.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/xyz-connectors/src/main/java/com/here/xyz/connectors/AbstractConnectorHandler.java
+++ b/xyz-connectors/src/main/java/com/here/xyz/connectors/AbstractConnectorHandler.java
@@ -242,7 +242,7 @@ public abstract class AbstractConnectorHandler implements RequestStreamHandler {
         dataOut = new ErrorResponse()
             .withStreamId(this.streamId)
             .withError(EXCEPTION)
-            .withErrorMessage("Unexpected exception occurred.");
+            .withErrorMessage("Unexpected exception occurred: " + e.getMessage());
       }
       catch (OutOfMemoryError e) {
        throw e;

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/ChangesetApi.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/ChangesetApi.java
@@ -129,6 +129,7 @@ public class ChangesetApi extends SpaceBasedApi {
       SpaceConnectorBasedHandler.execute(getMarker(context),
               space -> Authorization.authorizeManageSpacesRights(context, space.getId(), space.getOwner()).map(space),
               new DeleteChangesetsEvent()
+                  .withStreamId(getMarker(context).getName())
                   .withSpace(spaceId)
                   .withMinVersion(minVersion))
 
@@ -166,6 +167,7 @@ public class ChangesetApi extends SpaceBasedApi {
     long limit = Query.getLong(context, Query.LIMIT, IterateChangesets.DEFAULT_LIMIT);
 
     return new IterateChangesetsEvent()
+        .withStreamId(getMarker(context).getName())
         .withSpace(getSpaceId(context))
         .withRef(versionRef)
         .withNextPageToken(pageToken)

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/task/FeatureHandler.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/task/FeatureHandler.java
@@ -19,6 +19,7 @@
 
 package com.here.xyz.hub.task;
 
+import static com.here.xyz.hub.task.FeatureTaskHandler.injectMinVersion;
 import static com.here.xyz.util.service.rest.TooManyRequestsException.ThrottlingReason.MEMORY;
 import static com.here.xyz.util.service.rest.TooManyRequestsException.ThrottlingReason.STORAGE_QUEUE_FULL;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_GATEWAY;
@@ -93,6 +94,8 @@ public class FeatureHandler {
           .withContext(spaceContext)
           .withAuthor(author)
           .withResponseDataExpected(responseDataExpected);
+
+      injectMinVersion(marker, space.getId(), event);
 
       //Enrich event with properties from the space
       injectSpaceParams(event, space);

--- a/xyz-models/src/main/java/com/here/xyz/events/SelectiveEvent.java
+++ b/xyz-models/src/main/java/com/here/xyz/events/SelectiveEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2024 HERE Europe B.V.
+ * Copyright (C) 2017-2025 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,6 @@ public class SelectiveEvent<T extends SelectiveEvent> extends ContextAwareEvent<
   private List<String> selection;
   private boolean force2D;
   private Ref ref = new Ref(HEAD);
-  private long minVersion;
 
   @SuppressWarnings("unused")
   public List<String> getSelection() {
@@ -56,19 +55,6 @@ public class SelectiveEvent<T extends SelectiveEvent> extends ContextAwareEvent<
 
   public T withRef(Ref ref) {
     setRef(ref);
-    return (T) this;
-  }
-
-  public long getMinVersion() {
-    return minVersion;
-  }
-
-  public void setMinVersion(long minVersion) {
-    this.minVersion = minVersion;
-  }
-
-  public T withMinVersion(long minVersion) {
-    setMinVersion(minVersion);
     return (T) this;
   }
 

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/WriteFeatures.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/WriteFeatures.java
@@ -22,6 +22,7 @@ package com.here.xyz.psql.query;
 import static com.here.xyz.responses.XyzError.CONFLICT;
 import static com.here.xyz.responses.XyzError.EXCEPTION;
 import static com.here.xyz.responses.XyzError.NOT_FOUND;
+import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.PARTITION_SIZE;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.here.xyz.XyzSerializable;
@@ -34,6 +35,7 @@ import com.here.xyz.util.db.SQLQuery;
 import com.here.xyz.util.db.datasource.DataSourceProvider;
 import com.here.xyz.util.db.pg.FeatureWriterQueryBuilder.FeatureWriterQueryContextBuilder;
 import com.here.xyz.util.db.pg.SQLError;
+import com.here.xyz.util.runtime.FunctionRuntime;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -67,6 +69,8 @@ public class WriteFeatures extends ExtendedSpace<WriteFeaturesEvent, FeatureColl
         .withSpaceContext(spaceContext)
         .withHistoryEnabled(event.getVersionsToKeep() > 1)
         .withBatchMode(true)
+        .with("debug", "true".equals(System.getenv("FW_DEBUG")))
+        .with("queryId", FunctionRuntime.getInstance().getStreamId())
         .build();
 
     return new SQLQuery("SELECT write_features(#{modifications}, 'Modifications', #{author}, #{responseDataExpected});")

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/WriteFeatures.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/WriteFeatures.java
@@ -71,6 +71,10 @@ public class WriteFeatures extends ExtendedSpace<WriteFeaturesEvent, FeatureColl
         .withBatchMode(true)
         .with("debug", "true".equals(System.getenv("FW_DEBUG")))
         .with("queryId", FunctionRuntime.getInstance().getStreamId())
+        .with("PARTITION_SIZE", PARTITION_SIZE)
+        .with("minVersion", event.getMinVersion())
+        .with("versionsToKeep", event.getVersionsToKeep())
+        .with("pw", getDataSourceProvider().getDatabaseSettings().getPassword())
         .build();
 
     return new SQLQuery("SELECT write_features(#{modifications}, 'Modifications', #{author}, #{responseDataExpected});")

--- a/xyz-util/src/main/resources/sql/DatabaseWriter.js
+++ b/xyz-util/src/main/resources/sql/DatabaseWriter.js
@@ -316,7 +316,7 @@ class DatabaseWriter {
     this.resultParsers[method].push(deletedRows => {
       if (deletedRows == 0) {
         if (onVersionConflict != null) {
-          this.debugBox("HandleConflict for id: " + inputFeature.id);
+          plv8.elog(NOTICE, "FW_LOG HandleConflict for deletion of id: " + inputFeature.id);
           //handleDeleteVersionConflict //TODO: throw some conflict error here that can be caught & handled by FeatureWriter
           return null;
         }
@@ -344,23 +344,6 @@ class DatabaseWriter {
 
   _throwFeatureNotExistsError(featureId) {
     throw new FeatureNotExistsException(`Feature with ID ${featureId} not exists!`);
-  }
-
-  //TODO: deduplicate
-  debugBox(message) {
-    if (!this.debugOutput)
-      return;
-
-    let width = 140;
-    let leftRightBuffer = 2;
-    let maxLineLength = width - leftRightBuffer * 2;
-    let lines = message.split("\n").map(line => !line ? line : line.match(new RegExp(`.{1,${maxLineLength}}`, "g"))).flat();
-    let longestLine = lines.map(line => line.length).reduce((a, b) => Math.max(a, b), -Infinity);
-    let leftPadding = new Array(Math.floor((width - longestLine) / 2)).join(" ");
-    lines = lines.map(line => "#" + leftPadding + line
-        + new Array(width - leftPadding.length - line.length - 1).join(" ") + "#");
-    if(this.debugOutput)
-      plv8.elog(NOTICE, "\n" + new Array(width + 1).join("#") + "\n" + lines.join("\n") + "\n" + new Array(width + 1).join("#"));
   }
 }
 

--- a/xyz-util/src/main/resources/sql/FeatureWriter.js
+++ b/xyz-util/src/main/resources/sql/FeatureWriter.js
@@ -94,7 +94,8 @@ class FeatureWriter {
       throw new IllegalArgumentException("MERGE can not be executed for spaces without history!");
 
     if (this.onVersionConflict && this.baseVersion == null)
-      throw new IllegalArgumentException(`No base version was provided, but a version conflict detection was requested! Please provide a base-version in the request or in the input-feature with ID ${this.inputFeature.id}.`);
+      if (this.featureExistsInHead(this.inputFeature.id)) //TODO: Remove that workaround, once the global base version can be defined and the "conflictDetection" param was deprecated
+        throw new IllegalArgumentException(`No base version was provided, but a version conflict detection was requested! Please provide a base-version in the request or in the input-feature with ID ${this.inputFeature.id}.`);
 
     if (this.debug)
       this.debugBox(JSON.stringify(this, null, 2));

--- a/xyz-util/src/main/resources/sql/FeatureWriter.js
+++ b/xyz-util/src/main/resources/sql/FeatureWriter.js
@@ -661,7 +661,7 @@ class FeatureWriter {
 
     //Check for removed properties
     for (let key in minuend)
-      if (minuend.hasOwnProperty(key) && !subtrahend.hasOwnProperty(key) && !(keyPath.includes("coordinates") && minuend.length == 3 && subtrahend.length == 2))
+      if (minuend.hasOwnProperty(key) && !subtrahend.hasOwnProperty(key) && !(keyPath.includes("coordinates") && minuend.length == 3 && minuend[2] == 0 && subtrahend.length == 2))
         diff[key] = null;
 
     if (ignoreXyzNs && diff.properties && diff.properties[XYZ_NS]) {
@@ -741,18 +741,23 @@ class FeatureWriter {
   debugBox(message) {
     if (!this.debug)
       return;
+    let boxMode = false;
 
-    message = `[${this.queryId}] ` + message;
+    message = `FW_LOG [${this.queryId}] ` + message;
 
     let width = 140;
-    let leftRightBuffer = 2;
-    let maxLineLength = width - leftRightBuffer * 2;
-    let lines = message.split("\n").map(line => !line ? line : line.match(new RegExp(`.{1,${maxLineLength}}`, "g"))).flat();
-    let longestLine = lines.map(line => line.length).reduce((a, b) => Math.max(a, b), -Infinity);
-    let leftPadding = new Array(Math.floor((width - longestLine) / 2)).join(" ");
-    lines = lines.map(line => "#" + leftPadding + line
-        + new Array(width - leftPadding.length - line.length - 1).join(" ") + "#");
-    plv8.elog(NOTICE, "\n" + new Array(width + 1).join("#") + "\n" + lines.join("\n") + "\n" + new Array(width + 1).join("#"));
+    if (boxMode) {
+      let leftRightBuffer = 2;
+      let maxLineLength = width - leftRightBuffer * 2;
+      let lines = message.split("\n").map(line => !line ? line : line.match(new RegExp(`.{1,${maxLineLength}}`, "g"))).flat();
+      let longestLine = lines.map(line => line.length).reduce((a, b) => Math.max(a, b), -Infinity);
+      let leftPadding = new Array(Math.floor((width - longestLine) / 2)).join(" ");
+      lines = lines.map(line => "#" + leftPadding + line
+          + new Array(width - leftPadding.length - line.length - 1).join(" ") + "#");
+      plv8.elog(NOTICE, "\n" + new Array(width + 1).join("#") + "\n" + lines.join("\n") + "\n" + new Array(width + 1).join("#"));
+    }
+    else
+      plv8.elog(NOTICE, "\n" + new Array(width + 1).join("#") + "\n" + message + "\n" + new Array(width + 1).join("#"));
   }
 
   //Low level DB / table facing helper methods:

--- a/xyz-util/src/test/java/com/here/xyz/test/featurewriter/SpaceWriter.java
+++ b/xyz-util/src/test/java/com/here/xyz/test/featurewriter/SpaceWriter.java
@@ -20,7 +20,6 @@
 package com.here.xyz.test.featurewriter;
 
 import static com.here.xyz.events.ContextAwareEvent.SpaceContext.SUPER;
-import static com.here.xyz.test.featurewriter.TestSuite.TEST_FEATURE_GEOMETRY;
 import static com.here.xyz.test.featurewriter.TestSuite.TEST_FEATURE_ID;
 import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.SCHEMA;
 import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.TABLE;
@@ -121,7 +120,7 @@ public abstract class SpaceWriter extends SQLITBase {
 
   public SpaceTableRow getFeatureRow(SpaceContext context) throws Exception {
     try (DataSourceProvider dsp = getDataSourceProvider()) {
-      return new SQLQuery("SELECT id, version, next_version, operation, author, jsondata, geo " + " FROM ${schema}.${table} "
+      return new SQLQuery("SELECT id, version, next_version, operation, author, jsondata, ST_AsGeojson(geo) AS geo " + " FROM ${schema}.${table} "
           + "WHERE id = #{id} AND next_version = #{MAX_BIGINT}")
           .withVariable(SCHEMA, dsp.getDatabaseSettings().getSchema())
           .withVariable(TABLE, context == SUPER ? superSpaceId() : spaceId())
@@ -137,7 +136,7 @@ public abstract class SpaceWriter extends SQLITBase {
                       Operation.valueOf(rs.getString("operation")),
                       rs.getString("author"),
                       XyzSerializable.deserialize(rs.getString("jsondata"), Map.class),
-                      TEST_FEATURE_GEOMETRY //TODO: Read & transform geo from row, when it becomes relevant
+                      rs.getString("geo") == null ? null : XyzSerializable.deserialize(rs.getString("geo"))
                     )
                   : null;
             }

--- a/xyz-util/src/test/java/com/here/xyz/test/featurewriter/TestSuite.java
+++ b/xyz-util/src/test/java/com/here/xyz/test/featurewriter/TestSuite.java
@@ -68,7 +68,7 @@ import org.junit.jupiter.api.BeforeEach;
 
 public abstract class TestSuite {
   public static final String TEST_FEATURE_ID = "id1";
-  public static final Point TEST_FEATURE_GEOMETRY = new Point().withCoordinates(new PointCoordinates(8, 50));
+  public static final Point TEST_FEATURE_GEOMETRY = new Point().withCoordinates(new PointCoordinates(8, 50, 0));
   private static final TestArgs EMPTY_ARGS = new TestArgs("EMPTY_ARGS", false, false, false, false, false, false, UserIntent.WRITE, null, null, null, null, null, null);
 
   protected String testName;
@@ -174,7 +174,8 @@ public abstract class TestSuite {
   }
 
   protected static Feature deletedFeature(long version) {
-    Feature feature = featureWithEmptyProperties();
+    Feature feature = featureWithEmptyProperties()
+        .withGeometry(null);
     feature.getProperties().withXyzNamespace(new XyzNamespace()
         .withDeleted(true)
         .withVersion(version));

--- a/xyz-util/src/test/java/com/here/xyz/test/featurewriter/sql/functional/FWMerge.java
+++ b/xyz-util/src/test/java/com/here/xyz/test/featurewriter/sql/functional/FWMerge.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2017-2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.xyz.test.featurewriter.sql.functional;
+
+import static com.here.xyz.test.featurewriter.SpaceWriter.DEFAULT_AUTHOR;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.here.xyz.events.UpdateStrategy.OnExists;
+import com.here.xyz.events.UpdateStrategy.OnMergeConflict;
+import com.here.xyz.events.UpdateStrategy.OnNotExists;
+import com.here.xyz.events.UpdateStrategy.OnVersionConflict;
+import com.here.xyz.models.geojson.coordinates.PointCoordinates;
+import com.here.xyz.models.geojson.implementation.Feature;
+import com.here.xyz.models.geojson.implementation.Point;
+import com.here.xyz.models.geojson.implementation.Properties;
+import com.here.xyz.models.geojson.implementation.XyzNamespace;
+import com.here.xyz.test.featurewriter.sql.SQLTestSuite;
+import java.util.List;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class FWMerge extends SQLTestSuite {
+
+  private static List<Arguments> mergeGeometryChangeArgs() {
+    return List.of(
+        Arguments.of(new PointCoordinates(0, 0), new PointCoordinates(10, 0)),
+        Arguments.of(new PointCoordinates(0, 0), new PointCoordinates(0, 10)),
+        Arguments.of(new PointCoordinates(0, 0, 0), new PointCoordinates(10, 0, 0))
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("mergeGeometryChangeArgs")
+  public void mergeGeometryChange(PointCoordinates coordsBefore, PointCoordinates coordsAfter) throws Exception {
+    //Create f1 (v1)
+    spaceWriter().writeFeature(
+        new Feature()
+            .withId(TEST_FEATURE_ID)
+            .withProperties(new Properties().with("prop1", "value1"))
+            .withGeometry(new Point().withCoordinates(coordsBefore)),
+        DEFAULT_AUTHOR,
+        OnExists.ERROR,
+        OnNotExists.CREATE,
+        null,
+        null,
+        false,
+        null,
+        true);
+
+    //Update f1 with different property value (v2)
+    spaceWriter().writeFeature(
+        new Feature()
+            .withId(TEST_FEATURE_ID)
+            .withProperties(new Properties().with("prop1", "value2"))
+            .withGeometry(new Point().withCoordinates(coordsBefore)),
+        DEFAULT_AUTHOR,
+        OnExists.REPLACE,
+        OnNotExists.ERROR,
+        null,
+        null,
+        false,
+        null,
+        true);
+
+    //Update f1 with different geometry but use v1 as base (v3)
+    spaceWriter().writeFeature(
+        new Feature()
+            .withId(TEST_FEATURE_ID)
+            .withProperties(new Properties()
+                .with("prop1", "value1")
+                .withXyzNamespace(new XyzNamespace()
+                    .withVersion(1)))
+            .withGeometry(new Point().withCoordinates(coordsAfter)),
+        DEFAULT_AUTHOR,
+        OnExists.REPLACE,
+        OnNotExists.ERROR,
+        OnVersionConflict.MERGE,
+        OnMergeConflict.ERROR,
+        false,
+        null,
+        true);
+
+    Feature writtenFeature = spaceWriter().getFeature(null);
+
+    assertEquals(3, writtenFeature.getProperties().getXyzNamespace().getVersion());
+    assertEquals(coordsAfter.get(0), ((Point) writtenFeature.getGeometry()).getCoordinates().get(0));
+    assertEquals(coordsAfter.get(1), ((Point) writtenFeature.getGeometry()).getCoordinates().get(1));
+  }
+}

--- a/xyz-util/src/test/js/db/featurewriter/TestFeatureWriter.js
+++ b/xyz-util/src/test/js/db/featurewriter/TestFeatureWriter.js
@@ -67,19 +67,18 @@ class TestFeatureWriter {
 
   sqlQueryJson = {
     "namedParameters" : {
-      "author" : "XYZ-01234567-89ab-cdef-0123-456789aUSER1",
-      "responseDataExpected" : true,
-      "modifications" : "[{\"updateStrategy\":{\"onExists\":\"REPLACE\",\"onNotExists\":\"CREATE\"},\"featureData\":{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"id\":\"F1\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[2.0,2.0]},\"properties\":{\"b\":2}}]},\"partialUpdates\":true}]"
+      "featureModificationList" : "[ {\n  \"updateStrategy\" : {\n    \"onExists\" : \"REPLACE\",\n    \"onNotExists\" : \"ERROR\",\n    \"onVersionConflict\" : \"MERGE\",\n    \"onMergeConflict\" : \"ERROR\"\n  },\n  \"featureData\" : {\n    \"type\" : \"FeatureCollection\",\n    \"features\" : [ {\n      \"type\" : \"Feature\",\n      \"id\" : \"id1\",\n      \"geometry\" : {\n        \"type\" : \"Point\",\n        \"coordinates\" : [ 0.0, 10.0 ]\n      },\n      \"properties\" : {\n        \"@ns:com:here:xyz\" : {\n          \"version\" : 1\n        },\n        \"prop1\" : \"value1\"\n      }\n    } ]\n  },\n  \"partialUpdates\" : false\n} ]",
+      "author" : "ANONYMOUS",
+      "responseDataExpected" : true
     },
-    "queryId" : "a6ea901e-9e69-4ca2-afbe-29e4889e6317",
+    "queryId" : "786f0a6b-8f42-4736-accb-f4cc4e1918fe",
     "context" : {
       "schema" : "public",
       "historyEnabled" : true,
-      "batchMode" : true,
-      "tables" : [ "x-psql-test" ]
+      "batchMode" : false,
+      "tables" : [ "FWMerge" ]
     },
-    "loggingEnabled" : false,
-    "text" : "SELECT write_features(#{modifications}, 'Modifications', #{author}, #{responseDataExpected});"
+    "text" : "SELECT write_features(#{featureModificationList}, 'Modifications', #{author}, #{responseDataExpected});"
   };
 
   runFromSqlQueryJson() {


### PR DESCRIPTION
- Enhance FeatureWriter to create history partitions and execute purge when necessary
    - purge and partition creation is necessary only if the affected space is a space with history.
    - inject minVersion into WriteFeaturesEvent
    - Remove obsolete property SelectiveEvent#minVersion

- Fix FeatureWriter's diff & patch impl with respect to arrays & geometries
    - Also fix FeatureWriter's TestSuite to load & compare the actual feature geometry correctly
    - Adjust FeatureWriter to use a new "debug" flag from the queryContext to activate debug logs
        - Setting that flag in WriteFeatures QR using an environment variable called "FW_DEBUG"

- Add BWC-workaround for missing base versions on feature creations
    - If the base version was not defined by the user, but a version conflict detection was requested, the FeatureWriter was throwing an exception until now. While that behavior is basically correct, this workaround is necessary to keep the backwards compatibility temporarily. That workaround can be removed again once the global base version can be set by the user and the "conflictDetection" param was deprecated

- Some further minor fixes
    - Fix issue with missing error message in unexpected connector exceptions
    - Fix issue with missing stream IDs for events being sent by ChangesetApi