### PR TITLE
Ds 2171 introduce singleJobPerResourcePolicy and extend JobAdminApi with dynamic scheduler configuration

### DIFF
--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/Job.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/Job.java
@@ -538,8 +538,8 @@ public class Job implements XyzSerializable {
             //Delete the inputs of this job
             .compose(b -> deleteInputs())
             //Delete the outputs of this job
-            .compose(v -> hasRegisterDataReferencesStep()
-                    //Temporary deletion deactivation for jobs with RegisterDataReferences step(s).
+            .compose(v -> (hasRegisterDataReferencesStep() || isReleaseJob())
+                    //Temporary deletion deactivation for jobs with RegisterDataReferences step(s) or for release jobs.
                     ? Future.succeededFuture()
                     : Future.all(Job.forEach(getSteps().stepStream().toList(), Job::deleteStepOutputs)).mapEmpty());
   }
@@ -548,6 +548,10 @@ public class Job implements XyzSerializable {
     return getSteps() != null
         && getSteps().stepStream().anyMatch(step -> step != null
             && "RegisterDataReferences".equals(step.getClass().getSimpleName()));
+  }
+
+  private boolean isReleaseJob() {
+    return getProcess() != null && "Release".equalsIgnoreCase(getProcess().getClass().getSimpleName());
   }
 
   private static Future<Void> deleteStepOutputs(Step step) {

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/service/JobAdminApi.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/service/JobAdminApi.java
@@ -35,12 +35,14 @@ import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static io.vertx.core.http.HttpMethod.DELETE;
 import static io.vertx.core.http.HttpMethod.GET;
 import static io.vertx.core.http.HttpMethod.POST;
+import static io.vertx.core.http.HttpMethod.PUT;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.here.xyz.XyzSerializable;
 import com.here.xyz.jobs.Job;
 import com.here.xyz.jobs.RuntimeInfo;
 import com.here.xyz.jobs.RuntimeInfo.State;
+import com.here.xyz.jobs.config.JobConfigClient;
 import com.here.xyz.jobs.steps.Step;
 import com.here.xyz.jobs.steps.execution.JobExecutor;
 import com.here.xyz.jobs.steps.execution.SFNInspector;
@@ -59,6 +61,7 @@ public class JobAdminApi extends JobApiBase {
   private static final String ADMIN_JOB_STEP = ADMIN_JOB_STEPS + "/:stepId";
   private static final String ADMIN_JOB_STEP_STATUS = ADMIN_JOB_STEP + "/status";
   private static final String ADMIN_STATE_MACHINE_EVENTS = "/admin/state/events";
+  private static final String ADMIN_SERVICE_SCHEDULER_STATE = "/admin/service/scheduler/state";
 
   public JobAdminApi(Router router) {
     router.route(GET, ADMIN_JOBS).handler(handleErrors(this::getJobs));
@@ -68,6 +71,8 @@ public class JobAdminApi extends JobApiBase {
     router.route(GET, ADMIN_JOB_STEP).handler(handleErrors(this::getStep));
     router.route(POST, ADMIN_JOB_STEP_STATUS).handler(handleErrors(this::postStepStatus));
     router.route(POST, ADMIN_STATE_MACHINE_EVENTS).handler(handleErrors(this::postStateEvent));
+    router.route(GET, ADMIN_SERVICE_SCHEDULER_STATE).handler(handleErrors(this::getSchedulerState));
+    router.route(PUT, ADMIN_SERVICE_SCHEDULER_STATE).handler(handleErrors(this::putSchedulerState));
   }
 
   private void getJobs(RoutingContext context) {
@@ -432,6 +437,10 @@ public class JobAdminApi extends JobApiBase {
     return deserializeFromBody(context, Job.class);
   }
 
+  private SchedulerStateRequest getStateRequestFromBody(RoutingContext context) throws HttpException {
+    return deserializeFromBody(context, SchedulerStateRequest.class);
+  }
+
   private <T extends XyzSerializable> T deserializeFromBody(RoutingContext context, Class<T> type) throws HttpException {
     try {
       return XyzSerializable.deserialize(context.body().asString(), type);
@@ -444,4 +453,94 @@ public class JobAdminApi extends JobApiBase {
   private static String stepId(RoutingContext context) {
     return context.pathParam("stepId");
   }
+
+  private void putSchedulerState(RoutingContext context) throws HttpException {
+    String body = context.body().asString();
+    if (body == null)
+      throw new HttpException(BAD_REQUEST, "Request body must be a JSON object.");
+
+    SchedulerStateRequest request =  getStateRequestFromBody(context);
+    boolean changeApplied = false;
+
+    if (request.state() != null) {
+      switch (request.state()) {
+        // As requested: START pauses scheduler pickup; STOP resumes pickup.
+        case START -> JobExecutor.resumeScheduling();
+        case STOP -> JobExecutor.pauseScheduling();
+        default -> throw new HttpException(BAD_REQUEST, "State must be either START or STOP.");
+      }
+      changeApplied = true;
+    }
+
+    if (request.singleJobAllowedPoliciesEnabled() != null) {
+      JobExecutor.setSingleJobAllowedPoliciesEnabled(request.singleJobAllowedPoliciesEnabled());
+      changeApplied = true;
+    }
+
+    if (request.singleJobPerResourceEnabled() != null) {
+      JobExecutor.setSingleJobPerResourceEnabled(request.singleJobPerResourceEnabled());
+      changeApplied = true;
+    }
+
+    if (!changeApplied)
+      throw new HttpException(BAD_REQUEST,
+          "Nothing to update. Provide 'state', 'singleJobAllowedPoliciesEnabled' and/or 'singleJobPerResourceEnabled'.");
+
+    loadSchedulerState(true)
+        .onSuccess(state -> sendResponse(context, OK, state))
+        .onFailure(t -> sendErrorResponse(context, t));
+  }
+
+  private void getSchedulerState(RoutingContext context) {
+    loadSchedulerState(true)
+        .onSuccess(state -> sendResponse(context, OK, state))
+        .onFailure(t -> sendErrorResponse(context, t));
+  }
+
+  private Future<SchedulerStateResponse> loadSchedulerState(boolean includeCounts) {
+    SchedulerStateResponse base = new SchedulerStateResponse(
+        JobExecutor.isSchedulingPaused() ? SchedulerRuntimeState.PAUSED : SchedulerRuntimeState.RUNNING,
+        JobExecutor.isSingleJobAllowedPoliciesEnabled(),
+        JobExecutor.isSingleJobPerResourceEnabled(),
+        null,
+        null
+    );
+
+    if (!includeCounts)
+      return Future.succeededFuture(base);
+
+    return JobConfigClient.getInstance().loadJobs(RUNNING)
+        .compose(runningJobs -> JobConfigClient.getInstance().loadJobs(PENDING)
+            .map(pendingJobs -> new SchedulerStateResponse(
+                base.state(),
+                base.singleJobAllowedPoliciesEnabled(),
+                base.singleJobPerResourceEnabled(),
+                runningJobs.size(),
+                pendingJobs.size()
+            )));
+  }
+
+  private record SchedulerStateRequest(
+      SchedulerControlState state,
+      Boolean singleJobAllowedPoliciesEnabled,
+      Boolean singleJobPerResourceEnabled
+  ) implements XyzSerializable {}
+
+  private enum SchedulerControlState {
+    START,
+    STOP
+  }
+
+  private enum SchedulerRuntimeState {
+    RUNNING,
+    PAUSED
+  }
+
+  private record SchedulerStateResponse(
+      SchedulerRuntimeState state,
+      boolean singleJobAllowedPoliciesEnabled,
+      boolean singleJobPerResourceEnabled,
+      Integer runningJobs,
+      Integer queuedJobs
+  ) implements XyzSerializable {}
 }

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/service/JobAdminApi.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/service/JobAdminApi.java
@@ -465,13 +465,13 @@ public class JobAdminApi extends JobApiBase {
       throw new HttpException(BAD_REQUEST,
           "Nothing to update. Provide 'state', 'singleJobAllowedPoliciesEnabled' and/or 'singleJobPerResourceEnabled'.");
 
-    JobExecutor.loadSchedulerState(true)
+    JobExecutor.loadSchedulerState()
         .onSuccess(state -> sendResponse(context, OK, state))
         .onFailure(t -> sendErrorResponse(context, t));
   }
 
   private void getSchedulerState(RoutingContext context) {
-    JobExecutor.loadSchedulerState(true)
+    JobExecutor.loadSchedulerState()
         .onSuccess(state -> sendResponse(context, OK, state))
         .onFailure(t -> sendErrorResponse(context, t));
   }

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/service/JobAdminApi.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/service/JobAdminApi.java
@@ -42,7 +42,6 @@ import com.here.xyz.XyzSerializable;
 import com.here.xyz.jobs.Job;
 import com.here.xyz.jobs.RuntimeInfo;
 import com.here.xyz.jobs.RuntimeInfo.State;
-import com.here.xyz.jobs.config.JobConfigClient;
 import com.here.xyz.jobs.steps.Step;
 import com.here.xyz.jobs.steps.execution.JobExecutor;
 import com.here.xyz.jobs.steps.execution.SFNInspector;
@@ -437,8 +436,8 @@ public class JobAdminApi extends JobApiBase {
     return deserializeFromBody(context, Job.class);
   }
 
-  private SchedulerStateRequest getStateRequestFromBody(RoutingContext context) throws HttpException {
-    return deserializeFromBody(context, SchedulerStateRequest.class);
+  private JobExecutor.SchedulerState getStateRequestFromBody(RoutingContext context) throws HttpException {
+    return deserializeFromBody(context, JobExecutor.SchedulerState.class);
   }
 
   private <T extends XyzSerializable> T deserializeFromBody(RoutingContext context, Class<T> type) throws HttpException {
@@ -459,88 +458,21 @@ public class JobAdminApi extends JobApiBase {
     if (body == null)
       throw new HttpException(BAD_REQUEST, "Request body must be a JSON object.");
 
-    SchedulerStateRequest request =  getStateRequestFromBody(context);
-    boolean changeApplied = false;
-
-    if (request.state() != null) {
-      switch (request.state()) {
-        // As requested: START pauses scheduler pickup; STOP resumes pickup.
-        case START -> JobExecutor.resumeScheduling();
-        case STOP -> JobExecutor.pauseScheduling();
-        default -> throw new HttpException(BAD_REQUEST, "State must be either START or STOP.");
-      }
-      changeApplied = true;
-    }
-
-    if (request.singleJobAllowedPoliciesEnabled() != null) {
-      JobExecutor.setSingleJobAllowedPoliciesEnabled(request.singleJobAllowedPoliciesEnabled());
-      changeApplied = true;
-    }
-
-    if (request.singleJobPerResourceEnabled() != null) {
-      JobExecutor.setSingleJobPerResourceEnabled(request.singleJobPerResourceEnabled());
-      changeApplied = true;
-    }
+    JobExecutor.SchedulerState request = getStateRequestFromBody(context);
+    boolean changeApplied = JobExecutor.applySchedulerState(request);
 
     if (!changeApplied)
       throw new HttpException(BAD_REQUEST,
           "Nothing to update. Provide 'state', 'singleJobAllowedPoliciesEnabled' and/or 'singleJobPerResourceEnabled'.");
 
-    loadSchedulerState(true)
+    JobExecutor.loadSchedulerState(true)
         .onSuccess(state -> sendResponse(context, OK, state))
         .onFailure(t -> sendErrorResponse(context, t));
   }
 
   private void getSchedulerState(RoutingContext context) {
-    loadSchedulerState(true)
+    JobExecutor.loadSchedulerState(true)
         .onSuccess(state -> sendResponse(context, OK, state))
         .onFailure(t -> sendErrorResponse(context, t));
   }
-
-  private Future<SchedulerStateResponse> loadSchedulerState(boolean includeCounts) {
-    SchedulerStateResponse base = new SchedulerStateResponse(
-        JobExecutor.isSchedulingPaused() ? SchedulerRuntimeState.PAUSED : SchedulerRuntimeState.RUNNING,
-        JobExecutor.isSingleJobAllowedPoliciesEnabled(),
-        JobExecutor.isSingleJobPerResourceEnabled(),
-        null,
-        null
-    );
-
-    if (!includeCounts)
-      return Future.succeededFuture(base);
-
-    return JobConfigClient.getInstance().loadJobs(RUNNING)
-        .compose(runningJobs -> JobConfigClient.getInstance().loadJobs(PENDING)
-            .map(pendingJobs -> new SchedulerStateResponse(
-                base.state(),
-                base.singleJobAllowedPoliciesEnabled(),
-                base.singleJobPerResourceEnabled(),
-                runningJobs.size(),
-                pendingJobs.size()
-            )));
-  }
-
-  private record SchedulerStateRequest(
-      SchedulerControlState state,
-      Boolean singleJobAllowedPoliciesEnabled,
-      Boolean singleJobPerResourceEnabled
-  ) implements XyzSerializable {}
-
-  private enum SchedulerControlState {
-    START,
-    STOP
-  }
-
-  private enum SchedulerRuntimeState {
-    RUNNING,
-    PAUSED
-  }
-
-  private record SchedulerStateResponse(
-      SchedulerRuntimeState state,
-      boolean singleJobAllowedPoliciesEnabled,
-      boolean singleJobPerResourceEnabled,
-      Integer runningJobs,
-      Integer queuedJobs
-  ) implements XyzSerializable {}
 }

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/service/JobAdminApi.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/service/JobAdminApi.java
@@ -36,6 +36,7 @@ import static io.vertx.core.http.HttpMethod.DELETE;
 import static io.vertx.core.http.HttpMethod.GET;
 import static io.vertx.core.http.HttpMethod.POST;
 import static io.vertx.core.http.HttpMethod.PUT;
+import static com.here.xyz.jobs.steps.execution.JobExecutor.SchedulerStatePatch;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.here.xyz.XyzSerializable;
@@ -436,8 +437,8 @@ public class JobAdminApi extends JobApiBase {
     return deserializeFromBody(context, Job.class);
   }
 
-  private JobExecutor.SchedulerState getStateRequestFromBody(RoutingContext context) throws HttpException {
-    return deserializeFromBody(context, JobExecutor.SchedulerState.class);
+  private SchedulerStatePatch getStateRequestFromBody(RoutingContext context) throws HttpException {
+    return deserializeFromBody(context, SchedulerStatePatch.class);
   }
 
   private <T extends XyzSerializable> T deserializeFromBody(RoutingContext context, Class<T> type) throws HttpException {
@@ -458,7 +459,7 @@ public class JobAdminApi extends JobApiBase {
     if (body == null)
       throw new HttpException(BAD_REQUEST, "Request body must be a JSON object.");
 
-    JobExecutor.SchedulerState request = getStateRequestFromBody(context);
+    SchedulerStatePatch request = getStateRequestFromBody(context);
     boolean changeApplied = JobExecutor.applySchedulerState(request);
 
     if (!changeApplied)

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/execution/JobExecutor.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/execution/JobExecutor.java
@@ -59,19 +59,19 @@ public abstract class JobExecutor implements Initializable {
   private static volatile boolean running;
   private static volatile boolean stopRequested;
   private static AtomicBoolean cancellationCheckRunning = new AtomicBoolean();
-  private static final long CANCELLATION_TIMEOUT = 10 * 60 * 1_000; //10 min
-  private static final long CANCELLATION_CHECK_RERUN_PERIOD = 10_000; //10 sec
-  private static final long JOB_START_TIMEOUT = 60_000;
-  private static Set<Predicate<Job>> singleJobAllowedPolicies = new ConcurrentHashSet<>();
-
+  private static final AtomicBoolean schedulerPaused = new AtomicBoolean(false);
+  private static final AtomicBoolean singleJobAllowedPoliciesEnabled = new AtomicBoolean(true);
   /**
    * Global switch to enable/disable the "one active job per resource" policy.
    * <p>When enabled, a job will not be started (it stays in PENDING) if any other RUNNING job
    * shares at least one resource key (source or target) with it. This prevents concurrent
    * imports writing to the same target or concurrent exports reading from the same source.
-   * <p>Defaults to {@code false} to preserve previous behavior.
    */
-  public static volatile boolean singleJobPerResourceEnabled = true;
+  private static final AtomicBoolean singleJobPerResourceEnabled = new AtomicBoolean(true);
+  private static final long CANCELLATION_TIMEOUT = 10 * 60 * 1_000; //10 min
+  private static final long CANCELLATION_CHECK_RERUN_PERIOD = 10_000; //10 sec
+  private static final long JOB_START_TIMEOUT = 60_000;
+  private static Set<Predicate<Job>> singleJobAllowedPolicies = new ConcurrentHashSet<>();
 
   {
     exec.scheduleWithFixedDelay(this::checkPendingJobs, 10, 60, SECONDS);
@@ -84,6 +84,11 @@ public abstract class JobExecutor implements Initializable {
   }
 
   public final Future<Void> startExecution(Job job, String formerExecutionId) {
+    if (isSchedulingPaused()) {
+      logger.info("[{}] Scheduler is paused. Job remains in PENDING and will not be started.", job.getId());
+      return Future.succeededFuture();
+    }
+
     //TODO: Care about concurrency between nodes when it comes to resource-load calculation within this thread
     return Future.succeededFuture()
         .compose(v -> formerExecutionId == null ? reuseExistingJobIfPossible(job) : Future.succeededFuture())
@@ -133,6 +138,12 @@ public abstract class JobExecutor implements Initializable {
     if (stopRequested) {
       //Do not start an execution if a stop was requested
       running = false;
+      return;
+    }
+
+    if (isSchedulingPaused()) {
+      running = false;
+      logger.info("[checkPendingJobs] Scheduler is paused. Skipping check of pending jobs...");
       return;
     }
 
@@ -364,7 +375,7 @@ public abstract class JobExecutor implements Initializable {
    *         resources (in which case the job remains in PENDING and is re-checked later).
    */
   private static Future<Boolean> singleJobPerResourceSatisfied(Job job) {
-    if (!singleJobPerResourceEnabled)
+    if (!isSingleJobPerResourceEnabled())
       return Future.succeededFuture(true);
 
     Set<String> resourceKeys = job.getResourceKeys();
@@ -433,6 +444,9 @@ public abstract class JobExecutor implements Initializable {
   }
 
   private Future<Boolean> executionPoliciesSatisfied(Job job) {
+    if (!isSingleJobAllowedPoliciesEnabled())
+      return Future.succeededFuture(true);
+
     logger.info("[{}] Checking all execution policies prior to executing the job ...", job.getId());
     Set<Predicate<Job>> policiesToApply = findMatchingJobPolicies(job);
     if (policiesToApply.isEmpty())
@@ -507,6 +521,34 @@ public abstract class JobExecutor implements Initializable {
 
   public static void registerSingleJobAllowedPolicy(Predicate<Job> policy) {
     singleJobAllowedPolicies.add(policy);
+  }
+
+  public static void pauseScheduling() {
+    schedulerPaused.set(true);
+  }
+
+  public static void resumeScheduling() {
+    schedulerPaused.set(false);
+  }
+
+  public static boolean isSchedulingPaused() {
+    return schedulerPaused.get();
+  }
+
+  public static void setSingleJobAllowedPoliciesEnabled(boolean enabled) {
+    singleJobAllowedPoliciesEnabled.set(enabled);
+  }
+
+  public static boolean isSingleJobAllowedPoliciesEnabled() {
+    return singleJobAllowedPoliciesEnabled.get();
+  }
+
+  public static void setSingleJobPerResourceEnabled(boolean enabled) {
+    singleJobPerResourceEnabled.set(enabled);
+  }
+
+  public static boolean isSingleJobPerResourceEnabled() {
+    return singleJobPerResourceEnabled.get();
   }
 
   private static Set<Predicate<Job>> findMatchingJobPolicies(Job job) {

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/execution/JobExecutor.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/execution/JobExecutor.java
@@ -64,6 +64,15 @@ public abstract class JobExecutor implements Initializable {
   private static final long JOB_START_TIMEOUT = 60_000;
   private static Set<Predicate<Job>> singleJobAllowedPolicies = new ConcurrentHashSet<>();
 
+  /**
+   * Global switch to enable/disable the "one active job per resource" policy.
+   * <p>When enabled, a job will not be started (it stays in PENDING) if any other RUNNING job
+   * shares at least one resource key (source or target) with it. This prevents concurrent
+   * imports writing to the same target or concurrent exports reading from the same source.
+   * <p>Defaults to {@code false} to preserve previous behavior.
+   */
+  public static volatile boolean singleJobPerResourceEnabled = true;
+
   {
     exec.scheduleWithFixedDelay(this::checkPendingJobs, 10, 60, SECONDS);
   }
@@ -334,11 +343,77 @@ public abstract class JobExecutor implements Initializable {
   private Future<Boolean> mayExecute(Job job) {
     //Check execution policies and resources
     return executionPoliciesSatisfied(job)
-        .compose(policiesSatisfied -> {
-          if (!policiesSatisfied)
+            .compose(policiesSatisfied -> {
+              if (!policiesSatisfied)
+                return Future.succeededFuture(false);
+              return singleJobPerResourceSatisfied(job);
+            })
+            .compose(singleJobCanGetStarted -> {
+              if (!singleJobCanGetStarted)
+                return Future.succeededFuture(false);
+              return enoughResourcesAvailable(job);
+            });
+  }
+
+  /**
+   * If {@link #singleJobPerResourceEnabled} is on, ensures no other RUNNING job shares any
+   * resource key (source/target) with the given job.
+   *
+   * @return A future that resolves to true if the job may execute, false if another RUNNING job
+   *         already occupies one of its resources or an older PENDING job exists for overlapping
+   *         resources (in which case the job remains in PENDING and is re-checked later).
+   */
+  private static Future<Boolean> singleJobPerResourceSatisfied(Job job) {
+    if (!singleJobPerResourceEnabled)
+      return Future.succeededFuture(true);
+
+    Set<String> resourceKeys = job.getResourceKeys();
+    if (resourceKeys == null || resourceKeys.isEmpty())
+      return Future.succeededFuture(true);
+
+    return JobConfigClient.getInstance().loadJobs(resourceKeys, RUNNING)
+        .compose(runningJobs -> {
+          //Filter the job itself in case its state is already RUNNING when this check runs
+          List<Job> conflictingRunning = runningJobs.stream()
+              .filter(other -> !job.getId().equals(other.getId()))
+              .toList();
+
+          if (!conflictingRunning.isEmpty()) {
+            logger.info("[{}] Job can not be executed (yet) because the following RUNNING job(s) already occupy at least one of "
+                    + "its source/target resources: {}",
+                job.getId(),
+                conflictingRunning.stream().map(Job::getId).collect(Collectors.joining(", ")));
             return Future.succeededFuture(false);
-          return enoughResourcesAvailable(job);
+          }
+
+          //No RUNNING conflict exists. Enforce FIFO for pending jobs on overlapping resources.
+          return JobConfigClient.getInstance().loadJobs(resourceKeys, PENDING)
+              .map(pendingJobs -> {
+                List<Job> olderPendingConflicts = pendingJobs.stream()
+                    .filter(other -> !job.getId().equals(other.getId()))
+                    .filter(other -> compareBySchedulingOrder(other, job) < 0)
+                    .sorted(JobExecutor::compareBySchedulingOrder)
+                    .toList();
+
+                if (olderPendingConflicts.isEmpty())
+                  return true;
+
+                logger.info("[{}] Job can not be executed (yet) because older PENDING job(s) exist for overlapping resources: {}",
+                    job.getId(),
+                    olderPendingConflicts.stream().map(Job::getId).collect(Collectors.joining(", ")));
+                return false;
+              });
         });
+  }
+
+  private static int compareBySchedulingOrder(Job left, Job right) {
+    int byCreatedAt = Long.compare(left.getCreatedAt(), right.getCreatedAt());
+    if (byCreatedAt != 0)
+      return byCreatedAt;
+
+    String leftId = left.getId() == null ? "" : left.getId();
+    String rightId = right.getId() == null ? "" : right.getId();
+    return leftId.compareTo(rightId);
   }
 
   private static Future<Boolean> enoughResourcesAvailable(Job job) {

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/execution/JobExecutor.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/execution/JobExecutor.java
@@ -25,6 +25,7 @@ import static com.here.xyz.jobs.RuntimeInfo.State.FAILED;
 import static com.here.xyz.jobs.RuntimeInfo.State.PENDING;
 import static com.here.xyz.jobs.RuntimeInfo.State.RUNNING;
 import static com.here.xyz.jobs.RuntimeInfo.State.SUCCEEDED;
+import static com.here.xyz.jobs.steps.execution.JobExecutor.SchedulerState.SchedulerRuntimeState.PAUSED;
 import static com.here.xyz.jobs.steps.execution.GraphFusionTool.fuseGraphs;
 import static java.util.Comparator.comparingLong;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -43,6 +44,7 @@ import com.here.xyz.util.service.Initializable;
 import io.vertx.core.Future;
 import io.vertx.core.impl.ConcurrentHashSet;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Executors;
@@ -83,6 +85,17 @@ public abstract class JobExecutor implements Initializable {
       PAUSED
     }
   }
+
+  /**
+   * Partial update payload for {@link SchedulerState}. All fields are nullable; only non-null fields
+   * are applied to the current state. This allows callers to update a single flag without having to
+   * resend the complete state.
+   */
+  public record SchedulerStatePatch(
+          SchedulerState.SchedulerRuntimeState state,
+          Boolean singleJobAllowedPoliciesEnabled,
+          Boolean singleJobPerResourceEnabled
+  ) implements XyzSerializable {}
 
   {
     exec.scheduleWithFixedDelay(this::checkPendingJobs, 10, 60, SECONDS);
@@ -363,18 +376,28 @@ public abstract class JobExecutor implements Initializable {
    * @return true, if the job may be executed / enough resources are free
    */
   private Future<Boolean> mayExecute(Job job) {
-    //Check execution policies and resources
-    return executionPoliciesSatisfied(job)
+    Set<Predicate<Job>> policiesToApply = isSingleJobAllowedPoliciesEnabled() ? findMatchingJobPolicies(job) : Set.of();
+    boolean needRunningForPolicies = !policiesToApply.isEmpty();
+    boolean needRunningForResources = isSingleJobPerResourceEnabled()
+        && job.getResourceKeys() != null && !job.getResourceKeys().isEmpty();
+
+    //Load RUNNING-jobs list once - only if needed.
+    Future<List<Job>> runningJobsFuture = (needRunningForPolicies || needRunningForResources)
+        ? JobConfigClient.getInstance().loadJobs(RUNNING)
+        : Future.succeededFuture(List.of());
+
+    return runningJobsFuture
+        .compose(runningJobs -> executionPoliciesSatisfied(job, runningJobs, policiesToApply)
             .compose(policiesSatisfied -> {
               if (!policiesSatisfied)
                 return Future.succeededFuture(false);
-              return singleJobPerResourceSatisfied(job);
+              return singleJobPerResourceSatisfied(job, runningJobs);
             })
             .compose(singleJobCanGetStarted -> {
               if (!singleJobCanGetStarted)
                 return Future.succeededFuture(false);
               return enoughResourcesAvailable(job);
-            });
+            }));
   }
 
   /**
@@ -385,7 +408,7 @@ public abstract class JobExecutor implements Initializable {
    *         already occupies one of its resources or an older PENDING job exists for overlapping
    *         resources (in which case the job remains in PENDING and is re-checked later).
    */
-  private static Future<Boolean> singleJobPerResourceSatisfied(Job job) {
+  private static Future<Boolean> singleJobPerResourceSatisfied(Job job, List<Job> runningJobs) {
     if (!isSingleJobPerResourceEnabled())
       return Future.succeededFuture(true);
 
@@ -393,41 +416,40 @@ public abstract class JobExecutor implements Initializable {
     if (resourceKeys == null || resourceKeys.isEmpty())
       return Future.succeededFuture(true);
 
-    return JobConfigClient.getInstance().loadJobs(resourceKeys, RUNNING)
-        .compose(runningJobs -> {
-          //Filter the job itself in case its state is already RUNNING when this check runs
-          List<Job> conflictingRunning = runningJobs.stream()
+    //Filter the pre-loaded RUNNING jobs to those sharing at
+    //least one resource key (and excluding the job itself)
+    List<Job> conflictingRunning = runningJobs.stream()
+        .filter(other -> !job.getId().equals(other.getId()))
+        .filter(other -> other.getResourceKeys() != null && !Collections.disjoint(other.getResourceKeys(), resourceKeys))
+        .toList();
+
+    if (!conflictingRunning.isEmpty()) {
+      logger.info("[{}] Job can not be executed (yet) because the following RUNNING job(s) already occupy at least one of "
+              + "its source/target resources: {}",
+          job.getId(),
+          conflictingRunning.stream().map(Job::getId).collect(Collectors.joining(", ")));
+      return Future.succeededFuture(false);
+    }
+
+    //No RUNNING conflict exists. Enforce FIFO for pending jobs on overlapping resources.
+    //NOTE: This check is still needed even though checkPendingJobs() sorts by createdAt, because:
+    // 1. A job directly submitted via startExecution() (outside the poll loop) has no ordering guarantee.
+    // 2. An older job blocked by insufficient virtual units stays PENDING while a newer job could otherwise jump ahead.
+    return JobConfigClient.getInstance().loadJobs(resourceKeys, PENDING)
+        .map(pendingJobs -> {
+          List<Job> olderPendingConflicts = pendingJobs.stream()
               .filter(other -> !job.getId().equals(other.getId()))
+              .filter(other -> other.getCreatedAt() < job.getCreatedAt())
+              .sorted(comparingLong(Job::getCreatedAt))
               .toList();
 
-          if (!conflictingRunning.isEmpty()) {
-            logger.info("[{}] Job can not be executed (yet) because the following RUNNING job(s) already occupy at least one of "
-                    + "its source/target resources: {}",
-                job.getId(),
-                conflictingRunning.stream().map(Job::getId).collect(Collectors.joining(", ")));
-            return Future.succeededFuture(false);
-          }
+          if (olderPendingConflicts.isEmpty())
+            return true;
 
-          //No RUNNING conflict exists. Enforce FIFO for pending jobs on overlapping resources.
-          //NOTE: This check is still needed even though checkPendingJobs() sorts by createdAt, because:
-          // 1. A job directly submitted via startExecution() (outside the poll loop) has no ordering guarantee.
-          // 2. An older job blocked by insufficient virtual units stays PENDING while a newer job could otherwise jump ahead.
-          return JobConfigClient.getInstance().loadJobs(resourceKeys, PENDING)
-              .map(pendingJobs -> {
-                List<Job> olderPendingConflicts = pendingJobs.stream()
-                    .filter(other -> !job.getId().equals(other.getId()))
-                    .filter(other -> other.getCreatedAt() < job.getCreatedAt())
-                    .sorted(comparingLong(Job::getCreatedAt))
-                    .toList();
-
-                if (olderPendingConflicts.isEmpty())
-                  return true;
-
-                logger.info("[{}] Job can not be executed (yet) because older PENDING job(s) exist for overlapping resources: {}",
-                    job.getId(),
-                    olderPendingConflicts.stream().map(Job::getId).collect(Collectors.joining(", ")));
-                return false;
-              });
+          logger.info("[{}] Job can not be executed (yet) because older PENDING job(s) exist for overlapping resources: {}",
+              job.getId(),
+              olderPendingConflicts.stream().map(Job::getId).collect(Collectors.joining(", ")));
+          return false;
         });
   }
 
@@ -447,21 +469,15 @@ public abstract class JobExecutor implements Initializable {
             })));
   }
 
-  private Future<Boolean> executionPoliciesSatisfied(Job job) {
-    if (!isSingleJobAllowedPoliciesEnabled())
-      return Future.succeededFuture(true);
-
-    logger.info("[{}] Checking all execution policies prior to executing the job ...", job.getId());
-    Set<Predicate<Job>> policiesToApply = findMatchingJobPolicies(job);
+  private Future<Boolean> executionPoliciesSatisfied(Job job, List<Job> runningJobs, Set<Predicate<Job>> policiesToApply) {
     if (policiesToApply.isEmpty())
       return Future.succeededFuture(true);
 
+    logger.info("[{}] Checking all execution policies prior to executing the job ...", job.getId());
+
     //Check if there exists at least one other RUNNING job that matches one of the policies (if yes, the current job may not be executed)
-    return JobConfigClient.getInstance()
-        .loadJobs(RUNNING)
-        .compose(runningJobs ->
-            Future.succeededFuture(runningJobs.stream().noneMatch(runningJob ->
-                policiesToApply.stream().anyMatch(policy -> policy.test(runningJob)))));
+    return Future.succeededFuture(runningJobs.stream().noneMatch(runningJob ->
+        policiesToApply.stream().anyMatch(policy -> policy.test(runningJob))));
   }
 
   private Future<Boolean> needsExecution(Job job) {
@@ -528,7 +544,7 @@ public abstract class JobExecutor implements Initializable {
   }
 
   public static boolean isSchedulingPaused() {
-    return schedulerState.state() == SchedulerState.SchedulerRuntimeState.PAUSED;
+    return schedulerState.state() == PAUSED;
   }
 
   public static boolean isSingleJobAllowedPoliciesEnabled() {
@@ -539,11 +555,21 @@ public abstract class JobExecutor implements Initializable {
     return schedulerState.singleJobPerResourceEnabled();
   }
 
-  public static boolean applySchedulerState(SchedulerState patch) {
-    if (patch == null || patch.state() == null)
+  public static boolean applySchedulerState(SchedulerStatePatch patch) {
+    if (patch == null
+        || (patch.state() == null
+            && patch.singleJobAllowedPoliciesEnabled() == null
+            && patch.singleJobPerResourceEnabled() == null))
       return false;
 
-    schedulerState = patch;
+    SchedulerState current = schedulerState;
+    schedulerState = new SchedulerState(
+        patch.state() != null ? patch.state() : current.state(),
+        patch.singleJobAllowedPoliciesEnabled() != null
+            ? patch.singleJobAllowedPoliciesEnabled() : current.singleJobAllowedPoliciesEnabled(),
+        patch.singleJobPerResourceEnabled() != null
+            ? patch.singleJobPerResourceEnabled() : current.singleJobPerResourceEnabled()
+    );
     return true;
   }
 

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/execution/JobExecutor.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/execution/JobExecutor.java
@@ -30,6 +30,7 @@ import static java.util.Comparator.comparingLong;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
+import com.here.xyz.XyzSerializable;
 import com.here.xyz.jobs.Job;
 import com.here.xyz.jobs.RuntimeInfo.State;
 import com.here.xyz.jobs.config.JobConfigClient;
@@ -59,19 +60,32 @@ public abstract class JobExecutor implements Initializable {
   private static volatile boolean running;
   private static volatile boolean stopRequested;
   private static AtomicBoolean cancellationCheckRunning = new AtomicBoolean();
-  private static final AtomicBoolean schedulerPaused = new AtomicBoolean(false);
-  private static final AtomicBoolean singleJobAllowedPoliciesEnabled = new AtomicBoolean(true);
   /**
-   * Global switch to enable/disable the "one active job per resource" policy.
-   * <p>When enabled, a job will not be started (it stays in PENDING) if any other RUNNING job
-   * shares at least one resource key (source or target) with it. This prevents concurrent
-   * imports writing to the same target or concurrent exports reading from the same source.
+   * Live scheduler configuration. The {@code runningJobs}/{@code queuedJobs} fields are always
+   * {@code null} here; they are filled in dynamically by {@link #loadSchedulerState(boolean)}.
+   * <p>Defaults: state={@code RUNNING}, singleJobAllowedPoliciesEnabled={@code true},
+   * singleJobPerResourceEnabled={@code true}.
    */
-  private static final AtomicBoolean singleJobPerResourceEnabled = new AtomicBoolean(true);
+  private static volatile SchedulerState schedulerState = new SchedulerState(
+      SchedulerState.SchedulerRuntimeState.RUNNING, true, true, null, null
+  );
   private static final long CANCELLATION_TIMEOUT = 10 * 60 * 1_000; //10 min
   private static final long CANCELLATION_CHECK_RERUN_PERIOD = 10_000; //10 sec
   private static final long JOB_START_TIMEOUT = 60_000;
   private static Set<Predicate<Job>> singleJobAllowedPolicies = new ConcurrentHashSet<>();
+
+  public record SchedulerState(
+          SchedulerRuntimeState state,
+          Boolean singleJobAllowedPoliciesEnabled,
+          Boolean singleJobPerResourceEnabled,
+          Integer runningJobs,
+          Integer queuedJobs
+  ) implements XyzSerializable {
+    public enum SchedulerRuntimeState {
+      RUNNING,
+      PAUSED
+    }
+  }
 
   {
     exec.scheduleWithFixedDelay(this::checkPendingJobs, 10, 60, SECONDS);
@@ -367,7 +381,7 @@ public abstract class JobExecutor implements Initializable {
   }
 
   /**
-   * If {@link #singleJobPerResourceEnabled} is on, ensures no other RUNNING job shares any
+   * If the {@code singleJobPerResourceEnabled} flag is on, ensures no other RUNNING job shares any
    * resource key (source/target) with the given job.
    *
    * @return A future that resolves to true if the job may execute, false if another RUNNING job
@@ -398,12 +412,15 @@ public abstract class JobExecutor implements Initializable {
           }
 
           //No RUNNING conflict exists. Enforce FIFO for pending jobs on overlapping resources.
+          //NOTE: This check is still needed even though checkPendingJobs() sorts by createdAt, because:
+          // 1. A job directly submitted via startExecution() (outside the poll loop) has no ordering guarantee.
+          // 2. An older job blocked by insufficient virtual units stays PENDING while a newer job could otherwise jump ahead.
           return JobConfigClient.getInstance().loadJobs(resourceKeys, PENDING)
               .map(pendingJobs -> {
                 List<Job> olderPendingConflicts = pendingJobs.stream()
                     .filter(other -> !job.getId().equals(other.getId()))
-                    .filter(other -> compareBySchedulingOrder(other, job) < 0)
-                    .sorted(JobExecutor::compareBySchedulingOrder)
+                    .filter(other -> other.getCreatedAt() < job.getCreatedAt())
+                    .sorted(comparingLong(Job::getCreatedAt))
                     .toList();
 
                 if (olderPendingConflicts.isEmpty())
@@ -415,16 +432,6 @@ public abstract class JobExecutor implements Initializable {
                 return false;
               });
         });
-  }
-
-  private static int compareBySchedulingOrder(Job left, Job right) {
-    int byCreatedAt = Long.compare(left.getCreatedAt(), right.getCreatedAt());
-    if (byCreatedAt != 0)
-      return byCreatedAt;
-
-    String leftId = left.getId() == null ? "" : left.getId();
-    String rightId = right.getId() == null ? "" : right.getId();
-    return leftId.compareTo(rightId);
   }
 
   private static Future<Boolean> enoughResourcesAvailable(Job job) {
@@ -523,32 +530,49 @@ public abstract class JobExecutor implements Initializable {
     singleJobAllowedPolicies.add(policy);
   }
 
-  public static void pauseScheduling() {
-    schedulerPaused.set(true);
-  }
-
-  public static void resumeScheduling() {
-    schedulerPaused.set(false);
-  }
-
   public static boolean isSchedulingPaused() {
-    return schedulerPaused.get();
-  }
-
-  public static void setSingleJobAllowedPoliciesEnabled(boolean enabled) {
-    singleJobAllowedPoliciesEnabled.set(enabled);
+    return schedulerState.state() == SchedulerState.SchedulerRuntimeState.PAUSED;
   }
 
   public static boolean isSingleJobAllowedPoliciesEnabled() {
-    return singleJobAllowedPoliciesEnabled.get();
-  }
-
-  public static void setSingleJobPerResourceEnabled(boolean enabled) {
-    singleJobPerResourceEnabled.set(enabled);
+    return schedulerState.singleJobAllowedPoliciesEnabled();
   }
 
   public static boolean isSingleJobPerResourceEnabled() {
-    return singleJobPerResourceEnabled.get();
+    return schedulerState.singleJobPerResourceEnabled();
+  }
+
+  public static boolean applySchedulerState(SchedulerState patch) {
+    if (patch == null)
+      return false;
+
+    if (patch.state() == null && patch.singleJobAllowedPoliciesEnabled() == null && patch.singleJobPerResourceEnabled() == null)
+      return false;
+
+    SchedulerState current = schedulerState;
+    schedulerState = new SchedulerState(
+        patch.state() != null ? patch.state() : current.state(),
+        patch.singleJobAllowedPoliciesEnabled() != null ? patch.singleJobAllowedPoliciesEnabled() : current.singleJobAllowedPoliciesEnabled(),
+        patch.singleJobPerResourceEnabled() != null ? patch.singleJobPerResourceEnabled() : current.singleJobPerResourceEnabled(),
+        null,
+        null
+    );
+    return true;
+  }
+
+  public static Future<SchedulerState> loadSchedulerState(boolean includeCounts) {
+    if (!includeCounts)
+      return Future.succeededFuture(schedulerState);
+
+    return JobConfigClient.getInstance().loadJobs(RUNNING)
+        .compose(runningJobs -> JobConfigClient.getInstance().loadJobs(PENDING)
+            .map(pendingJobs -> new SchedulerState(
+                schedulerState.state(),
+                schedulerState.singleJobAllowedPoliciesEnabled(),
+                schedulerState.singleJobPerResourceEnabled(),
+                runningJobs.size(),
+                pendingJobs.size()
+            )));
   }
 
   private static Set<Predicate<Job>> findMatchingJobPolicies(Job job) {

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/execution/JobExecutor.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/execution/JobExecutor.java
@@ -61,13 +61,12 @@ public abstract class JobExecutor implements Initializable {
   private static volatile boolean stopRequested;
   private static AtomicBoolean cancellationCheckRunning = new AtomicBoolean();
   /**
-   * Live scheduler configuration. The {@code runningJobs}/{@code queuedJobs} fields are always
-   * {@code null} here; they are filled in dynamically by {@link #loadSchedulerState(boolean)}.
+   * Live scheduler configuration.
    * <p>Defaults: state={@code RUNNING}, singleJobAllowedPoliciesEnabled={@code true},
    * singleJobPerResourceEnabled={@code true}.
    */
   private static volatile SchedulerState schedulerState = new SchedulerState(
-      SchedulerState.SchedulerRuntimeState.RUNNING, true, true, null, null
+      SchedulerState.SchedulerRuntimeState.RUNNING, true, true
   );
   private static final long CANCELLATION_TIMEOUT = 10 * 60 * 1_000; //10 min
   private static final long CANCELLATION_CHECK_RERUN_PERIOD = 10_000; //10 sec
@@ -76,10 +75,8 @@ public abstract class JobExecutor implements Initializable {
 
   public record SchedulerState(
           SchedulerRuntimeState state,
-          Boolean singleJobAllowedPoliciesEnabled,
-          Boolean singleJobPerResourceEnabled,
-          Integer runningJobs,
-          Integer queuedJobs
+          boolean singleJobAllowedPoliciesEnabled,
+          boolean singleJobPerResourceEnabled
   ) implements XyzSerializable {
     public enum SchedulerRuntimeState {
       RUNNING,
@@ -543,36 +540,15 @@ public abstract class JobExecutor implements Initializable {
   }
 
   public static boolean applySchedulerState(SchedulerState patch) {
-    if (patch == null)
+    if (patch == null || patch.state() == null)
       return false;
 
-    if (patch.state() == null && patch.singleJobAllowedPoliciesEnabled() == null && patch.singleJobPerResourceEnabled() == null)
-      return false;
-
-    SchedulerState current = schedulerState;
-    schedulerState = new SchedulerState(
-        patch.state() != null ? patch.state() : current.state(),
-        patch.singleJobAllowedPoliciesEnabled() != null ? patch.singleJobAllowedPoliciesEnabled() : current.singleJobAllowedPoliciesEnabled(),
-        patch.singleJobPerResourceEnabled() != null ? patch.singleJobPerResourceEnabled() : current.singleJobPerResourceEnabled(),
-        null,
-        null
-    );
+    schedulerState = patch;
     return true;
   }
 
-  public static Future<SchedulerState> loadSchedulerState(boolean includeCounts) {
-    if (!includeCounts)
-      return Future.succeededFuture(schedulerState);
-
-    return JobConfigClient.getInstance().loadJobs(RUNNING)
-        .compose(runningJobs -> JobConfigClient.getInstance().loadJobs(PENDING)
-            .map(pendingJobs -> new SchedulerState(
-                schedulerState.state(),
-                schedulerState.singleJobAllowedPoliciesEnabled(),
-                schedulerState.singleJobPerResourceEnabled(),
-                runningJobs.size(),
-                pendingJobs.size()
-            )));
+  public static Future<SchedulerState> loadSchedulerState() {
+    return Future.succeededFuture(schedulerState);
   }
 
   private static Set<Predicate<Job>> findMatchingJobPolicies(Job job) {


### PR DESCRIPTION
JobExecutor: 
* Implement single job per resource policy in JobExecutor. Enforce FIFO for pending jobs on overlapping resources.

JobAdminApi:
* Add new endpoint /admin/service/scheduler/state to control/configure scheduler during runtime.