### PR TITLE
DS-1184: Streamline public serialization of API responses

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/ChangesetApi.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/ChangesetApi.java
@@ -25,6 +25,7 @@ import static com.here.xyz.hub.rest.ApiParam.Query.END_VERSION;
 import static com.here.xyz.hub.rest.ApiParam.Query.START_VERSION;
 import static com.here.xyz.models.hub.Ref.HEAD;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
+import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 
 import com.here.xyz.events.DeleteChangesetsEvent;
 import com.here.xyz.events.GetChangesetStatisticsEvent;
@@ -158,7 +159,7 @@ public class ChangesetApi extends SpaceBasedApi {
         space.getOwner()).map(space);
 
     getChangesetStatistics(getMarker(context), changesetAuthorization, getSpaceId(context))
-        .onSuccess(result -> sendResponse(context, HttpResponseStatus.OK, result))
+        .onSuccess(result -> sendResponse(context, OK.code(), result))
         .onFailure(t -> sendErrorResponse(context, t));
   }
 
@@ -196,7 +197,7 @@ public class ChangesetApi extends SpaceBasedApi {
         ((ChangesetCollection) result).getEndVersion() == -1)
       sendErrorResponse(context, new HttpException(NOT_FOUND, "The requested resource does not exist."));
     else
-      sendResponseWithXyzSerialization(context, HttpResponseStatus.OK, result);
+      sendResponse(context, OK.code(), result);
   }
 
   private long getVersionFromPathParam(RoutingContext context) {

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/FeatureApi.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/FeatureApi.java
@@ -439,7 +439,7 @@ public class FeatureApi extends SpaceBasedApi {
 
   private void sendWriteFeaturesResponse(RoutingContext context, ApiResponseType responseType, FeatureCollection featureCollection) {
     switch (responseType) {
-      case EMPTY -> sendResponse(context, 200, (XyzSerializable) null);
+      case EMPTY -> sendResponse(context, 200, null);
       case FEATURE_COLLECTION -> sendResponse(context, 200, featureCollection);
       case FEATURE -> {
         try {
@@ -779,7 +779,7 @@ public class FeatureApi extends SpaceBasedApi {
 
   public static boolean eraseContent(RoutingContext context) {
    final List<String> featureIds = new ArrayList<>(new HashSet<>(queryParam(FEATURE_ID, context)));
-   return Query.getBoolean(context, ERASE_CONTENT, false) && featureIds.isEmpty(); 
+   return Query.getBoolean(context, ERASE_CONTENT, false) && featureIds.isEmpty();
   }
 
   private static void checkModificationOnSuper(SpaceContext spaceContext) throws HttpException {

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/service/JobAdminApi.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/service/JobAdminApi.java
@@ -76,8 +76,7 @@ public class JobAdminApi extends JobApiBase {
 
   private void getJob(RoutingContext context) {
     loadJob(jobId(context))
-        //TODO: Use internal serialization here
-        .onSuccess(job -> sendResponseWithXyzSerialization(context, OK, job))
+        .onSuccess(job -> sendInternalResponse(context, OK.code(), job))
         .onFailure(t -> sendErrorResponse(context, t));
   }
 
@@ -88,7 +87,7 @@ public class JobAdminApi extends JobApiBase {
 
   private void deleteJob(RoutingContext context) throws HttpException {
     getJobFromBody(context).deleteJobResources()
-        .onSuccess(v -> sendResponseWithXyzSerialization(context, NO_CONTENT, null))
+        .onSuccess(v -> sendResponse(context, NO_CONTENT.code(), null))
         .onFailure(t -> sendErrorResponse(context, t));
   }
 
@@ -96,7 +95,7 @@ public class JobAdminApi extends JobApiBase {
     Step step = getStepFromBody(context);
     loadJob(jobId(context))
         .compose(job -> job.updateStep(step).mapEmpty())
-        .onSuccess(v -> sendResponseWithXyzSerialization(context, OK, null))
+        .onSuccess(v -> sendResponse(context, OK.code(), null))
         .onFailure(t -> sendErrorResponse(context, t));
   }
 
@@ -151,7 +150,7 @@ public class JobAdminApi extends JobApiBase {
     else
       logger.error("The event does not include a detail field: {}", event);
 
-    sendResponseWithXyzSerialization(context, NO_CONTENT, null);
+    sendResponse(context, NO_CONTENT.code(), null);
   }
 
   /**

--- a/xyz-models/src/main/java/com/here/xyz/models/geojson/implementation/FeatureCollection.java
+++ b/xyz-models/src/main/java/com/here/xyz/models/geojson/implementation/FeatureCollection.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -40,19 +41,30 @@ import java.util.List;
 @JsonInclude(Include.NON_EMPTY)
 public class FeatureCollection extends XyzResponse<FeatureCollection> {
 
+  @JsonView({Public.class})
   private LazyParsable<List<Feature>> features;
+  @JsonView({Public.class})
   private BBox bbox;
   private Boolean partial;
+  @JsonView({Public.class})
   @Deprecated
   private String handle;
+  @JsonView({Public.class})
   private String nextPageToken;
+  @JsonView({Public.class})
   @Deprecated
   private Long count;
+  @JsonView({Public.class})
   private List<String> inserted;
+  @JsonView({Public.class})
   private List<String> updated;
+  @JsonView({Public.class})
   private List<String> deleted;
+  @JsonView({Public.class})
   private List<Feature> oldFeatures;
+  @JsonView({Public.class})
   private List<ModificationFailure> failed;
+  @JsonView({Public.class})
   @JsonInclude(Include.NON_EMPTY)
   private Long version;
 

--- a/xyz-models/src/main/java/com/here/xyz/responses/ChangesetsStatisticsResponse.java
+++ b/xyz-models/src/main/java/com/here/xyz/responses/ChangesetsStatisticsResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2023 HERE Europe B.V.
+ * Copyright (C) 2017-2025 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,14 +20,20 @@
 package com.here.xyz.responses;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonView;
 
+@Deprecated
 public class ChangesetsStatisticsResponse extends XyzResponse<ChangesetsStatisticsResponse> {
+  @JsonView({Public.class})
   private Long minVersion;
+  @JsonView({Public.class})
   private Long maxVersion;
+  @JsonView({Public.class})
   @JsonInclude
   public final String DEPRECATION_NOTE = "This endpoint is deprecated and will be removed in the next releases. "
       + "Please use '{resource}/statistics' instead of '{resource}/changesets/statistics'.";
 
+  @JsonView({Public.class})
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Long minTagVersion;
 

--- a/xyz-models/src/main/java/com/here/xyz/responses/SuccessResponse.java
+++ b/xyz-models/src/main/java/com/here/xyz/responses/SuccessResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2025 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,11 +21,13 @@ package com.here.xyz.responses;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.annotation.JsonView;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeName(value = "SuccessResponse")
 public class SuccessResponse extends XyzResponse<SuccessResponse> {
 
+  @JsonView({Public.class})
   private String status;
 
   public String getStatus() {

--- a/xyz-models/src/main/java/com/here/xyz/responses/changesets/Changeset.java
+++ b/xyz-models/src/main/java/com/here/xyz/responses/changesets/Changeset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2024 HERE Europe B.V.
+ * Copyright (C) 2017-2025 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ package com.here.xyz.responses.changesets;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonView;
 import com.here.xyz.models.geojson.implementation.FeatureCollection;
 import com.here.xyz.responses.XyzResponse;
 
@@ -30,12 +31,19 @@ import com.here.xyz.responses.XyzResponse;
  */
 @JsonInclude(Include.NON_DEFAULT)
 public class Changeset extends XyzResponse<Changeset> {
+  @JsonView({Public.class})
   long version = -1;
+  @JsonView({Public.class})
   String author;
+  @JsonView({Public.class})
   long createdAt;
+  @JsonView({Public.class})
   private FeatureCollection inserted;
+  @JsonView({Public.class})
   private FeatureCollection updated;
+  @JsonView({Public.class})
   private FeatureCollection deleted;
+  @JsonView({Public.class})
   private String nextPageToken;
 
   public long getVersion() {

--- a/xyz-models/src/main/java/com/here/xyz/responses/changesets/ChangesetCollection.java
+++ b/xyz-models/src/main/java/com/here/xyz/responses/changesets/ChangesetCollection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2024 HERE Europe B.V.
+ * Copyright (C) 2017-2025 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.annotation.JsonView;
 import com.here.xyz.responses.XyzResponse;
 import java.util.Map;
 
@@ -30,13 +31,17 @@ import java.util.Map;
 @JsonTypeName(value = "ChangesetCollection")
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class ChangesetCollection extends XyzResponse<ChangesetCollection> {
+  @JsonView({Public.class})
   private long startVersion;
+  @JsonView({Public.class})
   private long endVersion;
 
+  @JsonView({Public.class})
   @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
   @JsonInclude(JsonInclude.Include.ALWAYS)
   private Map<Long, Changeset> versions;
 
+  @JsonView({Public.class})
   private String nextPageToken;
 
   @SuppressWarnings("unused")

--- a/xyz-util/src/main/java/com/here/xyz/util/service/rest/Api.java
+++ b/xyz-util/src/main/java/com/here/xyz/util/service/rest/Api.java
@@ -33,6 +33,7 @@ import static io.vertx.core.http.HttpHeaders.CONTENT_TYPE;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.here.xyz.XyzSerializable;
+import com.here.xyz.XyzSerializable.Internal;
 import com.here.xyz.XyzSerializable.Public;
 import com.here.xyz.XyzSerializable.SerializationView;
 import com.here.xyz.responses.ErrorResponse;
@@ -108,7 +109,7 @@ public class Api {
     protected <R> Handler<RoutingContext> handle(ThrowingTask<R, RoutingContext> taskHandler) {
         return handleErrors(context -> {
             taskHandler.execute(context)
-                    .onSuccess(response -> sendResponseWithXyzSerialization(context, OK, response))
+                    .onSuccess(response -> sendResponse(context, OK.code(), response))
                     .onFailure(t -> {
                         if (t instanceof HttpException httpException)
                             sendErrorResponse(context, httpException);
@@ -242,43 +243,6 @@ public class Api {
         sendResponseBytes(context, httpResponse, response);
     }
 
-    /**
-     * @deprecated Please use {@link #sendResponse(RoutingContext, int, XyzSerializable)} or {@link #sendResponse(RoutingContext, int, List)} instead.
-     * @param context
-     * @param status
-     * @param o
-     */
-    protected void sendResponseWithXyzSerialization(RoutingContext context, HttpResponseStatus status, Object o) {
-        sendResponseWithXyzSerialization(context, status, o, null);
-    }
-
-    /**
-     * @deprecated Please use {@link #sendResponse(RoutingContext, int, XyzSerializable)} or {@link #sendResponse(RoutingContext, int, List)} instead.
-     * @param context
-     * @param status
-     * @param o
-     * @param type
-     */
-    @Deprecated
-    protected void sendResponseWithXyzSerialization(RoutingContext context, HttpResponseStatus status, Object o, TypeReference type) {
-        HttpServerResponse httpResponse = context.response().setStatusCode(status.code());
-
-        byte[] response;
-        try {
-            if (o == null)
-                response = new byte[]{};
-            else
-                response = o instanceof ByteArrayOutputStream bos ? bos.toByteArray() : (type == null ? XyzSerializable.serialize(o)
-                    : XyzSerializable.serialize(o, type)).getBytes();
-        }
-        catch (EncodeException e) {
-            sendErrorResponse(context, new HttpException(INTERNAL_SERVER_ERROR, "Could not serialize response.", e));
-            return;
-        }
-
-        sendResponseBytes(context, httpResponse, response);
-    }
-
     protected void sendResponseBytes(RoutingContext context, HttpServerResponse httpResponse, byte[] response) {
         if (response.length == 0)
             httpResponse.setStatusCode(NO_CONTENT.code()).end();
@@ -290,11 +254,18 @@ public class Api {
         }
     }
 
-    protected void sendResponse(RoutingContext context, int statusCode, XyzSerializable object) {
+    protected void sendResponse(RoutingContext context, int statusCode, Object object) {
+      if (object == null || object instanceof XyzSerializable)
+        sendResponse(context, statusCode, (XyzSerializable) object);
+      else if (object instanceof List)
+        sendResponse(context, statusCode, (List<? extends XyzSerializable>) object);
+    }
+
+    private void sendResponse(RoutingContext context, int statusCode, XyzSerializable object) {
         serializeAndSendResponse(context, statusCode, object, null, Public.class);
     }
 
-    protected void sendResponse(RoutingContext context, int statusCode, List<? extends XyzSerializable> list) {
+    private void sendResponse(RoutingContext context, int statusCode, List<? extends XyzSerializable> list) {
         serializeAndSendResponse(context, statusCode, list, null, Public.class);
     }
 
@@ -304,16 +275,16 @@ public class Api {
     }
 
     protected void sendInternalResponse(RoutingContext context, int statusCode, XyzSerializable object) {
-        serializeAndSendResponse(context, statusCode, object, null, null); //TODO: Use Internal view here in future
+        serializeAndSendResponse(context, statusCode, object, null, Internal.class);
     }
 
     protected void sendInternalResponse(RoutingContext context, int statusCode, List<? extends XyzSerializable> list) {
-        serializeAndSendResponse(context, statusCode, list, null, null); //TODO: Use Internal view here in future
+        serializeAndSendResponse(context, statusCode, list, null, Internal.class);
     }
 
     protected void sendInternalResponse(RoutingContext context, int statusCode, List<? extends XyzSerializable> list,
         TypeReference listItemTypeReference) {
-        serializeAndSendResponse(context, statusCode, list, listItemTypeReference, null); //TODO: Use Internal view here in future
+        serializeAndSendResponse(context, statusCode, list, listItemTypeReference, Internal.class);
     }
 
     private void serializeAndSendResponse(RoutingContext context, int statusCode, Object object,


### PR DESCRIPTION
- Ensure no internal fields are serialized anymore by always using the correct serialization methods of the Api base class
- Adjust some Api implementations that were still using the deprecated serialization methods
- Remove some deprecated (now obsolete) serialization methods from Api base class
- Adjust affected models accordingly to mark all public fields