### PR TITLE
Ds 2322 - Enhance import into non-empty layers functionality 

### DIFF
--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/compiler/ImportFromFiles.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/compiler/ImportFromFiles.java
@@ -80,6 +80,7 @@ public class ImportFromFiles implements JobCompilationInterceptor {
     checkIfSpaceIsAccessible(spaceId);
 
     TaskedImportFilesToSpace importFilesStep = new TaskedImportFilesToSpace() //Perform import
+            .withFeatureWriterBatchSizeInMb(20)
             .withEntityPerLine(getEntityPerLine(sourceFormat))
             .withSpaceId(spaceId)
             .withVersionRef(new Ref(Ref.HEAD))

--- a/xyz-jobs/xyz-job-service/src/test/java/com/here/xyz/jobs/ExportToFilesAndImportIT.java
+++ b/xyz-jobs/xyz-job-service/src/test/java/com/here/xyz/jobs/ExportToFilesAndImportIT.java
@@ -169,7 +169,7 @@ public class ExportToFilesAndImportIT extends JobTest {
     checkSucceededJob(job);
 
     List<Map> outputs = getJobOutputs(job.getId());
-    Assertions.assertEquals(1, outputs.size());
+    Assertions.assertEquals(2, outputs.size());
     Assertions.assertEquals(0, outputs.get(0).get("featureCount"));
 
     StatisticsResponse targetStats = getStatistics(TRG_SPACE);

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/TaskedImportFilesToSpace.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/TaskedImportFilesToSpace.java
@@ -105,6 +105,12 @@ public class TaskedImportFilesToSpace extends TaskedSpaceBasedStep<TaskedImportF
   @JsonView({Internal.class, Static.class})
   private int estimatedSeconds = -1;
 
+  @JsonView({Internal.class, Static.class})
+  private long targetVersion = -1;
+
+  @JsonView({Internal.class, Static.class})
+  private double featureWriterBatchSizeInMb = 20;
+
   //Compilers can decide max allowed import size. Set default to 200G for normal use-case
   @JsonIgnore
   private long maxInputBytesForNonEmptyImport = 200l * 1024 * 1024 * 1024;
@@ -188,6 +194,19 @@ public class TaskedImportFilesToSpace extends TaskedSpaceBasedStep<TaskedImportF
     return this;
   }
 
+  public void setFeatureWriterBatchSizeInMb(double featureWriterBatchSizeInMb) {
+    this.featureWriterBatchSizeInMb = featureWriterBatchSizeInMb;
+  }
+
+  public double getFeatureWriterBatchSizeInMb() {
+    return featureWriterBatchSizeInMb;
+  }
+
+  public TaskedImportFilesToSpace withFeatureWriterBatchSizeInMb(double featureWriterBatchSizeInMb) {
+    setFeatureWriterBatchSizeInMb(featureWriterBatchSizeInMb);
+    return this;
+  }
+
   @Override
   protected boolean queryRunsOnWriter(){
     return true;
@@ -195,24 +214,20 @@ public class TaskedImportFilesToSpace extends TaskedSpaceBasedStep<TaskedImportF
 
   @Override
   protected void initialSetup() throws SQLException, TooManyResourcesClaimed, WebClientException {
-    long newVersion = getOrIncreaseVersionSequence();
+    targetVersion = getOrIncreaseVersionSequence();
 
     if(useFeatureWriter()) {
       infoLog(STEP_EXECUTE,  "initialSetup - Using FeatureWriter for import!");
 
       //Pre-create two spare history partitions to avoid concurrency issue with hub requests.
-      createSpareHistoryPartitions(newVersion);
-
-      String superRootTable = space().getExtension() != null ? getRootTableName(superSpace()) : null;
-      runBatchWriteQuerySync(getQueryBuilder().buildTemporaryTriggerTableBlockForImportWithFW(space().getOwner(),
-             newVersion, superRootTable, updateStrategy, entityPerLine.name()), db(), 0);
+      createSpareHistoryPartitions(targetVersion);
     }else{
       infoLog(STEP_EXECUTE,  "initialSetup - Import into empty layer detected!");
 
       if(format.equals(FAST_IMPORT_INTO_EMPTY))
         return;
       //import into an empty, non-composite, layer
-      runBatchWriteQuerySync(getQueryBuilder().buildTemporaryTriggerTableBlockForImportIntoEmpty(space().getOwner(), newVersion, retainMetadata),
+      runWriteQuerySync(getQueryBuilder().buildCreateImportTriggerForEmptyLayers(space().getOwner(), targetVersion, retainMetadata),
               db(), 0);
     }
   }
@@ -327,6 +342,55 @@ public class TaskedImportFilesToSpace extends TaskedSpaceBasedStep<TaskedImportF
   }
 
   @Override
+  protected void onTaskProgress(int taskId, ImportOutput output) throws WebClientException, SQLException, TooManyResourcesClaimed {
+    //TODO: CHECK
+    //String superRootTable = space().getExtension() != null ? getRootTableName(superSpace()) : null;
+
+    runReadQueryAsync(getQueryBuilder().buildImportFromTmpTableTaskQuery(
+            taskId,
+            output.progress() == null ? 1 : output.progress().endI() + 1, //TBD check
+            space().getOwner(),
+            targetVersion,
+            false,
+            updateStrategy,
+            new LambdaStepRequest().withStep(this).serialize(),
+            getwOwnLambdaArn().toString(),
+            getwOwnLambdaArn().getRegion(),
+            getQueryContext(getSchema(db())),
+            buildFailureCallbackQuery().substitute().text()
+                    .replaceAll("'", "''")
+    ).withRetryableErrorCodes(RETRYABLE_SQL_CODES)
+            ,dbWriter(), 0, false);
+  }
+
+  @Override
+  protected boolean isTaskFinalized(int taskId, ImportOutput output) throws WebClientException {
+    if(useFeatureWriter() && (output.progress() == null || !output.progress().tmpTableLoaded())) {
+      infoLog(STEP_EXECUTE, "Task "+taskId+" is not finalized yet! " + output.progress());
+      return false;
+    }
+    return true;
+  }
+
+  @Override
+  protected void prepareTaskQuery(int taskId) throws WebClientException,
+          SQLException, TooManyResourcesClaimed {
+    if(useFeatureWriter()) {
+      //create tmp table for each file
+      runWriteQuerySync(getQueryBuilder().buildTemporaryDataTableForImportQuery(taskId), db(), 0);
+    }
+  }
+
+  @Override
+  protected void finalizeTaskQuery(int taskId) throws WebClientException,
+          SQLException, TooManyResourcesClaimed {
+    if(useFeatureWriter()) {
+      //drop tmp table for loaded file
+      runWriteQuerySync(getQueryBuilder().dropTemporaryDataTableForImportQuery(taskId), db(), 0);
+    }
+  }
+
+  @Override
   protected SQLQuery buildTaskQuery(Integer taskId, ImportInput taskInput, String failureCallback)
           throws WebClientException {
 
@@ -414,7 +478,8 @@ public class TaskedImportFilesToSpace extends TaskedSpaceBasedStep<TaskedImportF
 
   private ImportQueryBuilder getQueryBuilder() throws WebClientException {
     if(importQueryBuilder == null){
-      importQueryBuilder = new ImportQueryBuilder(getId(), getSchema(db()), getRootTableName(space()), space().getVersionsToKeep());
+      importQueryBuilder = new ImportQueryBuilder(getId(), getSchema(db()), getRootTableName(space()),
+              space().getVersionsToKeep(), featureWriterBatchSizeInMb);
     }
     return importQueryBuilder;
   }

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/TaskedImportFilesToSpace.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/TaskedImportFilesToSpace.java
@@ -394,6 +394,38 @@ public class TaskedImportFilesToSpace extends TaskedSpaceBasedStep<TaskedImportF
   protected SQLQuery buildTaskQuery(Integer taskId, ImportInput taskInput, String failureCallback)
           throws WebClientException {
 
+    //Resume support for non-empty (FeatureWriter) imports: if we already have a previous task output,
+    //the S3 -> tmp-table import (phase 1) was at least started. Skip phase 1 and resume phase 2
+    //(batched import from tmp table) starting from the last reported endI + 1.
+    if (useFeatureWriter()) {
+      try {
+        ImportOutput previous = loadTaskOutput(taskId);
+        if (previous != null) {
+          long resumeStartI = previous.progress() != null && previous.progress().endI() > 0
+                  ? previous.progress().endI() + 1 : 1;
+          infoLog(STEP_EXECUTE, "Resume task " + taskId + " - skipping phase 1, " +
+                  "starting phase 2 at startI=" + resumeStartI);
+
+          return getQueryBuilder().buildImportFromTmpTableTaskQuery(
+                  taskId,
+                  resumeStartI,
+                  space().getOwner(),
+                  targetVersion,
+                  false,
+                  updateStrategy,
+                  new LambdaStepRequest().withStep(this).serialize(),
+                  getwOwnLambdaArn().toString(),
+                  getwOwnLambdaArn().getRegion(),
+                  getQueryContext(getSchema(db())),
+                  failureCallback);
+        }
+      } catch (SQLException | TooManyResourcesClaimed e) {
+        //Resume detection failed -> fall back to normal phase 1 start
+        errorLog(STEP_EXECUTE, e, "Resume detection failed for task " + taskId + " - falling back to fresh start. " + e.getMessage());
+        throw new StepException("Resume detection failed for task " + taskId + " - falling back to fresh start. " + e.getMessage(), e);
+      }
+    }
+
     return getQueryBuilder().buildImportTaskQuery(format, taskId, taskInput, new LambdaStepRequest().withStep(this).serialize(),
                     getwOwnLambdaArn().toString(), getwOwnLambdaArn().getRegion(), getQueryContext(getSchema(db())),
                     useFeatureWriter(), failureCallback);

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/TaskedImportFilesToSpace.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/TaskedImportFilesToSpace.java
@@ -72,7 +72,7 @@ public class TaskedImportFilesToSpace extends TaskedSpaceBasedStep<TaskedImportF
   public static final String STATISTICS = "statistics";
 
   {
-    //Use 15 Threads as default for import tasks
+    //Use 11 Threads as default for import tasks
     threadCount = 11;
     setOutputSets(List.of(new OutputSet(STATISTICS, USER, true)));
   }

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/TaskedSpaceBasedStep.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/TaskedSpaceBasedStep.java
@@ -84,7 +84,7 @@ public abstract class TaskedSpaceBasedStep<T extends TaskedSpaceBasedStep, I ext
         extends SpaceBasedStep<T> {
   private static final String JOB_DATA_PREFIX = "job_data_";
   private static final Logger logger = LogManager.getLogger();
-  private static final Set<String> RETRYABLE_SQL_CODES = Set.of(
+  protected static final Set<String> RETRYABLE_SQL_CODES = Set.of(
           "40001", // serialization_failure
           "40P01", // deadlock_detected
           "55P03", // lock_not_available
@@ -303,6 +303,65 @@ public abstract class TaskedSpaceBasedStep<T extends TaskedSpaceBasedStep, I ext
   protected void finalCleanUp(boolean noTasksCreated) throws WebClientException, SQLException, TooManyResourcesClaimed, IOException {};
 
   /**
+   * Hook invoked immediately before starting an individual task query.
+   * <p>
+   * Use this to prepare task-scoped resources (for example creating temporary helper tables)
+   * that are required by the task query execution.
+   * </p>
+   *
+   * @param taskId The id of the task about to be started.
+   * @throws WebClientException If external calls fail.
+   * @throws SQLException If DB preparation fails.
+   * @throws TooManyResourcesClaimed If resource claiming exceeds configured limits.
+   */
+  protected void prepareTaskQuery(int taskId) throws WebClientException, SQLException, TooManyResourcesClaimed {}
+
+  /**
+   * Hook invoked when a non-final progress update for a running task is received.
+   * If a async query is needed - always use callback=false!
+   * <p>
+   * This is the place to trigger follow-up async work (for example the next chunk query).
+   * If a new async query is started here, it should use callback=false to avoid duplicate callback chains.
+   * </p>
+   *
+   * @param taskId The id of the task that reported progress.
+   * @param output The current task output payload from the callback.
+   * @throws WebClientException If external calls fail.
+   * @throws SQLException If DB interaction fails.
+   * @throws TooManyResourcesClaimed If resource claiming exceeds configured limits.
+   */
+  protected void onTaskProgress(int taskId, O output) throws WebClientException, SQLException, TooManyResourcesClaimed {}
+
+  /**
+   * Determines whether the received task update represents the final state of the task.
+   * <p>
+   * Returning {@code false} keeps the task in running state and routes the update through the
+   * progress hook. Returning {@code true} triggers finalization flow.
+   * </p>
+   *
+   * @param taskId The id of the task being evaluated.
+   * @param output The task output payload from the callback.
+   * @return {@code true} if the task is final and can be finalized; {@code false} otherwise.
+   * @throws WebClientException If external calls fail during decision making.
+   */
+  protected boolean isTaskFinalized(int taskId, O output) throws WebClientException { return true; }
+
+  /**
+   * Hook invoked after a task is considered finalized and before the framework marks it finalized
+   * in the process table and claims the next task.
+   * <p>
+   * Use this for task-level finalization work that must succeed before finalization is persisted
+   * (for example deleting task-specific temporary artifacts).
+   * </p>
+   *
+   * @param taskId The id of the task being finalized.
+   * @throws WebClientException If external calls fail.
+   * @throws SQLException If DB finalization work fails.
+   * @throws TooManyResourcesClaimed If resource claiming exceeds configured limits.
+   */
+  protected void finalizeTaskQuery(int taskId) throws WebClientException, SQLException, TooManyResourcesClaimed {}
+
+  /**
    * Prepares the process by resolving the version reference to an actual version.
    *
    * @param owner The owner of the job.
@@ -446,6 +505,9 @@ public abstract class TaskedSpaceBasedStep<T extends TaskedSpaceBasedStep, I ext
       //We can`t use the default callback here because we are reporting success during onAsyncUpdate in Java.
       //The failureCallback is still needed to report failures from the DB-side
       String failureCallback = buildFailureCallbackQuery().substitute().text().replaceAll("'", "''");
+
+      prepareTaskQuery(taskProgressAndItem.getTaskId());
+
       runReadQueryAsync(buildTaskQuery(taskProgressAndItem.getTaskId(), (I) taskProgressAndItem.getTaskInput(), failureCallback)
                          .withRetryableErrorCodes(RETRYABLE_SQL_CODES),
                 queryRunsOnWriter() ? dbWriter() : dbReader(), 0d/*perItemAcus.doubleValue()*/,  false);
@@ -494,29 +556,42 @@ public abstract class TaskedSpaceBasedStep<T extends TaskedSpaceBasedStep, I ext
       //Update the task table and mark item as finalized
       SpaceBasedTaskUpdate update = (SpaceBasedTaskUpdate) processUpdate;
       infoLog(STEP_ON_ASYNC_UPDATE, "Received progress update: " + processUpdate.serialize());
-      TaskProgress taskProgressAndItem = finalizeCurrentTaskAndGetTaskProgressAndNextTaskItem(update);
-      if (taskProgressAndItem.isComplete()) {
-        infoLog(STEP_ON_ASYNC_UPDATE, "All tasks are finished." + taskProgressAndItem);
 
-        //Collect outputs and process them
-        processFinalizedTasks(collectOutputs());
+      if (!isTaskFinalized(update.taskId, (O) update.taskOutput)){
+        updateQueryTaskItemOutput(update); //update taskItem output
+        onTaskProgress(update.taskId, (O) update.taskOutput);  //hook method
+      }else{
+        finalizeTaskQuery(update.taskId); //hook method
 
-        //Clean up temporary resources
-        cleanUpDbResources(STEP_ON_ASYNC_UPDATE);
-
-        return true;
-      }else {
-        infoLog(STEP_ON_ASYNC_UPDATE, "Found existing tasks. Start new item:" + taskProgressAndItem);
-        //If we are not finished, start the next task
-        startTask(taskProgressAndItem);
-        //Calculate progress and set it on the step's status
-        getStatus().setEstimatedProgress((float) taskProgressAndItem.getFinalizedTasks() / (float) taskProgressAndItem.getTotalTasks());
+        TaskProgress taskProgressAndItem = finalizeCurrentTaskAndGetTaskProgressAndNextTaskItem(update);
+        if (taskProgressAndItem.isComplete()) {
+          return true;
+        }else {
+          infoLog(STEP_ON_ASYNC_UPDATE, "Found existing tasks. Start new item:" + taskProgressAndItem);
+          //If we are not finished, start the next task
+          startTask(taskProgressAndItem);
+          //Calculate progress and set it on the step's status
+          getStatus().setEstimatedProgress((float) taskProgressAndItem.getFinalizedTasks() / (float) taskProgressAndItem.getTotalTasks());
+        }
       }
-
       return false;
     }catch (Exception e) {
       throw new RuntimeException(e);
     }
+  }
+
+  @Override
+  protected void onAsyncSuccess() throws Exception {
+    infoLog(STEP_ON_ASYNC_SUCCESS, "Reached onAsyncSuccess!");
+    finalizeStep();
+  }
+
+  private void finalizeStep() throws IOException, WebClientException, SQLException, TooManyResourcesClaimed {
+    //Collect outputs and process them
+    processFinalizedTasks(collectOutputs());
+
+    //Clean up temporary resources
+    cleanUpDbResources(STEP_ON_ASYNC_UPDATE);
   }
 
   @Override
@@ -621,9 +696,9 @@ public abstract class TaskedSpaceBasedStep<T extends TaskedSpaceBasedStep, I ext
   }
 
   private AsyncExecutionState evaluateExecutionState(TaskProgress taskProgress) throws UnknownStateException {
-    if (taskProgress.isComplete())
+    if (taskProgress.isComplete()) {
       return AsyncExecutionState.SUCCEEDED;
-    if (taskProgress.hasRunningTasks())
+    }if (taskProgress.hasRunningTasks())
       // Check if the expected queries are still running.
       return super.getExecutionState();
     if (taskProgress.hasNoRunningTasks()) {
@@ -675,6 +750,39 @@ public abstract class TaskedSpaceBasedStep<T extends TaskedSpaceBasedStep, I ext
           throws WebClientException, SQLException, TooManyResourcesClaimed {
     infoLog(STEP_ON_ASYNC_UPDATE, "Update process table and claim next task with: " + update.serialize());
     return  executeTaskItemQuery(retrieveTaskItemAndStatisticsAfterUpdateQuery(getSchema(db(WRITER)), update));
+  }
+
+  /**
+   * Merges the task update into the task's {@code task_output} column.
+   * <p>
+   * The update is merged with the existing output to preserve any previously stored fields.
+   * For example, if the existing output contains {@code fileBytes} and {@code importStatistics},
+   * and the update contains a {@code progress} field, the result will contain all three fields.
+   * Fields in the update override fields with the same name in the existing output.
+   * </p>
+   *
+   * @param update The in-progress task update carrying the complete payload.
+   */
+  private void updateQueryTaskItemOutput(SpaceBasedTaskUpdate update) throws WebClientException, SQLException, TooManyResourcesClaimed {
+    String schema = getSchema(db(WRITER));
+    SQLQuery query = new SQLQuery("""
+            UPDATE ${schema}.${table}
+            SET task_output = (
+                COALESCE(task_output, '{}'::JSONB) || #{taskUpdate}::JSONB
+            ) || jsonb_build_object(
+                'taskOutput',
+                COALESCE(task_output->'taskOutput', '{}'::JSONB)
+                || COALESCE((#{taskUpdate}::JSONB)->'taskOutput', '{}'::JSONB)
+            )
+            WHERE task_id = #{taskId};
+        """)
+        .withVariable("schema", schema)
+        .withVariable("table", getTemporaryJobTableName(getId()))
+        .withNamedParameter("taskId", update.taskId)
+        .withNamedParameter("taskUpdate", XyzSerializable.serialize(update))
+        .withRetryableErrorCodes(RETRYABLE_SQL_CODES);
+
+    runWriteQuerySyncUnkillable(query, db(WRITER), 0);
   }
 
   private TaskProgress executeTaskItemQuery(SQLQuery query) throws WebClientException, SQLException, TooManyResourcesClaimed {

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/TaskedSpaceBasedStep.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/TaskedSpaceBasedStep.java
@@ -669,7 +669,7 @@ public abstract class TaskedSpaceBasedStep<T extends TaskedSpaceBasedStep, I ext
   @Override
   public AsyncExecutionState getExecutionState() throws UnknownStateException {
     if (noTasksCreated)
-      return handleNoTasksCreatedState();
+      return AsyncExecutionState.SUCCEEDED;
 
     try {
       TaskProgress taskProgress = getTaskProgress();
@@ -683,16 +683,6 @@ public abstract class TaskedSpaceBasedStep<T extends TaskedSpaceBasedStep, I ext
     catch (TooManyResourcesClaimed e) {
       throw new StepException("Unexpected error occurred during execution state check for step: " + getGlobalStepId() + " !", e);
     }
-  }
-
-  private AsyncExecutionState handleNoTasksCreatedState() {
-    try {
-      cleanUpDbResources(STEP_ON_ASYNC_SUCCESS);
-    }
-    catch (Exception e) {
-      throw new RuntimeException(e);
-    }
-    return AsyncExecutionState.SUCCEEDED;
   }
 
   private AsyncExecutionState evaluateExecutionState(TaskProgress taskProgress) throws UnknownStateException {

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/TaskedSpaceBasedStep.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/TaskedSpaceBasedStep.java
@@ -883,6 +883,40 @@ public abstract class TaskedSpaceBasedStep<T extends TaskedSpaceBasedStep, I ext
             .withRetryableErrorCodes(RETRYABLE_SQL_CODES);
   }
 
+  /**
+   * Loads the previously stored {@code task_output.taskOutput} payload of a single task item, if available.
+   * <p>
+   * Returns {@code null} when no row matches the given {@code taskId} or when no output has been stored yet.
+   * This helper is intended to support resume scenarios where a subclass needs to inspect the last
+   * persisted state of a task before deciding which query to start next.
+   * </p>
+   *
+   * @param taskId The id of the task whose output should be loaded.
+   * @return The deserialized output payload of type {@code O}, or {@code null} if not available.
+   */
+  protected O loadTaskOutput(int taskId) throws WebClientException, SQLException, TooManyResourcesClaimed {
+    SQLQuery query = new SQLQuery("""
+              SELECT task_output->'taskOutput' AS task_output
+                FROM ${schema}.${tmpTable}
+               WHERE task_id = #{taskId};
+        """)
+            .withVariable("schema", getSchema(db()))
+            .withVariable("tmpTable", getTemporaryJobTableName(getId()))
+            .withNamedParameter("taskId", taskId)
+            .withRetryableErrorCodes(RETRYABLE_SQL_CODES);
+
+    return runReadQuerySync(query, db(WRITER), 0, rs -> {
+      try {
+        if (!rs.next()) return null;
+        String taskOutput = rs.getString("task_output");
+        if (taskOutput == null) return null;
+        return XyzSerializable.deserialize(taskOutput, new TypeReference<O>() {});
+      } catch (JsonProcessingException e) {
+        throw new RuntimeException("Can not deserialize task_output for taskId=" + taskId, e);
+      }
+    });
+  }
+
   private boolean insertTaskItemsInTaskTable(String schema, Step step, List<I> taskInputs)
           throws WebClientException, SQLException, TooManyResourcesClaimed {
     List<SQLQuery> insertQueries = new ArrayList<>();

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/tasks/TaskPayload.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/tasks/TaskPayload.java
@@ -18,6 +18,7 @@
  */
 package com.here.xyz.jobs.steps.impl.transport.tasks;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.here.xyz.Typed;
 import com.here.xyz.jobs.steps.impl.transport.tasks.inputs.CountInput;
@@ -27,6 +28,7 @@ import com.here.xyz.jobs.steps.impl.transport.tasks.inputs.ImportInput;
 import com.here.xyz.jobs.steps.impl.transport.tasks.outputs.ExportOutput;
 import com.here.xyz.jobs.steps.impl.transport.tasks.outputs.ImportOutput;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonSubTypes({
         @JsonSubTypes.Type(value = CountInput.class, name = "CountInput"),
         @JsonSubTypes.Type(value = Empty.class, name = "Empty"),

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/tasks/outputs/ImportOutput.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/tasks/outputs/ImportOutput.java
@@ -18,13 +18,40 @@
  */
 package com.here.xyz.jobs.steps.impl.transport.tasks.outputs;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.here.xyz.Typed;
 import com.here.xyz.jobs.steps.impl.transport.tasks.TaskPayload;
 
-public record ImportOutput(String importStatistics, long fileBytes) implements TaskPayload {
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_DEFAULT;
+
+@JsonInclude(NON_DEFAULT)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ImportOutput(String importStatistics, long fileBytes,
+                           ImportProgress progress) implements TaskPayload {
+
+  public ImportOutput(String importStatistics, long fileBytes) {
+    this(importStatistics, fileBytes, null);
+  }
+
+  public ImportOutput(ImportProgress progress) {
+    this(null, -1, progress);
+  }
+
   //@TODO: shift this extraction to SQL function "perform_import_from_s3_task()"
   public long extractRowCount() {
     if (importStatistics == null) return 0;
     var matcher = java.util.regex.Pattern.compile("\\d+").matcher(importStatistics);
     return matcher.find() ? Long.parseLong(matcher.group()) : 0;
   }
+
+  @JsonInclude(NON_DEFAULT)
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public record ImportProgress(boolean tmpTableLoaded, long startI, long endI)
+          implements Typed {
+    public ImportProgress(boolean tmpTableLoaded){
+      this(tmpTableLoaded, -1,-1);
+    }
+  }
 }
+

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/tools/ImportQueryBuilder.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/tools/ImportQueryBuilder.java
@@ -9,52 +9,31 @@ import java.util.Map;
 
 import static com.here.xyz.jobs.steps.impl.transport.TaskedSpaceBasedStep.getTemporaryJobTableName;
 import static com.here.xyz.jobs.steps.impl.transport.TaskedImportFilesToSpace.Format;
-import static com.here.xyz.jobs.steps.impl.transport.TaskedImportFilesToSpace.Format.GEOJSON;
 
 public class ImportQueryBuilder {
-  private static final String TRIGGER_TABLE_SUFFIX = "_trigger_tbl";
+  private static final String TMP_TABLE_SUFFIX = "_tmp_tbl_";
 
+  private final String stepId;
   private final String schema;
-  private final String temporaryImportTable;
-  private long versionsToKeep = 1;
+  private final double featureWriterBatchSizeInMb;
+
   private String rootTable;
 
   public static void main(String[] args) {}
 
   public ImportQueryBuilder(String stepId, String schema){
+    this.stepId = stepId;
     this.schema = schema;
-    this.temporaryImportTable = getTemporaryJobTableName(stepId) + TRIGGER_TABLE_SUFFIX;;
+    this.featureWriterBatchSizeInMb = 10;
   }
 
-  public ImportQueryBuilder(String stepId, String schema, String rootTable, long versionsToKeep){
+  public ImportQueryBuilder(String stepId, String schema, String rootTable, long versionsToKeep, double featureWriterBatchSizeInMb) {
+    this.stepId = stepId;
     this.schema = schema;
     this.rootTable = rootTable;
-    this.versionsToKeep = versionsToKeep;
-    this.temporaryImportTable = getTemporaryJobTableName(stepId) + TRIGGER_TABLE_SUFFIX;;
+    this.featureWriterBatchSizeInMb = featureWriterBatchSizeInMb;
   }
 
-  public SQLQuery buildCleanUpStatement(){
-    return SQLQuery.batchOf(
-            new SQLQuery("DROP TRIGGER IF EXISTS insertTrigger ON ${schema}.${table};")
-                    .withVariable("schema", schema)
-                    .withVariable("table", rootTable),
-            //Only present if FeatureWriter is used
-            new SQLQuery("DROP TABLE IF EXISTS ${schema}.${triggerTable};")
-                    .withVariable("schema", schema)
-                    .withVariable("triggerTable", temporaryImportTable));
-  }
-
-  public SQLQuery buildTemporaryTriggerTableBlockForImportIntoEmpty(String targetAuthor, long newVersion, boolean retainMetadata){
-    return SQLQuery.batchOf(buildCreateImportTriggerForEmptyLayers(targetAuthor, newVersion, retainMetadata));
-  }
-
-  public SQLQuery buildTemporaryTriggerTableBlockForImportWithFW(String author, long newVersion, String superRootTable,
-                                                                 UpdateStrategy updateStrategy, String entityPerLine){
-    return SQLQuery.batchOf(
-            buildTemporaryTriggerTableForImportQuery(),
-            buildCreateFeatureWriterImportTrigger(author, newVersion, superRootTable, updateStrategy, entityPerLine)
-    );
-  }
   public SQLQuery buildNextVersionQuery(){
     return new SQLQuery("SELECT nextval('${schema}.${sequence}')")
             .withVariable("schema", schema)
@@ -65,7 +44,9 @@ public class ImportQueryBuilder {
                                        String lambdaArn, String ownLambdaRegion, Map<String, Object> context,
                                        boolean useFeatureWriter, String failureCallback){
 
-    String targetTable = useFeatureWriter ? schema+".\"" + temporaryImportTable + "\"" : schema+".\"" + rootTable + "\"";
+    String targetTable = useFeatureWriter ?
+            schema+".\"" + getTemporaryDataTableName(taskId) + "\""
+            : schema+".\"" + rootTable + "\"";
 
     return new SQLQuery(
             "SELECT perform_import_from_s3_task(#{taskId}, #{schema}, to_regclass(#{targetTable}), #{format}, " +
@@ -87,22 +68,7 @@ public class ImportQueryBuilder {
             .withQueryFragment("failureCallback", failureCallback);
   }
 
-  private SQLQuery buildTemporaryTriggerTableForImportQuery(){
-    String tableFields =
-            "jsondata TEXT, "
-                    + "geo geometry(GeometryZ, 4326), "
-                    + "count INT ";
-    return new SQLQuery("CREATE TABLE IF NOT EXISTS ${schema}.${table} (${{tableFields}} )")
-            .withQueryFragment("tableFields", tableFields)
-            .withVariable("schema", schema )
-            .withVariable("table", temporaryImportTable);
-  }
-
-  public String getTemporaryTriggerTableName() {
-    return this.temporaryImportTable;
-  }
-
-  private SQLQuery buildCreateImportTriggerForEmptyLayers(String targetAuthor, long targetSpaceVersion, boolean retainMetadata){
+  public SQLQuery buildCreateImportTriggerForEmptyLayers(String targetAuthor, long targetSpaceVersion, boolean retainMetadata){
     return new SQLQuery("CREATE OR REPLACE TRIGGER insertTrigger BEFORE INSERT ON ${schema}.${table} "
             + "FOR EACH ROW EXECUTE PROCEDURE ${triggerFunction}('${{author}}', ${{spaceVersion}}, ${{retainMetadata}});")
             .withQueryFragment("spaceVersion", "" + targetSpaceVersion)
@@ -113,50 +79,98 @@ public class ImportQueryBuilder {
             .withVariable("table", rootTable);
   }
 
-  //TODO: make private ones deprecated ImportFilesToSpace got removed
-  public SQLQuery buildCreateFeatureWriterImportTrigger(String author, long newVersion, String superRootTable,
-                                                        UpdateStrategy updateStrategy,
-                                                        String entityPerLine){
-    List<String> tables = superRootTable == null ? List.of(rootTable) : List.of(superRootTable, rootTable);
+  public SQLQuery buildTemporaryDataTableForImportQuery(int taskId){
+    String tableFields =
+            "  jsondata TEXT," +
+                    " i BIGSERIAL PRIMARY KEY";
+    return new SQLQuery("CREATE TABLE IF NOT EXISTS ${schema}.${table} (${{tableFields}} )")
+            .withQueryFragment("tableFields", tableFields)
+            .withVariable("schema", schema )
+            .withVariable("table", getTemporaryDataTableName(taskId));
+  }
 
-    //TODO: Check if we can forward the whole transaction to the FeatureWriter rather than doing it for each row
+  public SQLQuery dropTemporaryDataTableForImportQuery(int taskId){
+    return new SQLQuery("DROP TABLE IF EXISTS ${schema}.${table} ;")
+            .withVariable("schema", schema )
+            .withVariable("table", getTemporaryDataTableName(taskId));
+  }
+
+  public SQLQuery buildCleanUpStatement(){
+    return SQLQuery.batchOf(
+            //Delete trigger - if present
+            new SQLQuery("DROP TRIGGER IF EXISTS insertTrigger ON ${schema}.${table};")
+              .withVariable("schema", schema)
+              .withVariable("table", rootTable),
+            //Delete all existing temporary tables
+            buildDropAllTemporaryTablesByStepPrefixQuery());
+  }
+
+  public SQLQuery buildDropAllTemporaryDataTablesForImportQuery(int taskCount) {
+    if (taskCount <= 0) {
+      return SQLQuery.batchOf(List.of());
+    }
+
+    List<SQLQuery> dropQueries = new java.util.ArrayList<>();
+    for (int taskId = 1; taskId <= taskCount; taskId++) {
+      dropQueries.add(dropTemporaryDataTableForImportQuery(taskId));
+    }
+    return SQLQuery.batchOf(dropQueries);
+  }
+
+  public SQLQuery buildDropAllTemporaryTablesByStepPrefixQuery() {
     return new SQLQuery("""
-          CREATE TRIGGER insertTrigger
-            AFTER INSERT on ${schema}.${table}
-          REFERENCING NEW TABLE as new_rows
-            FOR EACH STATEMENT
-          EXECUTE FUNCTION ${triggerFunction}(
-             ${{author}},
-             ${{spaceVersion}},
-             false, --isPartial
-             ${{onExists}},
-             ${{onNotExists}},
-             ${{onVersionConflict}},
-             ${{onMergeConflict}},
-             ${{historyEnabled}},
-             ${{context}},
-             '${{tables}}',
-             '${{format}}',
-             '${{entityPerLine}}'
-             )
+            DO $$
+            DECLARE
+              r RECORD;
+            BEGIN
+              FOR r IN
+                SELECT tablename
+                  FROM pg_tables
+                 WHERE schemaname = #{schema}
+                   AND left(tablename, length(#{tablePrefix})) = #{tablePrefix}
+              LOOP
+                EXECUTE format('DROP TABLE IF EXISTS %I.%I;', #{schema}, r.tablename);
+              END LOOP;
+            END
+            $$;
         """)
-            .withQueryFragment("spaceVersion", Long.toString(newVersion))
-            .withQueryFragment("author", "'" + author + "'")
-            .withQueryFragment("onExists", updateStrategy.onExists() == null ? "NULL" : "'" + updateStrategy.onExists() + "'")
-            .withQueryFragment("onNotExists", updateStrategy.onNotExists() == null ? "NULL" : "'" + updateStrategy.onNotExists() + "'")
-            .withQueryFragment("onVersionConflict",
-                    updateStrategy.onVersionConflict() == null ? "NULL" : "'" + updateStrategy.onVersionConflict() + "'")
-            .withQueryFragment("onMergeConflict",
-                    updateStrategy.onMergeConflict() == null ? "NULL" : "'" + updateStrategy.onMergeConflict() + "'")
-            .withQueryFragment("historyEnabled", "" + (versionsToKeep > 1))
-            .withQueryFragment("context", superRootTable == null ? "NULL" : "'DEFAULT'")
-            .withQueryFragment("tables", String.join(",", tables))
-            //Maybe other formats will be supported in the future
-            .withQueryFragment("format", GEOJSON.name())
-            //If FeatureCollection is supported in the future, this needs to be adapted with EMR
-            .withQueryFragment("entityPerLine", entityPerLine)
-            .withVariable("schema", schema)
-            .withVariable("triggerFunction", "import_from_s3_trigger_for_non_empty_layer")
-            .withVariable("table", temporaryImportTable);
+            .withNamedParameter("schema", schema)
+            .withNamedParameter("tablePrefix", getTemporaryJobTableName(this.stepId));
+  }
+
+
+  public String getTemporaryDataTableName(int taskId) {
+    return getTemporaryJobTableName(this.stepId) + TMP_TABLE_SUFFIX + taskId;
+  }
+
+  /**
+   * Builds a task query which imports features from the temporary trigger table using i-range reads.
+   */
+  public SQLQuery buildImportFromTmpTableTaskQuery(Integer taskId, long rangeStart,
+                                                   String author, long currentVersion, boolean isPartial, UpdateStrategy updateStrategy,
+                                                   String serializedImportStep, String lambdaArn, String ownLambdaRegion,
+                                                   Map<String, Object> context, String failureCallback) {
+
+    return new SQLQuery(
+            "SELECT perform_import_from_tmp_table_task(#{taskId}, to_regclass(#{sourceTable}), #{rangeStart}, #{targetMb}, "
+                    + "#{author}, #{currentVersion}, #{isPartial}, #{onExists}, #{onNotExists}, #{onVersionConflict}, "
+                    + "#{onMergeConflict}, #{stepPayload}::JSON->'step', #{lambdaFunctionArn}, #{lambdaRegion}, '${{failureCallback}}')")
+            .withContext(context)
+            .withAsync(true)
+            .withNamedParameter("taskId", taskId)
+            .withNamedParameter("sourceTable", getTemporaryDataTableName(taskId))
+            .withNamedParameter("rangeStart", rangeStart)
+            .withNamedParameter("targetMb", featureWriterBatchSizeInMb)
+            .withNamedParameter("author", author)
+            .withNamedParameter("currentVersion", currentVersion)
+            .withNamedParameter("isPartial", isPartial)
+            .withNamedParameter("onExists", updateStrategy.onExists() == null ? null : updateStrategy.onExists().name())
+            .withNamedParameter("onNotExists", updateStrategy.onNotExists() == null ? null : updateStrategy.onNotExists().name())
+            .withNamedParameter("onVersionConflict", updateStrategy.onVersionConflict() == null ? null : updateStrategy.onVersionConflict().name())
+            .withNamedParameter("onMergeConflict", updateStrategy.onMergeConflict() == null ? null : updateStrategy.onMergeConflict().name())
+            .withNamedParameter("stepPayload", serializedImportStep)
+            .withNamedParameter("lambdaFunctionArn", lambdaArn)
+            .withNamedParameter("lambdaRegion", ownLambdaRegion)
+            .withQueryFragment("failureCallback", failureCallback);
   }
 }

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/util/test/StepTestBase.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/util/test/StepTestBase.java
@@ -382,11 +382,9 @@ public class StepTestBase {
           .withVariable("schema", SCHEMA)
           .withVariable("table", getTemporaryJobTableName(stepId))
       );
-      dropQueries.add(
-          new SQLQuery("DROP TABLE IF EXISTS ${schema}.${table};")
-              .withVariable("schema", SCHEMA)
-              .withVariable("table", new ImportQueryBuilder(stepId, SCHEMA).getTemporaryTriggerTableName())
-      );
+
+      dropQueries.add(new ImportQueryBuilder(stepId, SCHEMA)
+              .buildDropAllTemporaryTablesByStepPrefixQuery());
     }
     SQLQuery.join(dropQueries, ";").write(getDataSourceProvider());
   }

--- a/xyz-jobs/xyz-job-steps/src/main/resources/jobs/transport.sql
+++ b/xyz-jobs/xyz-job-steps/src/main/resources/jobs/transport.sql
@@ -89,12 +89,12 @@ DECLARE
     prefix TEXT := '';
     suffix TEXT := '';
 BEGIN
-    IF type = 'JOB_TABLE' OR type = 'TRIGGER_TABLE' THEN
+    IF type = 'JOB_TABLE' OR type = 'TMP_TABLE' THEN
        prefix = 'job_data_';
     END IF;
 
-    IF type = 'TRIGGER_TABLE' THEN
-       suffix = '_trigger_tbl';
+    IF type = 'TMP_TABLE' THEN
+       suffix = '_tmp_tbl_';
     END IF;
 
     RETURN (schema ||'.'|| '"' || prefix || tbl || suffix ||'"')::REGCLASS;
@@ -255,138 +255,6 @@ BEGIN
 END;
 $BODY$
     LANGUAGE plpgsql VOLATILE;
-    
-/**
- * Function: import_from_s3_trigger_for_non_empty_layer
- * (for tasked import into non-empty layers)
- *
- * Purpose:
- *   Trigger function for importing features into non-empty layers (entity features).
- *   Handles feature enrichment, conflict resolution, and batch context setup.
- *   Uses write_features to process and import features.
- *
- * Arguments:
- *   - TG_ARGV[0]: author (TEXT) - The author of the import.
- *   - TG_ARGV[1]: currentVersion (BIGINT) - The version to assign to the feature.
- *   - TG_ARGV[2]: isPartial (BOOLEAN) - Whether the import is partial.
- *   - TG_ARGV[3]: onExists (TEXT) - Action to take if the feature exists.
- *   - TG_ARGV[4]: onNotExists (TEXT) - Action to take if the feature does not exist.
- *   - TG_ARGV[5]: onVersionConflict (TEXT) - Action on version conflict.
- *   - TG_ARGV[6]: onMergeConflict (TEXT) - Action on merge conflict.
- *   - TG_ARGV[7]: historyEnabled (BOOLEAN) - Whether history tracking is enabled.
- *   - TG_ARGV[8]: spaceContext (TEXT) - Context for the import.
- *   - TG_ARGV[9]: tables (TEXT) - Comma-separated list of tables.
- *   - TG_ARGV[10]: format (TEXT) - Import format (e\.g\., CSV_JSON_WKB, GEOJSON, CSV_GEOJSON).
- *   - TG_ARGV[11]: entityPerLine (TEXT) - Entity type per line (Feature or Features).
- *
- * Behavior:
- *   - Prepares input data based on format and entity type.
- *   - Sets up context for batch or single feature import.
- *   - Calls write_features to process and import the feature(s).
- *   - Updates NEW row with import results.
- *
- * Returns:
- *   - The enriched NEW row (trigger return).
- */
-CREATE OR REPLACE FUNCTION import_from_s3_trigger_for_non_empty_layer() RETURNS trigger AS
-$BODY$
-DECLARE
-    author text := TG_ARGV[0];
-    currentVersion bigint := TG_ARGV[1];
-    isPartial boolean := TG_ARGV[2];
-    onExists text := TG_ARGV[3];
-    onNotExists text := TG_ARGV[4];
-    onVersionConflict text := TG_ARGV[5];
-    onMergeConflict text := TG_ARGV[6];
-    historyEnabled boolean := TG_ARGV[7]::boolean;
-    spaceContext text := TG_ARGV[8];
-    tables text := TG_ARGV[9];
-    format text := TG_ARGV[10];
-    entityPerLine text := TG_ARGV[11];
-
-    feature_collection text;
-    featureCount int := 0;
-BEGIN
-    --TODO: Remove the following workaround once the caller-side was fixed
-    onExists = CASE WHEN onExists = 'null' THEN NULL ELSE onExists END;
-    onNotExists = CASE WHEN onNotExists = 'null' THEN NULL ELSE onNotExists END;
-    onVersionConflict = CASE WHEN onVersionConflict = 'null' THEN NULL ELSE onVersionConflict END;
-    onMergeConflict = CASE WHEN onMergeConflict = 'null' THEN NULL ELSE onMergeConflict END;
-
-    PERFORM context(
-        jsonb_build_object(
-            'stepId', get_stepid_from_work_table(TG_TABLE_NAME::regclass),
-            'schema', TG_TABLE_SCHEMA,
-            'tables', string_to_array(tables, ','),
-            'historyEnabled', historyEnabled,
-            'context', CASE WHEN spaceContext = 'null' THEN null ELSE spaceContext END,
-            'batchMode', true
-        )
-    );
-
-    IF format = 'CSV_JSON_WKB' THEN
-        SELECT jsonb_build_object(
-	       'type', 'FeatureCollection',
-	       'features',
-	       coalesce(
-	           jsonb_agg(
-	               jsonb_set(
-	                   n.jsondata::jsonb,
-	                   '{geometry}',
-	                   xyz_reduce_precision(ST_AsGeoJSON(ST_Force3D(n.geo)), false)::JSONB
-	               )
-	           ),
-	           '[]'::jsonb
-	       )
-	   )::text
-        INTO feature_collection
-            FROM new_rows n
-        WHERE n.geo IS NOT NULL;
-    END IF;
-
-    IF format IN ('GEOJSON', 'CSV_GEOJSON') THEN
-        IF entityPerLine = 'Feature' THEN
-            SELECT jsonb_build_object(
-                       'type', 'FeatureCollection',
-                       'features',
-                       COALESCE(jsonb_agg(n.jsondata::jsonb), '[]'::jsonb)
-                   )::text
-              INTO feature_collection
-              FROM new_rows n;
-        ELSE
-            SELECT jsonb_build_object(
-                       'type', 'FeatureCollection',
-                       'features',
-                       COALESCE(jsonb_agg(f.feature), '[]'::jsonb)
-                   )::text
-              INTO feature_collection
-                  FROM new_rows n
-              CROSS JOIN LATERAL jsonb_array_elements(n.jsondata::jsonb -> 'features') AS f(feature);
-        END IF;
-    ELSE
-        RAISE EXCEPTION 'Unsupported format: %', format;
-    END IF;
-
-    IF feature_collection IS NOT NULL THEN
-        SELECT (write_features(
-                    feature_collection,
-                    'FeatureCollection',
-                    author,
-                    false,
-                    currentVersion,
-                    onExists,
-                    onNotExists,
-                    onVersionConflict,
-                    onMergeConflict,
-                    isPartial
-                )::jsonb ->> 'count')::int
-          INTO featureCount;
-    END IF;
-
-    RETURN null;
-END;
-$BODY$
-LANGUAGE plpgsql VOLATILE;
 
 /**
  * Function: import_from_s3_enrich_feature
@@ -756,7 +624,13 @@ BEGIN
     -- Set provided task as finalized and store output
     EXECUTE format(
         'UPDATE %1$s t
-            SET task_output = %2$L::JSONB,
+            SET task_output = (
+                    COALESCE(t.task_output, ''{}''::JSONB) || %2$L::JSONB
+                ) || jsonb_build_object(
+                    ''taskOutput'',
+                    COALESCE(t.task_output->''taskOutput'', ''{}''::JSONB)
+                    || COALESCE((%2$L::JSONB)->''taskOutput'', ''{}''::JSONB)
+                ),
                 finalized = %3$L
           WHERE task_id = %4$L;',
         get_table_reference(ctx->>'schema', ctx->>'stepId', 'JOB_TABLE'),
@@ -991,6 +865,202 @@ BEGIN
 		     jsonb_build_object(
                 'importStatistics', import_statistics,
                 'fileBytes', file_bytes,
+                'type', 'ImportOutput'
+            )
+		);
+
+		EXCEPTION
+		 	WHEN OTHERS THEN
+		 		BEGIN
+		 			$wrappedouter$ || failure_callback || $wrappedouter$
+		 		END;
+	END;
+	$wrappedinner$ $wrappedouter$;
+	EXECUTE sql_text;
+END;
+$BODY$;
+
+/**
+ * Function: perform_import_from_tmp_table_task
+ *
+ * Purpose:
+ *   Reads records from a temporary source table (jsondata TEXT) beginning at range_start,
+ *   selecting rows until a target MB window is reached,
+ *   builds a
+ *   FeatureCollection, writes it using write_features, and reports task progress.
+ *
+ * Notes:
+ *   - Rows are not deleted by this function.
+ *   - Expects an i column (serial/bigserial) in the source table.
+ *   - Selection starts at range_start and stops before cumulative bytes exceed target_mb.
+ *   - Expects source rows to contain one GeoJSON Feature per jsondata entry.
+ */
+CREATE OR REPLACE FUNCTION perform_import_from_tmp_table_task(
+        task_id INT,
+        source_tbl REGCLASS,
+        range_start BIGINT,
+        target_mb NUMERIC,
+        author TEXT,
+        currentVersion BIGINT,
+        isPartial BOOLEAN,
+        onExists TEXT,
+        onNotExists TEXT,
+        onVersionConflict TEXT,
+        onMergeConflict TEXT,
+        step_payload JSON,
+        lambda_function_arn TEXT,
+        lambda_region TEXT,
+        failure_callback TEXT
+	)
+    RETURNS void
+    LANGUAGE 'plpgsql'
+    VOLATILE
+AS $BODY$
+DECLARE
+	sql_text TEXT;
+BEGIN
+	sql_text = $wrappedouter$ DO
+	$wrappedinner$
+	DECLARE
+        feature_collection TEXT;
+        featureCount INT := 0;
+        pulled_count INT := 0;
+        pulled_bytes BIGINT := 0;
+        selected_range_start BIGINT := NULL;
+        selected_range_end BIGINT := NULL;
+        first_available_i BIGINT := NULL;
+        first_available_bytes BIGINT := NULL;
+        first_available_id TEXT := NULL;
+        import_statistics TEXT;
+
+        task_id INT := $wrappedouter$||task_id||$wrappedouter$::INT;
+        source_tbl REGCLASS := '$wrappedouter$||coalesce(source_tbl::TEXT, $v$null$v$)||$wrappedouter$'::REGCLASS;
+        range_start BIGINT := $wrappedouter$||coalesce(range_start::TEXT, $v$NULL$v$)||$wrappedouter$::BIGINT;
+        target_mb NUMERIC := $wrappedouter$||coalesce(target_mb::TEXT, $v$NULL$v$)||$wrappedouter$::NUMERIC;
+        author TEXT := '$wrappedouter$||author||$wrappedouter$'::TEXT;
+        currentVersion BIGINT := $wrappedouter$||coalesce(currentVersion::TEXT, $v$NULL$v$)||$wrappedouter$::BIGINT;
+        isPartial BOOLEAN := $wrappedouter$||coalesce(isPartial::TEXT, $v$NULL$v$)||$wrappedouter$::BOOLEAN;
+        onExists TEXT := '$wrappedouter$||coalesce(onExists, $v$null$v$)||$wrappedouter$'::TEXT;
+        onNotExists TEXT := '$wrappedouter$||coalesce(onNotExists, $v$null$v$)||$wrappedouter$'::TEXT;
+        onVersionConflict TEXT := '$wrappedouter$||coalesce(onVersionConflict, $v$null$v$)||$wrappedouter$'::TEXT;
+        onMergeConflict TEXT := '$wrappedouter$||coalesce(onMergeConflict, $v$null$v$)||$wrappedouter$'::TEXT;
+		step_payload JSON := '$wrappedouter$||coalesce(step_payload::TEXT, $v$null$v$)||$wrappedouter$'::JSON;
+		lambda_function_arn TEXT := '$wrappedouter$||lambda_function_arn||$wrappedouter$'::TEXT;
+		lambda_region TEXT := '$wrappedouter$||lambda_region||$wrappedouter$'::TEXT;
+	BEGIN
+        IF range_start IS NULL THEN
+            RAISE EXCEPTION 'range_start must be provided.' USING ERRCODE = 'XYZ40';
+        END IF;
+
+        IF target_mb IS NULL OR target_mb <= 0 THEN
+            RAISE EXCEPTION 'target_mb must be provided and > 0.' USING ERRCODE = 'XYZ40';
+        END IF;
+
+        onExists = CASE WHEN onExists = 'null' THEN NULL ELSE onExists END;
+        onNotExists = CASE WHEN onNotExists = 'null' THEN NULL ELSE onNotExists END;
+        onVersionConflict = CASE WHEN onVersionConflict = 'null' THEN NULL ELSE onVersionConflict END;
+        onMergeConflict = CASE WHEN onMergeConflict = 'null' THEN NULL ELSE onMergeConflict END;
+
+        PERFORM context();
+
+        EXECUTE format($fmt$
+            WITH params AS (
+                SELECT %2$s::BIGINT AS start_i,
+                       (%3$s::NUMERIC * 1024 * 1024)::BIGINT AS target_bytes
+            ),
+            ordered AS (
+                SELECT i,
+                       jsondata::jsonb AS feature,
+                       octet_length(jsondata) AS feature_bytes,
+                       SUM(octet_length(jsondata)) OVER (ORDER BY i) AS running_bytes
+                  FROM %1$s
+                 CROSS JOIN params p
+                 WHERE jsondata IS NOT NULL
+                   AND i >= p.start_i
+            ),
+            selected AS (
+                SELECT o.*
+                  FROM ordered o
+                 CROSS JOIN params p
+                 WHERE o.running_bytes <= p.target_bytes
+            ),
+            first_row AS (
+                SELECT o.i, o.feature_bytes, (o.feature->>'id') AS feature_id
+                  FROM ordered o
+                 ORDER BY o.i
+                 LIMIT 1
+            )
+            SELECT jsonb_build_object(
+                       'type', 'FeatureCollection',
+                       'features', COALESCE(jsonb_agg(s.feature ORDER BY s.i), '[]'::jsonb)
+                   )::text as feature_collection,
+                   COALESCE(COUNT(s.i), 0)::INT as pulled_count,
+                   COALESCE(SUM(s.feature_bytes), 0)::BIGINT as pulled_bytes,
+                   MIN(s.i)::BIGINT as minI,
+                   MAX(s.i)::BIGINT as maxI,
+                   MIN(fr.i)::BIGINT as first_available_i,
+                   MIN(fr.feature_bytes)::BIGINT as first_available_bytes,
+                   MIN(fr.feature_id) as first_available_id
+              FROM selected s
+              FULL JOIN first_row fr ON true
+        $fmt$, source_tbl, range_start, target_mb)
+        INTO feature_collection, pulled_count, pulled_bytes, selected_range_start, selected_range_end, first_available_i, first_available_bytes, first_available_id;
+
+        -- No more rows in the source table at or after range_start -> tmp table fully processed
+        IF first_available_i IS NULL THEN
+            PERFORM report_task_progress(
+                 lambda_function_arn,
+                 lambda_region,
+                 step_payload,
+                 task_id,
+                 jsonb_build_object(
+                    'progress', jsonb_build_object(
+                        'type', 'ImportOutput$ImportProgress',
+                        'tmpTableLoaded', true
+                    ),
+                    'type', 'ImportOutput'
+                )
+            );
+            RETURN;
+        END IF;
+
+        -- There are unprocessed rows, but the very next feature alone already exceeds the target window -> fail
+        IF pulled_count = 0 THEN
+            RAISE EXCEPTION 'Feature with id=''%'' with ''%'' bytes exceeds the per-batch limit of ''%'' MB! (Batch i=''%'')',
+                COALESCE(first_available_id, '<no-id>'), first_available_bytes, target_mb, first_available_i
+            USING HINT = 'Remove features which are exceeding the limit from your datasets.',
+                  ERRCODE = 'XYZ40';
+        END IF;
+
+        SELECT (write_features(
+                feature_collection,
+                'FeatureCollection',
+                author,
+                false,
+                currentVersion,
+                onExists,
+                onNotExists,
+                onVersionConflict,
+                onMergeConflict,
+                isPartial
+                )::jsonb ->> 'count')::int
+        INTO featureCount;
+
+        --currently we are not using this
+        --import_statistics := format('%s rows imported', featureCount);
+
+		PERFORM report_task_progress(
+			 lambda_function_arn,
+			 lambda_region,
+			 step_payload,
+			 task_id,
+		     jsonb_build_object(
+                'progress', jsonb_build_object(
+                    'type', 'ImportOutput$ImportProgress',
+                    'tmpTableLoaded', false,
+                    'startI', selected_range_start,
+                    'endI', selected_range_end
+                ),
                 'type', 'ImportOutput'
             )
 		);


### PR DESCRIPTION
Enhance import into non-empty layers functionality - use featureWriter by reading batches from temporary tables.

* Introduced featureWriterBatchSizeInMb to control batch size during imports.
* Updated ImportOutput to include ImportProgress for tracking task progress.
*  Refactored ImportQueryBuilder to manage temporary data tables for imports.
* Improved TaskedImportFilesToSpace to handle task progress and cleanup of temporary resources.
* Provide different hook methods (prepareTaskQuery,onTaskProgress,taskIsFinalized,finalizeTaskQuery) in TaskedSpaceBasedStep implementation to enable async batch processing of tasks.
* Added support for resuming imports into non-empty layers by loading previous task output. Proceed with the next batch of the task.

TaskedSpaceBasedStep fix: 
* override onAsyncSuccess() and call finalizeStep() to ensure a proper success handling.
Cleanup: code which is not required anymore in case of non-empty Imports.

TaskedSpaceBasedStep: 
* add correct handling if no tasks are available.