### PR TITLE
DS-1184: Allow setting the baseVersion for the transaction when writing features

### DIFF
--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/task/FeatureHandler.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/task/FeatureHandler.java
@@ -45,6 +45,7 @@ import com.here.xyz.hub.connectors.models.Space.ConnectorType;
 import com.here.xyz.hub.connectors.models.Space.ResolvableListenerConnectorRef;
 import com.here.xyz.hub.rest.Api;
 import com.here.xyz.models.geojson.implementation.FeatureCollection;
+import com.here.xyz.models.hub.Ref;
 import com.here.xyz.models.hub.Space.Extension;
 import com.here.xyz.models.hub.Space.ListenerConnectorRef;
 import com.here.xyz.responses.StatisticsResponse;
@@ -84,7 +85,7 @@ public class FeatureHandler {
   private static final LongAdder globalInflightRequestMemory = new LongAdder();
 
   public static Future<FeatureCollection> writeFeatures(Marker marker, Space space, Set<Modification> modifications, SpaceContext spaceContext,
-      String author, boolean responseDataExpected) {
+      String author, boolean responseDataExpected, Ref baseRef) {
     try {
       throttle(space);
 
@@ -93,7 +94,8 @@ public class FeatureHandler {
           .withModifications(modifications)
           .withContext(spaceContext)
           .withAuthor(author)
-          .withResponseDataExpected(responseDataExpected);
+          .withResponseDataExpected(responseDataExpected)
+          .withRef(baseRef);
 
       injectMinVersion(marker, space.getId(), event);
 

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/task/FeatureTaskHandler.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/task/FeatureTaskHandler.java
@@ -1040,7 +1040,7 @@ public class FeatureTaskHandler {
 
     try {
       List<Map<String, Object>> featureModifications = getFeatureModifications(task);
-      List<FeatureEntry> featureEntries = ModifyFeatureOp.convertToFeatureEntries(featureModifications, task.ifNotExists, task.ifExists, task.conflictResolution);
+      List<FeatureEntry> featureEntries = ModifyFeatureOp.convertToFeatureEntries(featureModifications, task.ifNotExists, task.ifExists, task.conflictResolution, task.getEvent().getRef());
       task.modifyOp = new ModifyFeatureOp(featureEntries, task.transactional);
       callback.call(task);
     } catch (HttpException e) {

--- a/xyz-hub-service/src/main/resources/openapi.yaml
+++ b/xyz-hub-service/src/main/resources/openapi.yaml
@@ -16,7 +16,7 @@ tags:
   - name: Read Features
     description: Read only endpoints for features.
   - name: Write Features
-    description: Read and write endpoints for features.
+    description: Write endpoints for features.
   - name: Manage Connectors
     description: Read and write endpoints for connectors.
   - name: Manage Subscriptions
@@ -204,12 +204,19 @@ paths:
       tags:
         - Manage Changesets
       summary: Get Changesets
-      description: >-
+      description: |
         Retrieves a subset of existing Changesets from the space's history.
         The subset can be defined either by a "startVersion" and an "endVersion"
         or by providing a version ref that references a version range
         e.g., "5..6" or "0..HEAD"
         
+
+        The version range can be specified using the `versionRef` query-parameter as follows:
+        `<start>..<end>`
+        
+        Where `<start>` is the start of the range (exclusive) and `<end>` is the end of the range
+        (inclusive).
+
 
         Each successful write transaction to the space is stored as one single Changeset,
         which can contain modifications applied to one or more features.
@@ -306,7 +313,9 @@ paths:
     get:
       tags:
         - Manage Changesets
-      summary: Get ChangesetStatistics (deprecated)
+      summary: |
+        `[Deprecated]` Get ChangesetStatistics
+      deprecated: true
       description: >-
         NOTE: This endpoint is <b>deprecated</b>. Use <code>/spaces/{spaceId}/statistics</code> instead to gather information about the min / max version of a space.<br /><br />
         Returns statistics about changesets.
@@ -451,8 +460,7 @@ paths:
         - $ref: '#/components/parameters/PropertiesSelection'
         - $ref: '#/components/parameters/Force2D'
         - $ref: '#/components/parameters/Context'
-        - $ref: '#/components/parameters/VersionStar'
-        - $ref: '#/components/parameters/VersionRefStar'
+        - $ref: '#/components/parameters/VersionRef'
         - $ref: '#/components/parameters/Author'
       responses:
         '200':
@@ -473,6 +481,7 @@ paths:
       operationId: putFeatures
       parameters:
         - $ref: '#/components/parameters/SpaceId'
+        - $ref: '#/components/parameters/VersionRef'
       requestBody:
         $ref: '#/components/requestBodies/FeatureCollectionRequest'
       responses:
@@ -608,6 +617,7 @@ paths:
         - $ref: '#/components/parameters/Transactional'
         - $ref: '#/components/parameters/PrefixId'
         - $ref: '#/components/parameters/Context'
+        - $ref: '#/components/parameters/VersionRef'
       requestBody:
         $ref: '#/components/requestBodies/FeatureCollectionOrFeatureModificationListRequest'
       responses:
@@ -640,6 +650,7 @@ paths:
         - $ref: '#/components/parameters/SpaceId'
         - $ref: '#/components/parameters/Ids'
         - $ref: '#/components/parameters/Context'
+        - $ref: '#/components/parameters/VersionRef'
         - name: eraseContent
           in: query
           description: >-
@@ -677,7 +688,7 @@ paths:
         - $ref: '#/components/parameters/Force2D'
         - $ref: '#/components/parameters/Context'
         - $ref: '#/components/parameters/VersionStar'
-        - $ref: '#/components/parameters/VersionRefStar'
+        - $ref: '#/components/parameters/VersionRef'
         - $ref: '#/components/parameters/Author'
       responses:
         '200':
@@ -699,6 +710,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/SpaceId'
         - $ref: '#/components/parameters/FeatureId'
+        - $ref: '#/components/parameters/VersionRef'
       requestBody:
         $ref: '#/components/requestBodies/FeatureRequest'
       responses:
@@ -725,6 +737,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/SpaceId'
         - $ref: '#/components/parameters/FeatureId'
+        - $ref: '#/components/parameters/VersionRef'
       requestBody:
         $ref: '#/components/requestBodies/FeatureRequest'
       responses:
@@ -754,6 +767,7 @@ paths:
         - $ref: '#/components/parameters/SpaceId'
         - $ref: '#/components/parameters/FeatureId'
         - $ref: '#/components/parameters/Context'
+        - $ref: '#/components/parameters/VersionRef'
       responses:
         '204':
           $ref: '#/components/responses/EmptyResponse'
@@ -1411,17 +1425,15 @@ components:
     EndVersion:
       name: endVersion
       in: query
-      description: Defines the end of the version-range [version <= endVersion].
+      description: |
+        `[Deprecated]` Please define the version range using the versionRef query parameter.
+        
+        
+        Defines the end of the version-range [version <= endVersion].
       required: false
       schema:
         type: integer
-    EndVersionNotRequired:
-      name: endVersion
-      in: query
-      description: Defines the end of the version-range [version <= endVersion].
-      required: false
-      schema:
-        type: integer
+      deprecated: true
     FeatureId:
       name: featureId
       in: path
@@ -1763,17 +1775,15 @@ components:
     StartVersion:
       name: startVersion
       in: query
-      description: Defines the start of the version-range [version >= startVersion].
+      description: |
+        `[Deprecated]` Please define the version range using the versionRef query parameter.
+        
+        
+        Defines the start of the version-range [version >= startVersion].
       required: false
       schema:
         type: integer
-    StartVersionNotRequired:
-      name: startVersion
-      in: query
-      description: Defines the start of the version-range [version >= startVersion].
-      required: false
-      schema:
-        type: integer
+      deprecated: true
     TileId:
       name: tileId
       in: path
@@ -1880,18 +1890,33 @@ components:
     VersionRef:
       name: versionRef
       in: query
-      description: >-
-        The query parameter used to specify the version reference pointing to a tag or a version.
-      required: false
-      schema:
-        type: string
-    VersionRefStar:
-      name: versionRef
-      in: query
-      description: >-
-        The query parameter used to specify the version reference pointing to a tag or a version
-        with also the possibility to use the star '*' to load all versions or 'HEAD' to load the
-        latest available version.
+      description: |
+        The query parameter used to specify the target version reference when reading or writing features.
+        A reference describes a target tag or a version.
+        
+        Default is: `HEAD`
+
+        <br>
+        Depending on the use-case it can be necessary to specify a range of versions rather than
+        only one version. In such a case the version part of the Ref would look like:
+        `<start>..<end>`
+
+        Where `<start>` is the start of the range (exclusive) and `<end>` is the end of the range
+        (inclusive).
+
+        Another way of specifying a version range is using the star-symbol: `*`
+
+        Using `*` refers to "all available versions" in the space or branch and is only
+        applicable in the cases in which a version range may be provided.
+
+        <br>
+        Samples:
+          - `42` points to version 42
+          - `HEAD` points to the latest version
+          - `myTag` points to the version of the tag with ID "myTag"
+          - `0..HEAD` points to all available versions
+          - `*` also points to all versions (short form)
+          - `5..10` points to the versions in the interval `]5, 10]`
       required: false
       schema:
         type: string
@@ -2226,7 +2251,7 @@ components:
                 createdAt: 1560417151751
                 updatedAt: 1561480482869
     SpacesResponse:
-      description: The list of spaces.
+      description: A list of spaces.
       content:
         application/json:
           schema:

--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/task/ModifyFeatureOpTest.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/task/ModifyFeatureOpTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2023 HERE Europe B.V.
+ * Copyright (C) 2017-2025 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@
 
 package com.here.xyz.hub.task;
 
+import static com.here.xyz.models.hub.Ref.HEAD;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
@@ -31,6 +32,7 @@ import com.here.xyz.models.geojson.implementation.Feature;
 import com.here.xyz.models.hub.FeatureModificationList.ConflictResolution;
 import com.here.xyz.models.hub.FeatureModificationList.IfExists;
 import com.here.xyz.models.hub.FeatureModificationList.IfNotExists;
+import com.here.xyz.models.hub.Ref;
 import com.here.xyz.util.service.HttpException;
 import io.vertx.core.json.JsonObject;
 import java.io.IOException;
@@ -69,7 +71,7 @@ public class ModifyFeatureOpTest {
       Map<String, Object> featureCollection = Collections.singletonMap("features", features);
 
       List<FeatureEntry> entries = ModifyFeatureOp.convertToFeatureEntries(Collections.singletonList(Collections.singletonMap("featureData", featureCollection)),
-          IfNotExists.CREATE, IfExists.MERGE, ConflictResolution.ERROR);
+          IfNotExists.CREATE, IfExists.MERGE, ConflictResolution.ERROR, new Ref(HEAD));
       ModifyFeatureOp op = new ModifyFeatureOp(entries, true);
       final Entry<Feature> entry = op.entries.get(0);
       entry.head = head;
@@ -102,7 +104,7 @@ public class ModifyFeatureOpTest {
       Map<String, Object> featureCollection = Collections.singletonMap("features", features);
 
       List<FeatureEntry> entries = ModifyFeatureOp.convertToFeatureEntries(Collections.singletonList(Collections.singletonMap("featureData", featureCollection)),
-          IfNotExists.CREATE, IfExists.MERGE, ConflictResolution.ERROR);
+          IfNotExists.CREATE, IfExists.MERGE, ConflictResolution.ERROR, new Ref(HEAD));
       ModifyFeatureOp op = new ModifyFeatureOp(entries, true);
       final Entry<Feature> entry = op.entries.get(0);
       entry.head = base;
@@ -132,7 +134,7 @@ public class ModifyFeatureOpTest {
       Map<String, Object> featureCollection = Collections.singletonMap("features", features);
 
       List<FeatureEntry> entries = ModifyFeatureOp.convertToFeatureEntries(Collections.singletonList(Collections.singletonMap("featureData", featureCollection)),
-          IfNotExists.CREATE, IfExists.MERGE, ConflictResolution.ERROR);
+          IfNotExists.CREATE, IfExists.MERGE, ConflictResolution.ERROR, new Ref(HEAD));
       ModifyFeatureOp op = new ModifyFeatureOp(entries, true);
       final Entry<Feature> entry = op.entries.get(0);
       op.process();

--- a/xyz-models/src/main/java/com/here/xyz/events/ContextAwareEvent.java
+++ b/xyz-models/src/main/java/com/here/xyz/events/ContextAwareEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2022 HERE Europe B.V.
+ * Copyright (C) 2017-2025 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,18 +20,33 @@
 
 package com.here.xyz.events;
 
+import static com.here.xyz.models.hub.Ref.HEAD;
 import static com.here.xyz.models.hub.Space.DEFAULT_VERSIONS_TO_KEEP;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.here.xyz.models.hub.Ref;
 
 @JsonInclude(Include.NON_DEFAULT)
 public abstract class ContextAwareEvent<T extends ContextAwareEvent> extends Event<T> {
-
   private SpaceContext context = SpaceContext.DEFAULT;
   private int versionsToKeep = DEFAULT_VERSIONS_TO_KEEP;
+  private Ref ref = new Ref(HEAD);
   private String author;
   private long minVersion;
+
+  public Ref getRef() {
+    return ref;
+  }
+
+  public void setRef(Ref ref) {
+    this.ref = ref;
+  }
+
+  public T withRef(Ref ref) {
+    setRef(ref);
+    return (T) this;
+  }
 
   public String getAuthor() {
     return author;

--- a/xyz-psql-connector/src/test/java/com/here/xyz/psql/PSQLWriteIT.java
+++ b/xyz-psql-connector/src/test/java/com/here/xyz/psql/PSQLWriteIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2023 HERE Europe B.V.
+ * Copyright (C) 2017-2025 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,7 +78,7 @@ public class PSQLWriteIT extends PSQLAbstractIT {
         LOGGER.info("Insert feature tested successfully");
 
         // =========== UPDATE ==========
-        FeatureCollection featureCollection = XyzSerializable.deserialize(insertResponse);
+        FeatureCollection featureCollection = deserializeResponse(insertResponse);
 
         ModifyFeaturesEvent mfevent = new ModifyFeaturesEvent()
                 .withConnectorParams(defaultTestConnectorParams)
@@ -105,7 +105,7 @@ public class PSQLWriteIT extends PSQLAbstractIT {
         LOGGER.info("Insert feature tested successfully");
 
         // =========== UPDATE ==========
-        FeatureCollection featureCollection = XyzSerializable.deserialize(insertResponse);
+        FeatureCollection featureCollection = deserializeResponse(insertResponse);
 
         ModifyFeaturesEvent mfevent = new ModifyFeaturesEvent()
                 .withConnectorParams(defaultTestConnectorParams)
@@ -122,7 +122,7 @@ public class PSQLWriteIT extends PSQLAbstractIT {
         // =========== LoadFeaturesEvent ==========
         String loadFeaturesEvent = "/events/LoadFeaturesEvent.json";
         String loadResponse = invokeLambdaFromFile(loadFeaturesEvent);
-        featureCollection = XyzSerializable.deserialize(loadResponse);
+        featureCollection = deserializeResponse(loadResponse);
         assertNotNull(featureCollection.getFeatures());
         assertEquals(1, featureCollection.getFeatures().size());
         assertEquals("test", featureCollection.getFeatures().get(0).getId());
@@ -138,7 +138,7 @@ public class PSQLWriteIT extends PSQLAbstractIT {
                 .withDeleteFeatures(new HashMap<String,String>(){{ put(deleteId, null);}});
 
         String deleteResponse = invokeLambda(mfevent);
-        featureCollection = XyzSerializable.deserialize(deleteResponse);
+        featureCollection = deserializeResponse(deleteResponse);
         assertNotNull(featureCollection.getFeatures());
         assertEquals(0, featureCollection.getFeatures().size());
         assertEquals(1, featureCollection.getDeleted().size());
@@ -198,7 +198,7 @@ public class PSQLWriteIT extends PSQLAbstractIT {
         LOGGER.info("Preparation: Insert features");
 
         // =========== Validate that "geometry":null is serialized ==========
-        // s. https://datatracker.ietf.org/doc/html/rfc7946#section-3.2 
+        // s. https://datatracker.ietf.org/doc/html/rfc7946#section-3.2
         String response = invokeLambdaFromFile("/events/GetFeaturesByIdEvent.json");
         assertTrue(response.indexOf("\"geometry\":null") > 0);
     }


### PR DESCRIPTION
- Add versionRef query param to feature writing endpoints
- Forward the specified versionRef to the connector if applicable
    - Respect the forwarded ref as baseVersion in DatabaseWriter & WriteFeatures QR
- Activate conflict detection automatically if a non-HEAD version is specified in the versionRef
- Update OAS accordingly