### PR TITLE
Fix class cast issue for some cases of starting PENDING jobs

### DIFF
--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/CompilationStepGraph.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/CompilationStepGraph.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2024 HERE Europe B.V.
+ * Copyright (C) 2017-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,10 +37,24 @@ public class CompilationStepGraph extends StepGraph {
    * - Starting state: NOT_READY
    *
    * @param jobId The job ID of the job for which this step graph was created
+   * @return This StepGraph for chaining
    */
   public StepGraph enrich(String jobId) {
-    enrich(jobId, new HashSet<>());
+    enrich(this, jobId);
     return this;
+  }
+
+  /**
+   * This method should be called after the whole step graph was created to set the needed properties on the steps:
+   * - job ID
+   * - previous step IDs
+   * - Starting state: NOT_READY
+   *
+   * @param stepGraph The step graph to be enriched with the jobId
+   * @param jobId The job ID of the job for which this step graph was created
+   */
+  public static void enrich(StepGraph stepGraph, String jobId) {
+    enrich(stepGraph, jobId, new HashSet<>());
   }
 
   /**
@@ -51,28 +65,28 @@ public class CompilationStepGraph extends StepGraph {
    * @return The steps that should be treated as previous steps for the next sequential execution (sibling of this graph)
    *  in a potential parent graph
    */
-  private Set<String> enrich(String jobId, Set<String> previousSteps) {
+  private static Set<String> enrich(StepGraph stepGraph, String jobId, Set<String> previousSteps) {
     HashSet<String> previousStepsForNextSibling = new HashSet<>();
 
-    for (StepExecution child : getExecutions()) {
-      if (!isParallel())
+    for (StepExecution child : stepGraph.getExecutions()) {
+      if (!stepGraph.isParallel())
         previousStepsForNextSibling = new HashSet<>();
 
       previousStepsForNextSibling.addAll(enrichChild(child, jobId, previousSteps));
 
-      if (!isParallel())
+      if (!stepGraph.isParallel())
         previousSteps = previousStepsForNextSibling;
     }
 
     return previousStepsForNextSibling;
   }
 
-  private Set<String> enrichChild(StepExecution child, String jobId, Set<String> previousSteps) {
+  private static Set<String> enrichChild(StepExecution child, String jobId, Set<String> previousSteps) {
     return child instanceof Step step ? enrichChild(step, jobId, previousSteps)
-        : ((CompilationStepGraph) child).enrich(jobId, previousSteps);
+        : enrich(((StepGraph) child), jobId, previousSteps);
   }
 
-  private Set<String> enrichChild(Step step, String jobId, Set<String> previousSteps) {
+  private static Set<String> enrichChild(Step step, String jobId, Set<String> previousSteps) {
     step.withJobId(jobId)
         .withPreviousStepIds(previousSteps);
     return Set.of(step.getId());

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/execution/GraphFusionTool.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/execution/GraphFusionTool.java
@@ -55,10 +55,10 @@ public class GraphFusionTool {
   protected static StepGraph fuseGraphs(String newJobId, StepGraph newGraph, StepGraph oldGraph) {
     newGraph = canonicalize(newGraph, false);
     oldGraph = canonicalize(oldGraph, true);
-    CompilationStepGraph fusedGraph = replaceByDelegations(newGraph, oldGraph);
+    StepGraph fusedGraph = replaceByDelegations(newGraph, oldGraph);
 
     //Replace previous step relations (previousStepIds)
-    fusedGraph.enrich(newJobId);
+    CompilationStepGraph.enrich(fusedGraph, newJobId);
 
     //Replace InputSets accordingly for new steps that should re-use outputs of old steps as inputs
     resolveReusedInputs(fusedGraph);
@@ -132,14 +132,14 @@ public class GraphFusionTool {
    * @param oldStepGraph The old step graph of which to take the steps that can be re-used
    * @return A graph that is equivalent to the new step graph, but contains as many DelegateSteps as possible
    */
-  private static CompilationStepGraph replaceByDelegations(StepGraph newStepGraph, StepGraph oldStepGraph) {
+  private static StepGraph replaceByDelegations(StepGraph newStepGraph, StepGraph oldStepGraph) {
     if (newStepGraph.isParallel() != oldStepGraph.isParallel()) {
       if (newStepGraph.isParallel())
         //Wrap the sequential old graph into a parallel one and continue
         oldStepGraph = wrap(oldStepGraph, true);
       else
         //Wrap the sequential new graph into a parallel one, do replacements parallel, and unwrap the result again
-        return (CompilationStepGraph) unwrap(replaceByDelegationsParallelly(wrap(newStepGraph, true), oldStepGraph));
+        return (StepGraph) unwrap(replaceByDelegationsParallelly(wrap(newStepGraph, true), oldStepGraph));
     }
     return newStepGraph.isParallel()
         ? replaceByDelegationsParallelly(newStepGraph, oldStepGraph) : replaceByDelegationsSequentially(newStepGraph, oldStepGraph);
@@ -153,8 +153,8 @@ public class GraphFusionTool {
    * @param oldStepGraph
    * @return
    */
-  private static CompilationStepGraph replaceByDelegationsSequentially(StepGraph newStepGraph, StepGraph oldStepGraph) {
-    CompilationStepGraph result = new CompilationStepGraph();
+  private static StepGraph replaceByDelegationsSequentially(StepGraph newStepGraph, StepGraph oldStepGraph) {
+    StepGraph result = new CompilationStepGraph();
     for (int i = 0; i < Math.min(newStepGraph.getExecutions().size(), oldStepGraph.getExecutions().size()); i++) {
       StepExecution newExecution = newStepGraph.getExecutions().get(i);
       StepExecution oldExecution = oldStepGraph.getExecutions().get(i);
@@ -174,7 +174,7 @@ public class GraphFusionTool {
     return result;
   }
 
-  private static CompilationStepGraph replaceByDelegation(StepGraph newStepGraph, Step oldStep) {
+  private static StepGraph replaceByDelegation(StepGraph newStepGraph, Step oldStep) {
     if (newStepGraph.isParallel())
       return replaceByDelegationsParallelly(newStepGraph, wrap(oldStep, true));
     else
@@ -196,8 +196,8 @@ public class GraphFusionTool {
    * @param oldStepGraph
    * @return
    */
-  private static CompilationStepGraph replaceByDelegationsParallelly(StepGraph newStepGraph, StepGraph oldStepGraph) {
-    CompilationStepGraph result = (CompilationStepGraph) new CompilationStepGraph().withParallel(true);
+  private static StepGraph replaceByDelegationsParallelly(StepGraph newStepGraph, StepGraph oldStepGraph) {
+    StepGraph result = new CompilationStepGraph().withParallel(true);
     for (StepExecution newBranch : newStepGraph.getExecutions()) {
       //Each execution is one parallel branch. Calculate the match count with each old parallel branch
       int maxMatchCount = 0;

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/execution/JobExecutor.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/execution/JobExecutor.java
@@ -25,8 +25,8 @@ import static com.here.xyz.jobs.RuntimeInfo.State.FAILED;
 import static com.here.xyz.jobs.RuntimeInfo.State.PENDING;
 import static com.here.xyz.jobs.RuntimeInfo.State.RUNNING;
 import static com.here.xyz.jobs.RuntimeInfo.State.SUCCEEDED;
-import static com.here.xyz.jobs.steps.execution.JobExecutor.SchedulerState.SchedulerRuntimeState.PAUSED;
 import static com.here.xyz.jobs.steps.execution.GraphFusionTool.fuseGraphs;
+import static com.here.xyz.jobs.steps.execution.JobExecutor.SchedulerState.SchedulerRuntimeState.PAUSED;
 import static java.util.Comparator.comparingLong;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -44,7 +44,6 @@ import com.here.xyz.util.service.Initializable;
 import io.vertx.core.Future;
 import io.vertx.core.impl.ConcurrentHashSet;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Executors;
@@ -143,8 +142,11 @@ public abstract class JobExecutor implements Initializable {
         })
         .onFailure(e -> {
           //E.g.: Resource got deleted during lifetime of job!
-          logger.error("Start Execution of job '{}' is failed!", job.getId(), e);
-          job.getStatus().setState(FAILED);
+          logger.error("Error starting execution of job '{}'", job.getId(), e);
+          job.getStatus()
+              .withState(FAILED)
+              .withErrorMessage("Unexpected error while trying to start the execution of the job.")
+              .withErrorCause(e.getMessage());
           job.storeStatus(null);
         });
   }


### PR DESCRIPTION
- A class cast exception happened in the GraphFusionTool for PENDING jobs because these were loaded & deserialized from DB. By that their StepGraphs lose their nature of being CompilationStepGraphs -> removed the necessity for casting completely by introducing a static method for StepGraph enrichment
- No error message / cause was present in these cases when jobs failed while trying to start them out of a PENDING state. <- also fixed