### PR TITLE
Revert "DS-2253" + apply new fix.

### DIFF
--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/service/JobAdminApi.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/service/JobAdminApi.java
@@ -57,6 +57,7 @@ public class JobAdminApi extends JobApiBase {
   private static final String ADMIN_JOB = ADMIN_JOBS + "/:jobId";
   private static final String ADMIN_JOB_STEPS = ADMIN_JOB + "/steps";
   private static final String ADMIN_JOB_STEP = ADMIN_JOB_STEPS + "/:stepId";
+  private static final String ADMIN_JOB_STEP_STATUS = ADMIN_JOB_STEP + "/status";
   private static final String ADMIN_STATE_MACHINE_EVENTS = "/admin/state/events";
 
   public JobAdminApi(Router router) {
@@ -65,6 +66,7 @@ public class JobAdminApi extends JobApiBase {
     router.route(DELETE, ADMIN_JOBS).handler(handleErrors(this::deleteJob));
     router.route(POST, ADMIN_JOB_STEPS).handler(handleErrors(this::postStep));
     router.route(GET, ADMIN_JOB_STEP).handler(handleErrors(this::getStep));
+    router.route(POST, ADMIN_JOB_STEP_STATUS).handler(handleErrors(this::postStepStatus));
     router.route(POST, ADMIN_STATE_MACHINE_EVENTS).handler(handleErrors(this::postStateEvent));
   }
 
@@ -128,6 +130,13 @@ public class JobAdminApi extends JobApiBase {
         .onFailure(t -> sendErrorResponse(context, t));
   }
 
+  private void postStepStatus(RoutingContext context) throws HttpException {
+    RuntimeInfo status = deserializeFromBody(context, RuntimeInfo.class);
+    loadJob(jobId(context))
+        .compose(job -> job.updateStepStatus(stepId(context), status, true))
+        .onSuccess(v -> sendResponse(context, OK.code(), null))
+        .onFailure(t -> sendErrorResponse(context, t));
+  }
 
   /**
    * The sample event format in the request:

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/execution/LambdaBasedStep.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/execution/LambdaBasedStep.java
@@ -129,6 +129,9 @@ public abstract class LambdaBasedStep<T extends LambdaBasedStep> extends Step<T>
 
   private ARN ownLambdaArn; //Will be defined from Lambda's execution context
 
+  @JsonIgnore
+  private boolean statusOnlySync;
+
   private static final String INVOKE_SUCCESS = """
       {"status": "OK"}""";
 
@@ -553,7 +556,11 @@ public abstract class LambdaBasedStep<T extends LambdaBasedStep> extends Step<T>
       return;
     logger.info("Synchronizing step {} with the job service ...", getGlobalStepId());
     try {
-      StepWebClient.getInstance(Config.instance.JOB_API_ENDPOINT.toString()).postStepUpdate(this);
+      StepWebClient stepWebClient = StepWebClient.getInstance(Config.instance.JOB_API_ENDPOINT.toString());
+      if (statusOnlySync)
+        stepWebClient.postStepStatusUpdate(getJobId(), getId(), getStatus());
+      else
+        stepWebClient.postStepUpdate(this);
     }
     catch (ErrorResponseException httpError) {
       HttpResponse<byte[]> errorResponse = httpError.getErrorResponse();
@@ -726,6 +733,7 @@ public abstract class LambdaBasedStep<T extends LambdaBasedStep> extends Step<T>
           switch (request.getType()) {
             case STATE_CHECK -> {
               logger.info("Checking async execution state of step {} ...", request.getStep().getGlobalStepId());
+              request.getStep().statusOnlySync = true;
               request.getStep().checkAsyncExecutionState();
               logger.info("Async execution state of step {} has been checked & reported successfully.", request.getStep().getGlobalStepId());
             }

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/execution/LambdaBasedStep.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/execution/LambdaBasedStep.java
@@ -57,6 +57,8 @@ import com.here.xyz.util.service.aws.lambda.SimulatedContext;
 import com.here.xyz.util.web.HubWebClient;
 import com.here.xyz.util.web.XyzWebClient.ErrorResponseException;
 import com.here.xyz.util.web.XyzWebClient.WebClientException;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -100,7 +102,6 @@ public abstract class LambdaBasedStep<T extends LambdaBasedStep> extends Step<T>
   @JsonView(Internal.class)
   protected boolean isSimulation = false; //TODO: Remove testing code
   private static final Logger logger = LogManager.getLogger();
-  protected boolean inLambda;
 
   @JsonView(Internal.class)
   private String taskToken = TASK_TOKEN_TEMPLATE; //Will be defined by the Step Function
@@ -200,7 +201,7 @@ public abstract class LambdaBasedStep<T extends LambdaBasedStep> extends Step<T>
           .targets(Target.builder()
               .id(getGlobalStepId())
               .arn(ownLambdaArn.toString())
-              .input(new LambdaStepRequest().withType(STATE_CHECK).withStep(this).serialize())
+              .input(compactStateCheckInput(new LambdaStepRequest().withType(STATE_CHECK).withStep(this).serialize()))
               .build())
           .build());
     }
@@ -212,6 +213,27 @@ public abstract class LambdaBasedStep<T extends LambdaBasedStep> extends Step<T>
 
   private void unregisterStateCheckTrigger() {
     _unregisterStateCheckTriggerDeferred(0, 1);
+  }
+
+  static String compactStateCheckInput(String input) {
+    JsonObject payload = new JsonObject(input);
+    stripLargeFilters(payload);
+    return payload.encode();
+  }
+
+  private static void stripLargeFilters(Object node) {
+    if (node instanceof JsonObject jsonObject) {
+      // SpatialFilter fields can be very large (e.g., huge multipolygons) and are
+      // not needed for heartbeat/state-checks.
+      jsonObject.remove("spatialFilter");
+      for (String fieldName : List.copyOf(jsonObject.fieldNames()))
+        stripLargeFilters(jsonObject.getValue(fieldName));
+      return;
+    }
+
+    if (node instanceof JsonArray jsonArray)
+      for (int i = 0; i < jsonArray.size(); i++)
+        stripLargeFilters(jsonArray.getValue(i));
   }
 
   private void _unregisterStateCheckTriggerDeferred(long waitMs, int attempt) {
@@ -671,8 +693,6 @@ public abstract class LambdaBasedStep<T extends LambdaBasedStep> extends Step<T>
 
         if (request.getStep() == null)
           throw new NullPointerException("Malformed step request, missing step definition.");
-
-        request.getStep().inLambda = true;
 
         //Set the userAgent of the web clients correctly
         HubWebClient.userAgent = StepWebClient.userAgent = "XYZ-JobStep-" + request.getStep().getClass().getSimpleName();

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/CopySpace.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/CopySpace.java
@@ -1,6 +1,5 @@
 /*
  * Copyright (C) 2017-2026 HERE Europe B.V.
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -27,6 +26,7 @@ import static com.here.xyz.jobs.steps.impl.SpaceBasedStep.LogPhase.STEP_RESUME;
 
 import com.fasterxml.jackson.annotation.JsonView;
 import com.here.xyz.events.PropertiesQuery;
+import com.here.xyz.models.filters.SpatialFilter;
 import com.here.xyz.jobs.steps.execution.StepException;
 import com.here.xyz.jobs.steps.execution.db.Database;
 import com.here.xyz.jobs.steps.impl.SpaceBasedStep;
@@ -34,7 +34,6 @@ import com.here.xyz.jobs.steps.inputs.InputFromOutput;
 import com.here.xyz.jobs.steps.outputs.CreatedVersion;
 import com.here.xyz.jobs.steps.resources.Load;
 import com.here.xyz.jobs.steps.resources.TooManyResourcesClaimed;
-import com.here.xyz.models.filters.SpatialFilter;
 import com.here.xyz.models.geojson.coordinates.WKTHelper;
 import com.here.xyz.models.geojson.implementation.Geometry;
 import com.here.xyz.models.hub.Ref;
@@ -47,6 +46,7 @@ import com.here.xyz.util.db.SQLQuery;
 import com.here.xyz.util.db.pg.FeatureWriterQueryBuilder.FeatureWriterQueryContextBuilder;
 import com.here.xyz.util.service.BaseHttpServerVerticle.ValidationException;
 import com.here.xyz.util.web.XyzWebClient.WebClientException;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -111,9 +111,6 @@ public class CopySpace extends SpaceBasedStep<CopySpace> {
 
 
   public SpatialFilter getSpatialFilter() {
-    //TODO: This is a hotfix for large spatial filters ending up in the state check trigger paylooad. Long term fix should be to only keep the Step ID in the trigger payload and fetch the step config from service when step executions starts in lambda
-    if (inLambda)
-      return null;
     return spatialFilter;
   }
 

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/ExportSpaceToFiles.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/ExportSpaceToFiles.java
@@ -1,6 +1,5 @@
 /*
  * Copyright (C) 2017-2026 HERE Europe B.V.
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -30,6 +29,7 @@ import static com.here.xyz.jobs.steps.impl.SpaceBasedStep.LogPhase.STEP_ON_ASYNC
 import com.fasterxml.jackson.annotation.JsonView;
 import com.here.xyz.events.ContextAwareEvent.SpaceContext;
 import com.here.xyz.events.PropertiesQuery;
+import com.here.xyz.models.filters.SpatialFilter;
 import com.here.xyz.jobs.steps.StepExecution;
 import com.here.xyz.jobs.steps.execution.StepException;
 import com.here.xyz.jobs.steps.execution.db.Database;
@@ -41,7 +41,6 @@ import com.here.xyz.jobs.steps.outputs.FeatureStatistics;
 import com.here.xyz.jobs.steps.resources.IOResource;
 import com.here.xyz.jobs.steps.resources.Load;
 import com.here.xyz.jobs.steps.resources.TooManyResourcesClaimed;
-import com.here.xyz.models.filters.SpatialFilter;
 import com.here.xyz.models.geojson.exceptions.InvalidGeometryException;
 import com.here.xyz.models.hub.Ref;
 import com.here.xyz.models.hub.Space;
@@ -54,6 +53,7 @@ import com.here.xyz.util.geo.GeoTools;
 import com.here.xyz.util.geo.GeometryValidator;
 import com.here.xyz.util.service.BaseHttpServerVerticle.ValidationException;
 import com.here.xyz.util.web.XyzWebClient.WebClientException;
+
 import java.io.IOException;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -153,9 +153,6 @@ public class ExportSpaceToFiles extends TaskedSpaceBasedStep<ExportSpaceToFiles,
   }
 
   public SpatialFilter getSpatialFilter() {
-    //TODO: This is a hotfix for large spatial filters ending up in the state check trigger paylooad. Long term fix should be to only keep the Step ID in the trigger payload and fetch the step config from service when step executions starts in lambda
-    if (inLambda)
-      return null;
     return spatialFilter;
   }
 

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/util/StepWebClient.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/util/StepWebClient.java
@@ -20,6 +20,7 @@
 package com.here.xyz.jobs.util;
 
 import com.here.xyz.XyzSerializable;
+import com.here.xyz.jobs.RuntimeInfo;
 import com.here.xyz.jobs.steps.Step;
 import com.here.xyz.util.web.JobWebClient;
 
@@ -58,5 +59,12 @@ public class StepWebClient extends JobWebClient {
         .uri(uri("/admin/jobs/" + step.getJobId() + "/steps"))
         .header(CONTENT_TYPE, JSON_UTF_8.toString())
         .method("POST", BodyPublishers.ofByteArray(XyzSerializable.serialize(step).getBytes())));
+  }
+
+  public void postStepStatusUpdate(String jobId, String stepId, RuntimeInfo<?> status) throws WebClientException {
+    request(HttpRequest.newBuilder()
+        .uri(uri("/admin/jobs/" + jobId + "/steps/" + stepId + "/status"))
+        .header(CONTENT_TYPE, JSON_UTF_8.toString())
+        .method("POST", BodyPublishers.ofByteArray(XyzSerializable.serialize(status).getBytes())));
   }
 }

--- a/xyz-jobs/xyz-job-steps/src/test/java/com/here/xyz/jobs/steps/execution/LambdaBasedStepPayloadTest.java
+++ b/xyz-jobs/xyz-job-steps/src/test/java/com/here/xyz/jobs/steps/execution/LambdaBasedStepPayloadTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2017-2026 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.xyz.jobs.steps.execution;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.vertx.core.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+public class LambdaBasedStepPayloadTest {
+
+  @Test
+  void compactStateCheckInputRemovesLargeFilterFields() {
+    String input = """
+        {
+          "type":"STATE_CHECK",
+          "step":{
+            "id":"s_bahygt",
+            "jobId":"okjcygbdjn",
+            "taskToken":"token",
+            "spatialFilter":{"geometry":{"type":"MultiPolygon","coordinates":[[[[1,2],[3,4],[1,2]]]]}},
+            "propertyFilter":[[{"key":"foo","operation":"EQUALS","values":["bar"]}]],
+            "nested":{"spatialFilter":{"geometry":{"type":"Polygon"}},"keep":true}
+          }
+        }
+        """;
+
+    String compacted = LambdaBasedStep.compactStateCheckInput(input);
+    JsonObject result = new JsonObject(compacted);
+    JsonObject step = result.getJsonObject("step");
+    assertEquals("s_bahygt", step.getString("id"));
+    assertEquals("okjcygbdjn", step.getString("jobId"));
+    assertEquals("token", step.getString("taskToken"));
+
+    assertFalse(step.containsKey("spatialFilter"));
+
+    JsonObject nested = step.getJsonObject("nested");
+    assertTrue(nested.getBoolean("keep"));
+    assertFalse(nested.containsKey("spatialFilter"));
+  }
+}
+

--- a/xyz-jobs/xyz-job-steps/src/test/java/com/here/xyz/jobs/steps/execution/LambdaBasedStepStateCheckTriggerIT.java
+++ b/xyz-jobs/xyz-job-steps/src/test/java/com/here/xyz/jobs/steps/execution/LambdaBasedStepStateCheckTriggerIT.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2017-2026 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.xyz.jobs.steps.execution;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.here.xyz.jobs.steps.impl.transport.ExportSpaceToFiles;
+import io.vertx.core.json.JsonObject;
+import java.net.URI;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.cloudwatchevents.CloudWatchEventsClient;
+import software.amazon.awssdk.services.cloudwatchevents.model.CloudWatchEventsException;
+import software.amazon.awssdk.services.cloudwatchevents.model.DeleteRuleRequest;
+import software.amazon.awssdk.services.cloudwatchevents.model.PutRuleRequest;
+import software.amazon.awssdk.services.cloudwatchevents.model.PutTargetsRequest;
+import software.amazon.awssdk.services.cloudwatchevents.model.PutTargetsResponse;
+import software.amazon.awssdk.services.cloudwatchevents.model.RemoveTargetsRequest;
+import software.amazon.awssdk.services.cloudwatchevents.model.ResourceNotFoundException;
+import software.amazon.awssdk.services.cloudwatchevents.model.RuleState;
+import software.amazon.awssdk.services.cloudwatchevents.model.Target;
+
+@Disabled("Requires AWS credentials and access to CloudWatch Events. By using localstack the size validation does " +
+        "not happens. Please configure a real job-step lambda (LAMBDA_ARN) in a AWS environment to run this test.")
+public class LambdaBasedStepStateCheckTriggerIT {
+
+  private CloudWatchEventsClient eventsClient;
+  private String ruleName;
+  private static final String LAMBDA_ARN = "TO_SET";
+
+  @BeforeEach
+  public void setup() {
+    eventsClient = CloudWatchEventsClient.builder()
+        .region(Region.EU_WEST_1)
+        //.endpointOverride(URI.create("http://" + localstackHost + ":4566"))
+        .build();
+
+    ruleName = "it-state-check-" + UUID.randomUUID();
+    eventsClient.putRule(PutRuleRequest.builder()
+        .name(ruleName)
+        .state(RuleState.ENABLED)
+        .scheduleExpression("rate(1 minute)")
+        .description("IT for CloudWatch target input size")
+        .build());
+  }
+
+  @AfterEach
+  public void cleanup() {
+    if (eventsClient == null)
+      return;
+
+    try {
+      eventsClient.removeTargets(RemoveTargetsRequest.builder().rule(ruleName).ids("state-check").build());
+    }
+    catch (Exception ignored) {
+      // Best effort cleanup.
+    }
+
+    try {
+      eventsClient.deleteRule(DeleteRuleRequest.builder().name(ruleName).build());
+    }
+    catch (ResourceNotFoundException ignored) {
+      // Already gone.
+    }
+    catch (Exception ignored) {
+      // Best effort cleanup.
+    }
+
+    eventsClient.close();
+  }
+
+  @Test
+  public void putTargetFailsWithLargeStateCheckInputButSucceedsAfterCompaction() {
+    String oversizedPayload = buildOversizedStateCheckPayload();
+    assertTrue(oversizedPayload.length() > 8192, "Test payload must exceed CloudWatch target input limit.");
+
+    CloudWatchEventsException ex = assertThrows(CloudWatchEventsException.class, () ->
+        eventsClient.putTargets(PutTargetsRequest.builder()
+            .rule(ruleName)
+            .targets(Target.builder()
+                .id("state-check-test")
+                .arn(LAMBDA_ARN)
+                .input(oversizedPayload)
+                .build())
+            .build()));
+
+    assertTrue(ex.getMessage().contains("8192") || ex.getMessage().contains("targets"),
+        "Expected validation to fail because target input exceeds 8192 bytes.");
+
+    String compactedPayload = LambdaBasedStep.compactStateCheckInput(oversizedPayload);
+    assertTrue(compactedPayload.length() < oversizedPayload.length(), "Compaction should reduce payload size.");
+    assertTrue(compactedPayload.length() <= 8192, LAMBDA_ARN);
+
+    PutTargetsResponse response = eventsClient.putTargets(PutTargetsRequest.builder()
+        .rule(ruleName)
+        .targets(Target.builder()
+            .id("state-check")
+            .arn(LAMBDA_ARN)
+            .input(compactedPayload)
+            .build())
+        .build());
+
+    assertEquals(0, response.failedEntryCount());
+  }
+
+  private static String buildOversizedStateCheckPayload() {
+    String largeSpatialFilter = "x".repeat(12_000 );
+
+    JsonObject payload = new JsonObject()
+        .put("type", "STATE_CHECK")
+        .put("step", new JsonObject()
+            .put("type", "CopySpace")
+            .put("id", "s_bahygt")
+            .put("jobId", "okjcygbdjn")
+            .put("taskToken", "token")
+            .put("executionId", "arn:aws:states:us-east-1:000000000000:execution:job-large:job-large")
+            .put("status", new JsonObject().put("state", "RUNNING"))
+            .put("spatialFilter", new JsonObject()
+                .put("geometry", new JsonObject()
+                    .put("type", "MultiPolygon")
+                    .put("coordinates", largeSpatialFilter))));
+
+    return payload.encode();
+  }
+}
+


### PR DESCRIPTION
Revert "DS-2253: Hotfix for too large spatial filters ending up in the state check trigger" and implement new fix by strip large spatialFilters only during the cloudwatchEventsClient target creation.

JobAdminApi/StepWebClient: Add endpoint which only updates the RuntimeStatus of a step.
LambdaBasedStep: In case of STATE_CHECKS only update the step status.