### PR TITLE
Improve Job filtering through REST API, add new query param "olderThan"

### DIFF
--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/Job.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/Job.java
@@ -504,9 +504,10 @@ public class Job implements XyzSerializable {
       return JobConfigClient.getInstance().loadJobs(resourceKey, state);
   }
 
-  public static Future<List<Job>> load(FilteredValues<Long> newerThan, FilteredValues<String> sourceType, FilteredValues<String> targetType,
-                                               FilteredValues<String> processType, FilteredValues<String> resourceKeys, FilteredValues<State> stateTypes) {
-    return JobConfigClient.getInstance().loadJobs(newerThan, sourceType, targetType, processType, resourceKeys, stateTypes);
+  public static Future<List<Job>> load(FilteredValues<Long> newerThan, FilteredValues<Long> olderThan, FilteredValues<String> sourceType,
+      FilteredValues<String> targetType, FilteredValues<String> processType, FilteredValues<String> resourceKeys,
+      FilteredValues<State> stateTypes) {
+    return JobConfigClient.getInstance().loadJobs(newerThan, olderThan, sourceType, targetType, processType, resourceKeys, stateTypes);
   }
 
   public static Future<Set<Job>> loadByResourceKey(String resourceKey) {

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/config/DynamoJobConfigClient.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/config/DynamoJobConfigClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2025 HERE Europe B.V.
+ * Copyright (C) 2017-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -113,9 +113,9 @@ public class DynamoJobConfigClient extends JobConfigClient {
   }
 
   @Override
-  public Future<List<Job>> loadJobs(FilteredValues<Long> newerThan, FilteredValues<String> sourceTypes,
-                                    FilteredValues<String> targetTypes, FilteredValues<String> processTypes,
-                                    FilteredValues<String> resourceKeys, FilteredValues<State> stateTypes) {
+  public Future<List<Job>> loadJobs(FilteredValues<Long> newerThan, FilteredValues<Long> olderThan, FilteredValues<String> sourceTypes,
+      FilteredValues<String> targetTypes, FilteredValues<String> processTypes, FilteredValues<String> resourceKeys,
+      FilteredValues<State> stateTypes) {
     List<Job> jobs = new LinkedList<>();
 
     List<String> filters = new ArrayList<>();
@@ -123,12 +123,10 @@ public class DynamoJobConfigClient extends JobConfigClient {
     Map<String, Object> attrValues = new HashMap<>();
 
     // --- createdAt special case ---
-    if (newerThan != null && !newerThan.values().isEmpty()) {
-      Long ts = newerThan.values().iterator().next(); // Only use one timestamp
-      filters.add("#createdAt " + (newerThan.include() ? ">" : "<=") + " :ts");
-      attrNames.put("#createdAt", "createdAt");
-      attrValues.put(":ts", ts);
-    }
+    if (newerThan != null && !newerThan.values().isEmpty())
+      addCreatedAtCondition(newerThan, filters, attrNames, attrValues);
+    if (olderThan != null && !olderThan.values().isEmpty())
+      addCreatedAtCondition(new FilteredValues<>(false, olderThan.values()), filters, attrNames, attrValues);
 
     // --- IN / NOT IN filters ---
     Optional.ofNullable(buildInFilter("source.type", sourceTypes, attrNames, attrValues)).ifPresent(filters::add);
@@ -149,24 +147,31 @@ public class DynamoJobConfigClient extends JobConfigClient {
 
       attrNames.put("#resourceKeys", "resourceKeys");
 
-      if (resourceKeys.include()) {
+      if (resourceKeys.include())
         filters.add("(" + String.join(" OR ", subFilters) + ")");
-      } else {
+      else
         filters.add("(" + subFilters.stream().map(f -> "NOT " + f).collect(Collectors.joining(" AND ")) + ")");
-      }
     }
 
     String filterExpr = filters.isEmpty() ? null : String.join(" AND ", filters);
-    if (attrNames.isEmpty()) attrNames = null;
-    if (attrValues.isEmpty()) attrValues = null;
+    if (attrNames.isEmpty())
+      attrNames = null;
+    if (attrValues.isEmpty())
+      attrValues = null;
 
     jobTable.scan(filterExpr, attrNames, attrValues)
-            .pages()
-            .forEach(page ->
-                    page.forEach(item -> jobs.add(XyzSerializable.fromMap(item.asMap(), Job.class)))
-            );
+        .pages()
+        .forEach(page -> page.forEach(item -> jobs.add(XyzSerializable.fromMap(item.asMap(), Job.class))));
 
     return Future.succeededFuture(jobs);
+  }
+
+  private static void addCreatedAtCondition(FilteredValues<Long> newerThan, List<String> filters, Map<String, String> attrNames,
+      Map<String, Object> attrValues) {
+    Long ts = newerThan.values().iterator().next(); // Only use one timestamp
+    filters.add("#createdAt " + (newerThan.include() ? ">" : "<=") + " :ts");
+    attrNames.put("#createdAt", "createdAt");
+    attrValues.put(":ts", ts);
   }
 
   private String buildInFilter(String fieldPath, FilteredValues<?> fv,

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/config/InMemJobConfigClient.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/config/InMemJobConfigClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2025 HERE Europe B.V.
+ * Copyright (C) 2017-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,38 +55,51 @@ public class InMemJobConfigClient extends JobConfigClient {
     return Future.succeededFuture(List.copyOf(jobMap.values()));
   }
 
-  public Future<List<Job>> loadJobs(FilteredValues<Long> newerThan, FilteredValues<String> sourceTypes,
-                                    FilteredValues<String> targetTypes, FilteredValues<String> processTypes,
-                                    FilteredValues<String> resourceKeys, FilteredValues<State> stateTypes) {
+  public Future<List<Job>> loadJobs(FilteredValues<Long> newerThan, FilteredValues<Long> olderThan, FilteredValues<String> sourceTypes,
+      FilteredValues<String> targetTypes, FilteredValues<String> processTypes, FilteredValues<String> resourceKeys,
+      FilteredValues<State> stateTypes) {
     return Future.succeededFuture(
-            jobMap.values().stream()
-                    .filter(job -> {
-                      if (newerThan == null || newerThan.values().isEmpty()) return true;
-                      Long ts = newerThan.values().iterator().next();
-                      return newerThan.include() ? job.getCreatedAt() > ts : job.getCreatedAt() < ts;
-                    })
+        jobMap.values().stream()
+            .filter(job -> {
+              if (newerThan == null || newerThan.values().isEmpty())
+                return true;
 
-                    .filter(job -> matchesFilteredValues(sourceTypes,
-                            job.getSource() != null ? job.getSource().getClass().getSimpleName() : null))
+              Long ts = newerThan.values().iterator().next();
+              return newerThan.include() ? job.getCreatedAt() > ts : job.getCreatedAt() <= ts;
+            })
 
-                    .filter(job -> matchesFilteredValues(targetTypes,
-                            job.getTarget() != null ? job.getTarget().getClass().getSimpleName() : null))
+            .filter(job -> {
+              if (olderThan == null || olderThan.values().isEmpty())
+                return true;
 
-                    .filter(job -> matchesFilteredValues(processTypes,
-                            job.getProcess() != null ? job.getProcess().getClass().getSimpleName() : null))
+              Long ts = olderThan.values().iterator().next();
+              return olderThan.include() ? job.getCreatedAt() < ts : job.getCreatedAt() >= ts;
+            })
 
-                    .filter(job -> matchesFilteredValues(stateTypes,
-                            job.getStatus() != null ? State.valueOf(job.getStatus().getState().name()) : null))
+            .filter(job -> matchesFilteredValues(sourceTypes,
+                job.getSource() != null ? job.getSource().getClass().getSimpleName() : null))
 
-                    .filter(job -> {
-                      if (resourceKeys == null || resourceKeys.values().isEmpty()) return true;
-                      Set<String> jobKeys = job.getResourceKeys();
-                      if (jobKeys == null || jobKeys.isEmpty()) return !resourceKeys.include(); // Exclude when filtering for presence
-                      boolean match = resourceKeys.values().stream().anyMatch(jobKeys::contains);
-                      return resourceKeys.include() ? match : !match;
-                    })
+            .filter(job -> matchesFilteredValues(targetTypes,
+                job.getTarget() != null ? job.getTarget().getClass().getSimpleName() : null))
 
-                    .toList()
+            .filter(job -> matchesFilteredValues(processTypes,
+                job.getProcess() != null ? job.getProcess().getClass().getSimpleName() : null))
+
+            .filter(job -> matchesFilteredValues(stateTypes,
+                job.getStatus() != null ? State.valueOf(job.getStatus().getState().name()) : null))
+
+            .filter(job -> {
+              if (resourceKeys == null || resourceKeys.values().isEmpty())
+                return true;
+
+              Set<String> jobKeys = job.getResourceKeys();
+              if (jobKeys == null || jobKeys.isEmpty())
+                return !resourceKeys.include(); // Exclude when filtering for presence
+
+              boolean match = resourceKeys.values().stream().anyMatch(jobKeys::contains);
+              return resourceKeys.include() ? match : !match;
+            })
+            .toList()
     );
   }
 

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/config/JobConfigClient.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/config/JobConfigClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2025 HERE Europe B.V.
+ * Copyright (C) 2017-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,8 +74,9 @@ public abstract class JobConfigClient implements Initializable {
    *                     otherwise, excludes them.
    * @return a {@link Future} containing the filtered list of jobs
    */
-  public abstract Future<List<Job>> loadJobs(FilteredValues<Long> newerThan, FilteredValues<String> sourceTypes, FilteredValues<String> targetTypes,
-                                               FilteredValues<String> processTypes, FilteredValues<String> resourceKeys, FilteredValues<State> stateTypes);
+  public abstract Future<List<Job>> loadJobs(FilteredValues<Long> newerThan, FilteredValues<Long> olderThan,
+      FilteredValues<String> sourceTypes, FilteredValues<String> targetTypes, FilteredValues<String> processTypes,
+      FilteredValues<String> resourceKeys, FilteredValues<State> stateTypes);
 
   /**
    * Load all jobs that are having the specified state.

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/service/JobApiBase.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/service/JobApiBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2025 HERE Europe B.V.
+ * Copyright (C) 2017-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,14 +20,15 @@
 package com.here.xyz.jobs.service;
 
 import static com.here.xyz.jobs.service.JobApiBase.ApiParam.Path.JOB_ID;
-import static com.here.xyz.jobs.service.JobApiBase.ApiParam.Query.RESOURCE;
 import static com.here.xyz.jobs.service.JobApiBase.ApiParam.Path.LIMIT;
 import static com.here.xyz.jobs.service.JobApiBase.ApiParam.Path.PAGE_TOKEN;
 import static com.here.xyz.jobs.service.JobApiBase.ApiParam.Query.NEWER_THAN;
+import static com.here.xyz.jobs.service.JobApiBase.ApiParam.Query.OLDER_THAN;
+import static com.here.xyz.jobs.service.JobApiBase.ApiParam.Query.PROCESS_TYPE;
+import static com.here.xyz.jobs.service.JobApiBase.ApiParam.Query.RESOURCE;
 import static com.here.xyz.jobs.service.JobApiBase.ApiParam.Query.SOURCE_TYPE;
 import static com.here.xyz.jobs.service.JobApiBase.ApiParam.Query.STATE;
 import static com.here.xyz.jobs.service.JobApiBase.ApiParam.Query.TARGET_TYPE;
-import static com.here.xyz.jobs.service.JobApiBase.ApiParam.Query.PROCESS_TYPE;
 import static com.here.xyz.jobs.service.JobApiBase.ApiParam.getQueryParam;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 
@@ -37,7 +38,6 @@ import com.here.xyz.jobs.config.JobConfigClient.FilteredValues;
 import com.here.xyz.util.service.rest.Api;
 import io.vertx.core.Future;
 import io.vertx.ext.web.RoutingContext;
-
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -64,73 +64,86 @@ public class JobApiBase extends Api {
   }
 
   protected void getJobs(final RoutingContext context, boolean internal) {
-    try {
-      // resource and type are indexed
-      final FilteredValues<String> resourceKeys = getFilteredValues(context, RESOURCE);
-      final FilteredValues<Long> newerThan = getFilteredValues(context, NEWER_THAN);
-      final FilteredValues<String> sourceTypes = getFilteredValues(context, SOURCE_TYPE);
-      final FilteredValues<String>  targetTypes = getFilteredValues(context, TARGET_TYPE);
-      final FilteredValues<String>  processTypes = getFilteredValues(context, PROCESS_TYPE);
-      final FilteredValues<State>  stateTypes= getFilteredValues(context, STATE);
+    //NOTE: Resource and state properties are indexed
+    final FilteredValues<String> resourceKeys = getFilteredValues(context, RESOURCE);
+    final FilteredValues<Long> newerThan = getFilteredValues(context, NEWER_THAN);
+    final FilteredValues<Long> olderThan = getFilteredValues(context, OLDER_THAN);
+    final FilteredValues<String> sourceTypes = getFilteredValues(context, SOURCE_TYPE);
+    final FilteredValues<String> targetTypes = getFilteredValues(context, TARGET_TYPE);
+    final FilteredValues<String> processTypes = getFilteredValues(context, PROCESS_TYPE);
+    final FilteredValues<State> stateTypes = getFilteredValues(context, STATE);
 
-      Future<List<Job>> resultFuture;
+    if (olderThan != null && newerThan == null)
+      throw new IllegalArgumentException("The parameter \"" + NEWER_THAN + "\" is required when the \"" + OLDER_THAN + "\" parameter is "
+          + "provided");
 
-      if(newerThan == null && sourceTypes == null && targetTypes == null && processTypes == null){
-        Set<State> stateTypeValues = stateTypes == null ? Set.of() : stateTypes.values();
-        Set<String> resourceKeyValues = resourceKeys == null ? Set.of() : resourceKeys.values();
-        boolean includeStateType = stateTypes == null ? true : stateTypes.include();
-        boolean includeResourceKeys = resourceKeys == null ? true : resourceKeys.include();
+    if (olderThan != null && olderThan.values().stream()
+        .anyMatch(olderThanValue -> olderThanValue < newerThan.values().stream().findFirst().get()))
+      throw new IllegalArgumentException("The value of the \"" + OLDER_THAN + "\" parameter must be bigger than the value of the \""
+          + NEWER_THAN + "\" parameter");
 
-        if(stateTypeValues.size() > 1  || resourceKeyValues.size() > 1 || !includeStateType || !includeResourceKeys) {
-          //index can`t get used
-          resultFuture = Job.load(newerThan, sourceTypes, targetTypes, processTypes, resourceKeys, stateTypes);
-        }else {
-          //index can get used
-          State state = stateTypes != null ? stateTypes.values().stream().findFirst().orElse(null) : null;
-          String resourceKey = resourceKeys != null ? resourceKeys.values().stream().findFirst().orElse(null) : null;
+    Future<List<Job>> resultFuture;
 
-          resultFuture = Job.load(state, resourceKey);
-        }
-      }else {
-        //scan is needed
-        resultFuture = Job.load(newerThan, sourceTypes, targetTypes, processTypes, resourceKeys, stateTypes);;
+    //TODO: Improve the loading implementation of jobs. The application level should not have to be bothered with details about indexing.
+    if (newerThan == null && olderThan == null && sourceTypes == null && targetTypes == null && processTypes == null) {
+      Set<State> stateTypeValues = stateTypes == null ? Set.of() : stateTypes.values();
+      Set<String> resourceKeyValues = resourceKeys == null ? Set.of() : resourceKeys.values();
+      boolean includeStateType = stateTypes == null ? true : stateTypes.include();
+      boolean includeResourceKeys = resourceKeys == null ? true : resourceKeys.include();
+
+      if (stateTypeValues.size() > 1 || resourceKeyValues.size() > 1 || !includeStateType || !includeResourceKeys)
+        //Index can not be used
+        resultFuture = Job.load(newerThan, olderThan, sourceTypes, targetTypes, processTypes, resourceKeys, stateTypes);
+      else {
+        //Index can be used
+        State state = stateTypes != null ? stateTypes.values().stream().findFirst().orElse(null) : null;
+        String resourceKey = resourceKeys != null ? resourceKeys.values().stream().findFirst().orElse(null) : null;
+
+        resultFuture = Job.load(state, resourceKey);
       }
+    }
+    else
+      //Scan is necessary
+      resultFuture = Job.load(newerThan, olderThan, sourceTypes, targetTypes, processTypes, resourceKeys, stateTypes);
 
-      resultFuture
-          .onSuccess(res -> {
-            if (internal)
-              sendInternalResponse(context, OK.code(), res);
-            else
-              sendResponse(context, OK.code(), res);
-          })
-          .onFailure(err -> sendErrorResponse(context, err));
-    }
-    catch (NumberFormatException e) {
-      throw new IllegalArgumentException("Illegal value for  " + NEWER_THAN + " parameter: " + NEWER_THAN, e);
-    }
+    resultFuture
+        .onSuccess(res -> {
+          if (internal)
+            sendInternalResponse(context, OK.code(), res);
+          else
+            sendResponse(context, OK.code(), res);
+        })
+        .onFailure(err -> sendErrorResponse(context, err));
+
   }
 
   protected FilteredValues getFilteredValues(RoutingContext context, String param) {
     String paramValue = getQueryParam(context, param);
     if (paramValue == null || paramValue.isBlank())
-      return  null;
+      return null;
 
     boolean include = true;
 
-    if(paramValue.startsWith("!")) {
+    if (paramValue.startsWith("!")) {
       paramValue = paramValue.substring(1);
       include = false;
     }
 
     HashSet<String> paramList = new HashSet<>((Arrays.stream(paramValue.split(",")).toList()));
 
-    if(param.equals(NEWER_THAN)) {
-      if(paramList.size() > 1)
-        throw new IllegalArgumentException("Illegal value for " + NEWER_THAN + " parameter: " + paramValue);
-      return new FilteredValues<Long>(include, new HashSet<>(paramList.stream().map(Long::parseLong).toList()));
-    }if(param.equals(STATE))
-      return new FilteredValues<State>(include, new HashSet<>(paramList.stream().map(State::valueOf).toList()));
-    return new FilteredValues<String>(include, new HashSet<>(paramList));
+    if (NEWER_THAN.equals(param) || OLDER_THAN.equals(param)) {
+      if (paramList.size() > 1)
+        throw new IllegalArgumentException("Illegal value for " + param + " parameter: " + paramValue);
+      try {
+        return new FilteredValues<>(include, new HashSet<>(paramList.stream().map(Long::parseLong).toList()));
+      }
+      catch (NumberFormatException e) {
+        throw new IllegalArgumentException("Illegal value for " + param + " parameter: " + paramValue, e);
+      }
+    }
+    if (param.equals(STATE))
+      return new FilteredValues<>(include, new HashSet<>(paramList.stream().map(State::valueOf).toList()));
+    return new FilteredValues<>(include, new HashSet<>(paramList));
   }
 
   public static class ApiParam {
@@ -153,6 +166,7 @@ public class JobApiBase extends Api {
       static final String STATE = "state";
       static final String RESOURCE = "resource";
       static final String NEWER_THAN = "newerThan";
+      static final String OLDER_THAN = "olderThan";
       static final String SOURCE_TYPE = "sourceType";
       static final String TARGET_TYPE = "targetType";
       static final String PROCESS_TYPE = "processType";


### PR DESCRIPTION
- The new query param "olderThan" can be used to get all jobs older than or equal to the specified timestamp. It can only be used in combination with the "newerThan" query parameter.