### PR TITLE
Add support for OutputSet references in step impl "RunEmrJob"

### DIFF
--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/execution/GraphFusionTool.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/execution/GraphFusionTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2025 HERE Europe B.V.
+ * Copyright (C) 2017-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -333,7 +333,7 @@ public class GraphFusionTool {
   private static String updateEmrScriptParamReferences(RunEmrJob runEmrJob, StepGraph containingStepGraph, String referenceIdentifier) {
     try {
       //Will throw an exception if the referenced inputSet is not found in the step
-      runEmrJob.fromReferenceIdentifier(referenceIdentifier);
+      runEmrJob.fromInputReferenceIdentifier(referenceIdentifier);
       //In case it was found, it means the reference is pointing to a "new" output, keep the reference as it is
       return null;
     }

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/Step.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/Step.java
@@ -811,13 +811,24 @@ public abstract class Step<T extends Step> implements Typed, StepExecution {
       this.stepId = other.stepId;
     }
 
-    public OutputSet(S3Uri s3Uri, String name) {
+    private OutputSet(S3Uri s3Uri, String name) {
       this.s3Uri = s3Uri;
       this.name = name;
       stepId = GENERIC_PROVIDER;
       visibility = SYSTEM;
       jobId = null;
       fileSuffix = "unknown";
+    }
+
+    /**
+     * NOTE: This factory method should only be used for already existing datasets (e.g. from references)
+     * Compilers *must not* use a generic OuputSet for the purpose of passing outputs from one step as inputs to the next step.
+     * @param s3Uri
+     * @param name
+     * @return
+     */
+    public static OutputSet newGenericOutputSet(S3Uri s3Uri, String name) {
+      return new OutputSet(s3Uri, name);
     }
 
     public String getJobId() {

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/execution/RunEmrJob.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/execution/RunEmrJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2025 HERE Europe B.V.
+ * Copyright (C) 2017-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,10 +56,13 @@ import software.amazon.awssdk.services.s3.model.S3Exception;
 public class RunEmrJob extends LambdaBasedStep<RunEmrJob> {
   public static final String EMR_JOB_NAME_PREFIX = "step:";
   private static final Logger logger = LogManager.getLogger();
+  private static final String OUTPUT_SET_REF_PREFIX = "${outputSet:";
   private static final String INPUT_SET_REF_PREFIX = "${inputSet:";
-  private static final String INPUT_SET_REF_SUFFIX = "}";
+  private static final String DATA_SET_REF_SUFFIX = "}";
   private static final Pattern INPUT_SET_REF_PATTERN = Pattern.compile(
-      Pattern.quote(INPUT_SET_REF_PREFIX) + "([a-zA-Z0-9._=-]+)" + Pattern.quote(INPUT_SET_REF_SUFFIX));
+      Pattern.quote(INPUT_SET_REF_PREFIX) + "([a-zA-Z0-9._=-]+)" + Pattern.quote(DATA_SET_REF_SUFFIX));
+  private static final Pattern OUTPUT_SET_REF_PATTERN = Pattern.compile(
+      Pattern.quote(OUTPUT_SET_REF_PREFIX) + "([a-zA-Z0-9._=-]+)" + Pattern.quote(DATA_SET_REF_SUFFIX));
 
   private String applicationId;
   private String executionRoleArn;
@@ -473,16 +476,39 @@ public class RunEmrJob extends LambdaBasedStep<RunEmrJob> {
   }
 
   public static String toInputSetReference(InputSet inputSet) {
-    return INPUT_SET_REF_PREFIX + toReferenceIdentifier(inputSet) + INPUT_SET_REF_SUFFIX;
+    return INPUT_SET_REF_PREFIX + toInputReferenceIdentifier(inputSet) + DATA_SET_REF_SUFFIX;
   }
 
-  private static String toReferenceIdentifier(InputSet inputSet) {
+  private static String toInputReferenceIdentifier(InputSet inputSet) {
     return inputSet.providerId() + "." + inputSet.name();
   }
 
-  InputSet fromReferenceIdentifier(String referenceIdentifier) {
+  public String outputSetReference(OutputSet outputSet) {
+    if (!getOutputSets().contains(outputSet))
+      throw new IllegalArgumentException("The provided outputSet is not a part of this EMR step.");
+
+    return toOuputSetReference(outputSet);
+  }
+
+  public static String toOuputSetReference(OutputSet outputSet) {
+    return OUTPUT_SET_REF_PREFIX + toOutputReferenceIdentifier(outputSet) + DATA_SET_REF_SUFFIX;
+  }
+
+  private static String toOutputReferenceIdentifier(OutputSet outputSet) {
+    return outputSet.getStepId() + "." + outputSet.name;
+  }
+
+  InputSet fromInputReferenceIdentifier(String referenceIdentifier) {
     ReferenceIdentifier ref = ReferenceIdentifier.fromString(referenceIdentifier);
     return getInputSet(ref.stepId(), ref.name());
+  }
+
+  OutputSet fromOutputReferenceIdentifier(String referenceIdentifier) {
+    ReferenceIdentifier ref = ReferenceIdentifier.fromString(referenceIdentifier);
+    if (!ref.stepId().equals(getId()))
+      throw new IllegalArgumentException("Output set reference \"" + referenceIdentifier
+          + "\" does not match the step ID of this EMR step.");
+    return getOutputSet(ref.name());
   }
 
   protected InputSet getInputSet(String providerId, String name) {
@@ -510,7 +536,7 @@ public class RunEmrJob extends LambdaBasedStep<RunEmrJob> {
     if(localInputRefMap.containsKey(referenceIdentifier))
       return localInputRefMap.get(referenceIdentifier);
 
-    String s3Uri = fromReferenceIdentifier(referenceIdentifier).toS3Uri(getJobId()).toString();
+    String s3Uri = fromInputReferenceIdentifier(referenceIdentifier).toS3Uri(getJobId()).toString();
     String tmpLocalDir = copyFolderFromS3ToLocal(S3Client.getKeyFromS3Uri(s3Uri));
     localInputRefMap.put(referenceIdentifier, tmpLocalDir);
     return tmpLocalDir;
@@ -518,18 +544,30 @@ public class RunEmrJob extends LambdaBasedStep<RunEmrJob> {
 
   List<String> getResolvedScriptParams() {
     //Replace potential inputSet references within the script params
-    return getScriptParams().stream().map(scriptParam -> replaceInputSetReferences(scriptParam)).toList();
+    return getScriptParams().stream()
+        .map(scriptParam -> replaceInputSetReferences(scriptParam))
+        .map(scriptParam -> replaceOutputSetReferences(scriptParam))
+        .toList();
   }
 
   private String replaceInputSetReferences(String scriptParam) {
-    return mapInputReferencesIn(scriptParam,
-        referenceIdentifier -> fromReferenceIdentifier(referenceIdentifier).toS3Uri(getJobId()).toString());
+    return mapReferencesIn(INPUT_SET_REF_PATTERN, scriptParam,
+        referenceIdentifier -> fromInputReferenceIdentifier(referenceIdentifier).toS3Uri(getJobId()).toString());
+  }
+
+  private String replaceOutputSetReferences(String scriptParam) {
+    return mapReferencesIn(OUTPUT_SET_REF_PATTERN, scriptParam,
+        referenceIdentifier -> fromOutputReferenceIdentifier(referenceIdentifier).toS3Uri(getJobId()).toString());
   }
 
   static String mapInputReferencesIn(String scriptParam, Function<String, String> mapper) {
+    return mapReferencesIn(INPUT_SET_REF_PATTERN, scriptParam, mapper);
+  }
+
+  private static String mapReferencesIn(Pattern placeholderPattern, String scriptParam, Function<String, String> mapper) {
     if (scriptParam == null)
       return null;
-    return INPUT_SET_REF_PATTERN.matcher(scriptParam)
+    return placeholderPattern.matcher(scriptParam)
         .replaceAll(match -> {
           String replacement = mapper.apply(match.group(1));
           if (replacement == null)


### PR DESCRIPTION
- Enables the possibility to pass a reference to a non-existent OutputSet at compilation time (e.g. because the job ID is not present yet)
- OutputSet references will be re-substituted later during Graph transformation time (similar to already supported InputSet references) when all necessary information is present