### PR TITLE
DS-2171: Enhance TaskedSpaceBasedStep - task query recovery for serve…

### DIFF
--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/execution/LambdaBasedStep.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/execution/LambdaBasedStep.java
@@ -316,6 +316,12 @@ public abstract class LambdaBasedStep<T extends LambdaBasedStep> extends Step<T>
       synchronizeStep();
       //NOTE: No heartbeat must be sent to SFN in this case!
     }
+    catch (StepException e) {
+      logger.warn("Expected error while checking async execution state", e);
+      //Expected exception, so cancel & report non-retryable failure
+      reportFailure(e, false,true);
+      throw e;
+    }
     catch (Exception e) {
       logger.warn("Unexpected error while checking async execution state", e);
       //Unexpected exception, there is an issue in the implementation of the step, so cancel & report non-retryable failure

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/execution/LambdaBasedStep.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/execution/LambdaBasedStep.java
@@ -316,12 +316,6 @@ public abstract class LambdaBasedStep<T extends LambdaBasedStep> extends Step<T>
       synchronizeStep();
       //NOTE: No heartbeat must be sent to SFN in this case!
     }
-    catch (StepException e) {
-      logger.warn("Expected error while checking async execution state", e);
-      //Expected exception, so cancel & report non-retryable failure
-      reportFailure(e, false,true);
-      throw e;
-    }
     catch (Exception e) {
       logger.warn("Unexpected error while checking async execution state", e);
       //Unexpected exception, there is an issue in the implementation of the step, so cancel & report non-retryable failure

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/TaskedSpaceBasedStep.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/TaskedSpaceBasedStep.java
@@ -91,6 +91,8 @@ public abstract class TaskedSpaceBasedStep<T extends TaskedSpaceBasedStep, I ext
         extends SpaceBasedStep<T> {
   private static final Logger logger = LogManager.getLogger();
   public static final String FINALIZATION_MARKER = "finalized_marker";
+  public static final Integer MAX_UNKNOWN_TASK_QUERY_CHECKS = 3;
+  public static final Integer MAX_TASK_RETRY_ATTEMPTS = 1;
   private TaskedSpaceBasedQueryBuilder taskedSpaceBasedQueryBuilder;
 
   {
@@ -839,26 +841,7 @@ public abstract class TaskedSpaceBasedStep<T extends TaskedSpaceBasedStep, I ext
     if (unknownStateTaskIds == null || unknownStateTaskIds.isEmpty())
       return Set.of();
 
-    SQLQuery query = new SQLQuery("""
-            WITH updated AS (
-                UPDATE ${schema}.${table}
-                   SET unknown_query_state_occurrences = COALESCE(unknown_query_state_occurrences, 0) + 1,
-                   updated_at = now() AT TIME ZONE 'UTC'
-                 WHERE task_id IN (
-                     SELECT value::INT
-                       FROM jsonb_array_elements_text(#{missingTaskIds}::JSONB)
-                 )
-                RETURNING task_id, unknown_query_state_occurrences
-            )
-            SELECT task_id
-              FROM updated
-             WHERE unknown_query_state_occurrences >= #{maxUnknownTaskQueryChecks};
-        """)
-        .withVariable("schema", getSchema(db(WRITER)))
-        .withVariable("table", getTemporaryJobTableName(getId()))
-        .withNamedParameter("missingTaskIds", XyzSerializable.serialize(unknownStateTaskIds))
-        .withNamedParameter("maxUnknownTaskQueryChecks", MAX_UNKNOWN_TASK_QUERY_CHECKS)
-        .withRetryableErrorCodes(RETRYABLE_SQL_CODES);
+    SQLQuery query = getQueryBuilder().buildIncrementUnknownQueryStateStatement(unknownStateTaskIds, MAX_UNKNOWN_TASK_QUERY_CHECKS);
 
     return runReadQuerySync(query, db(WRITER), 0, rs -> {
       Set<Integer> exceededTaskIds = new java.util.LinkedHashSet<>();
@@ -869,25 +852,12 @@ public abstract class TaskedSpaceBasedStep<T extends TaskedSpaceBasedStep, I ext
   }
 
   private TaskProgress<I> resetTaskForRetry(int taskId) throws WebClientException, SQLException, TooManyResourcesClaimed {
-    SQLQuery query = new SQLQuery("""
-            UPDATE ${schema}.${table}
-               SET unknown_query_state_occurrences = 0,
-                   updated_at = now() AT TIME ZONE 'UTC',
-                   retry_attempts = retry_attempts + 1
-             WHERE task_id = #{taskId}
-             RETURNING task_id, task_input, retry_attempts;
-        """)
-        .withVariable("schema", getSchema(db(WRITER)))
-        .withVariable("table", getTemporaryJobTableName(getId()))
-        .withNamedParameter("taskId", taskId)
-        .withRetryableErrorCodes(RETRYABLE_SQL_CODES);
-
-    return runReadQuerySync(query, db(WRITER), 0, rs -> {
+    return runReadQuerySync(getQueryBuilder().buildResetTaskForRetryStatement(taskId), db(WRITER), 0, rs -> {
       if (!rs.next())
         throw new SQLException("Task for retry not found: taskId=" + taskId);
 
       int retryAttempt = rs.getInt("retry_attempts");
-      if (retryAttempt > MAX_TASK_RETRY_ATTEMPS)
+      if (retryAttempt > MAX_TASK_RETRY_ATTEMPTS)
         return null;
 
       try {

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/TaskedSpaceBasedStep.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/TaskedSpaceBasedStep.java
@@ -500,8 +500,9 @@ public abstract class TaskedSpaceBasedStep<T extends TaskedSpaceBasedStep, I ext
 
       prepareTaskQuery(taskProgressAndItem.getTaskId());
 
-      runReadQueryAsync(buildTaskQuery(taskProgressAndItem.getTaskId(), (I) taskProgressAndItem.getTaskInput(), failureCallback),
-                queryRunsOnWriter() ? dbWriter() : dbReader(), 0d/*perItemAcus.doubleValue()*/,  false);
+      runReadQueryAsync(buildTaskQuery(taskProgressAndItem.getTaskId(), (I) taskProgressAndItem.getTaskInput(), failureCallback)
+              .withLabel(getId() + "#taskId", String.valueOf(taskProgressAndItem.getTaskId())),
+              queryRunsOnWriter() ? dbWriter() : dbReader(), 0d/*perItemAcus.doubleValue()*/,  false);
     }
   }
 

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/TaskedSpaceBasedStep.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/TaskedSpaceBasedStep.java
@@ -38,6 +38,7 @@ import com.here.xyz.events.ContextAwareEvent.SpaceContext;
 import com.here.xyz.jobs.JobClientInfo;
 import com.here.xyz.jobs.steps.execution.LambdaBasedStep.LambdaStepRequest.ProcessUpdate;
 import com.here.xyz.jobs.steps.execution.StepException;
+import com.here.xyz.jobs.steps.execution.db.Database;
 import com.here.xyz.jobs.steps.impl.SpaceBasedStep;
 import com.here.xyz.jobs.steps.impl.transport.tasks.TaskPayload;
 import com.here.xyz.jobs.steps.impl.transport.tasks.TaskProgress;
@@ -58,10 +59,16 @@ import com.here.xyz.util.web.XyzWebClient.ErrorResponseException;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.sql.Array;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -696,7 +703,7 @@ public abstract class TaskedSpaceBasedStep<T extends TaskedSpaceBasedStep, I ext
       return AsyncExecutionState.SUCCEEDED;
 
     try {
-      TaskProgress taskProgress = getTaskProgress();
+      TaskProgress<?> taskProgress = getTaskProgress();
       return evaluateExecutionState(taskProgress);
     }
     catch (SQLException e) {
@@ -709,13 +716,57 @@ public abstract class TaskedSpaceBasedStep<T extends TaskedSpaceBasedStep, I ext
     }
   }
 
-  private AsyncExecutionState evaluateExecutionState(TaskProgress taskProgress) throws UnknownStateException {
+  private AsyncExecutionState evaluateExecutionState(TaskProgress<?> taskProgress)
+      throws UnknownStateException, SQLException, WebClientException, TooManyResourcesClaimed {
     if (taskProgress.isComplete()) {
       //Only log and return RUNNING to avoid double success handling;
       infoLog(STEP_ON_STATE_CHECK, "All tasks finalized!");
-    }if (taskProgress.hasRunningTasks())
-      // Check if the expected queries are still running.
-      return super.getExecutionState();
+    }
+    if (taskProgress.hasRunningTasks()) {
+      Set<Integer> expectedTaskIds = taskProgress.getStartedNotFinalizedTaskIds();
+      Set<String> expectedTaskIdStrings = expectedTaskIds.stream()
+          .map(String::valueOf)
+          .collect(Collectors.toSet());
+
+      if (expectedTaskIdStrings.isEmpty()) {
+        infoLog(STEP_ON_STATE_CHECK, "Started tasks are reported but started_not_finalized_task_ids is empty.");
+        throw new UnknownStateException("No started-not-finalized task ids available for step: " + getGlobalStepId() + " !");
+      }
+
+      boolean runsOnWriter = queryRunsOnWriter();
+      Database database = runsOnWriter ? dbWriter() : dbReader();
+      //Check if all expected TaskQueries areRunning. Collect all taskIds where we are not able
+      //to find a running query.
+      Set<String> runningTaskIds = SQLQuery.areRunning(
+          requestResource(database, 0d), database.getRole() != WRITER,
+              getId() + "#taskId", expectedTaskIdStrings
+      );
+
+      Set<Integer> unknownStateTaskIds = expectedTaskIds.stream()
+          .filter(taskId -> !runningTaskIds.contains(String.valueOf(taskId)))
+          .collect(Collectors.toSet());
+
+      if (unknownStateTaskIds.isEmpty())
+        return AsyncExecutionState.RUNNING;
+
+      Set<Integer> exceededTaskIds = incrementUnknownQueryStateForTasks(unknownStateTaskIds);
+      for(int exceededTaskId : exceededTaskIds){
+        infoLog(STEP_ON_STATE_CHECK, "Unknown queryState of taskId " + exceededTaskId + " has exceeded unknown query state threshold. Retry the task now!");
+        try {
+          TaskProgress<I> retryTaskProgress = resetTaskForRetry(exceededTaskId);
+          if (retryTaskProgress == null) {
+            throw new StepException("Retry threshold exceeded for taskId " + exceededTaskId + ".");
+          }
+          startTask(retryTaskProgress);
+        } catch (StepException e1){
+          throw e1;
+        } catch (Exception e2){
+          throw new StepException("Not able to retry taskId " + exceededTaskId, e2);
+        }
+      }
+
+      return AsyncExecutionState.RUNNING;
+    }
     if (taskProgress.hasNoRunningTasks()) {
       infoLog(STEP_ON_STATE_CHECK, "No running tasks detected. StartedTasks: " + taskProgress.getStartedTasks() + ","
           + " FinalizedTasks: " + taskProgress.getFinalizedTasks() + " !");
@@ -783,6 +834,72 @@ public abstract class TaskedSpaceBasedStep<T extends TaskedSpaceBasedStep, I ext
             , db(WRITER), 0);
   }
 
+  private Set<Integer> incrementUnknownQueryStateForTasks(Set<Integer> unknownStateTaskIds)
+      throws WebClientException, SQLException, TooManyResourcesClaimed {
+    if (unknownStateTaskIds == null || unknownStateTaskIds.isEmpty())
+      return Set.of();
+
+    SQLQuery query = new SQLQuery("""
+            WITH updated AS (
+                UPDATE ${schema}.${table}
+                   SET unknown_query_state_occurrences = COALESCE(unknown_query_state_occurrences, 0) + 1,
+                   updated_at = now() AT TIME ZONE 'UTC'
+                 WHERE task_id IN (
+                     SELECT value::INT
+                       FROM jsonb_array_elements_text(#{missingTaskIds}::JSONB)
+                 )
+                RETURNING task_id, unknown_query_state_occurrences
+            )
+            SELECT task_id
+              FROM updated
+             WHERE unknown_query_state_occurrences >= #{maxUnknownTaskQueryChecks};
+        """)
+        .withVariable("schema", getSchema(db(WRITER)))
+        .withVariable("table", getTemporaryJobTableName(getId()))
+        .withNamedParameter("missingTaskIds", XyzSerializable.serialize(unknownStateTaskIds))
+        .withNamedParameter("maxUnknownTaskQueryChecks", MAX_UNKNOWN_TASK_QUERY_CHECKS)
+        .withRetryableErrorCodes(RETRYABLE_SQL_CODES);
+
+    return runReadQuerySync(query, db(WRITER), 0, rs -> {
+      Set<Integer> exceededTaskIds = new java.util.LinkedHashSet<>();
+      while (rs.next())
+        exceededTaskIds.add(rs.getInt("task_id"));
+      return exceededTaskIds;
+    });
+  }
+
+  private TaskProgress<I> resetTaskForRetry(int taskId) throws WebClientException, SQLException, TooManyResourcesClaimed {
+    SQLQuery query = new SQLQuery("""
+            UPDATE ${schema}.${table}
+               SET unknown_query_state_occurrences = 0,
+                   updated_at = now() AT TIME ZONE 'UTC',
+                   retry_attempts = retry_attempts + 1
+             WHERE task_id = #{taskId}
+             RETURNING task_id, task_input, retry_attempts;
+        """)
+        .withVariable("schema", getSchema(db(WRITER)))
+        .withVariable("table", getTemporaryJobTableName(getId()))
+        .withNamedParameter("taskId", taskId)
+        .withRetryableErrorCodes(RETRYABLE_SQL_CODES);
+
+    return runReadQuerySync(query, db(WRITER), 0, rs -> {
+      if (!rs.next())
+        throw new SQLException("Task for retry not found: taskId=" + taskId);
+
+      int retryAttempt = rs.getInt("retry_attempts");
+      if (retryAttempt > MAX_TASK_RETRY_ATTEMPS)
+        return null;
+
+      try {
+        return new TaskProgress<>(rs.getInt("task_id"),
+                XyzSerializable.deserialize(rs.getString("task_input"), new TypeReference<I>() {}));
+      }
+      catch (JsonProcessingException e) {
+        throw new StepException("Can not deserialize task_input for retry of taskId=" + taskId + "!", e);
+      }
+    });
+  }
+
   private TaskProgress executeTaskItemQuery(SQLQuery query) throws WebClientException, SQLException, TooManyResourcesClaimed {
     TaskProgress taskProgress;
     try {
@@ -816,8 +933,18 @@ public abstract class TaskedSpaceBasedStep<T extends TaskedSpaceBasedStep, I ext
               rs -> {
                 if (!rs.next())
                   return null;
-                return new TaskProgress(rs.getInt("total"), rs.getInt("started"), rs.getInt("finalized"));
+                return new TaskProgress(rs.getInt("total"), rs.getInt("started"), rs.getInt("finalized"),getIntegerList(rs, "started_not_finalized_task_ids"));
               });
+  }
+
+  private Set<Integer> getIntegerList(ResultSet rs, String columnName) throws SQLException {
+    Array sqlArray = rs.getArray(columnName);
+
+    return sqlArray == null
+            ? Set.of()
+            : Arrays.stream((Object[]) sqlArray.getArray())
+            .map(value -> ((Number) value).intValue())
+            .collect(Collectors.toSet());
   }
 
   private SQLQuery resetTaskItemWhichAreNotFinalized() {

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/TaskedSpaceBasedStep.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/TaskedSpaceBasedStep.java
@@ -90,9 +90,12 @@ import org.apache.logging.log4j.Logger;
 public abstract class TaskedSpaceBasedStep<T extends TaskedSpaceBasedStep, I extends TaskPayload, O extends TaskPayload>
         extends SpaceBasedStep<T> {
   private static final Logger logger = LogManager.getLogger();
+  /** Marker output-set key/file prefix used to indicate successful step finalization. */
   public static final String FINALIZATION_MARKER = "finalized_marker";
+  /** Number of consecutive unknown running-query checks before a task is considered retryable. */
   public static final Integer MAX_UNKNOWN_TASK_QUERY_CHECKS = 3;
-  public static final Integer MAX_TASK_RETRY_ATTEMPTS = 1;
+  /** Maximum number of retry attempts, for a server side killed single, before failing retry handling. */
+  public static final Integer MAX_TASK_RETRY_ATTEMPTS = 3;
   private TaskedSpaceBasedQueryBuilder taskedSpaceBasedQueryBuilder;
 
   {

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/tasks/TaskProgress.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/tasks/TaskProgress.java
@@ -18,17 +18,25 @@
  */
 package com.here.xyz.jobs.steps.impl.transport.tasks;
 
+import java.util.Set;
+
 public class TaskProgress<I> {
   private int totalTasks;
   private int startedTasks;
   private int finalizedTasks;
   private Integer taskId;
   private I taskInput;
+  private Set<Integer> startedNotFinalizedTaskIds = Set.of();
 
   public TaskProgress() {}
 
   public TaskProgress(Integer taskId) {
     this.taskId = taskId;
+  }
+
+  public TaskProgress(Integer taskId, I taskInput) {
+    this.taskId = taskId;
+    this.taskInput = taskInput;
   }
 
   public TaskProgress(int totalTasks, int startedTasks, int finalizedTasks) {
@@ -43,6 +51,13 @@ public class TaskProgress<I> {
     this.finalizedTasks = finalizedTasks;
     this.taskId = taskId;
     this.taskInput = taskInput;
+  }
+
+  public TaskProgress(int totalTasks, int startedTasks, int finalizedTasks, Set<Integer> startedNotFinalizedTaskIds) {
+    this.totalTasks = totalTasks;
+    this.startedTasks = startedTasks;
+    this.finalizedTasks = finalizedTasks;
+    this.startedNotFinalizedTaskIds = startedNotFinalizedTaskIds;
   }
 
   public int getTotalTasks() {
@@ -85,6 +100,14 @@ public class TaskProgress<I> {
     this.taskInput = taskInput;
   }
 
+  public Set<Integer> getStartedNotFinalizedTaskIds() {
+    return startedNotFinalizedTaskIds;
+  }
+
+  public void setStartedNotFinalizedTaskIds(Set<Integer> startedNotFinalizedTaskIds) {
+    this.startedNotFinalizedTaskIds = startedNotFinalizedTaskIds;
+  }
+
   public boolean isComplete() {
     return totalTasks == finalizedTasks;
   }
@@ -109,6 +132,7 @@ public class TaskProgress<I> {
             "totalTasks=" + totalTasks +
             ", startedTasks=" + startedTasks +
             ", finalizedTasks=" + finalizedTasks +
+            ", startedNotFinalizedTaskIds=" + startedNotFinalizedTaskIds +
             ", taskId=" + taskId +
             ", taskInput=" + taskInput +
             '}';

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/tools/TaskedSpaceBasedQueryBuilder.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/tools/TaskedSpaceBasedQueryBuilder.java
@@ -23,6 +23,8 @@ import com.here.xyz.XyzSerializable;
 import com.here.xyz.models.hub.Space;
 import com.here.xyz.util.db.SQLQuery;
 
+import java.util.Set;
+
 import static com.here.xyz.events.ContextAwareEvent.SpaceContext;
 import static com.here.xyz.jobs.steps.impl.transport.TaskedSpaceBasedStep.SpaceBasedTaskUpdate;
 
@@ -42,10 +44,13 @@ public class TaskedSpaceBasedQueryBuilder extends DatabaseStepQueryBuilder {
             	task_output JSONB,
             	started BOOLEAN DEFAULT false,
             	finalized BOOLEAN DEFAULT false,
+            	unknown_query_state_occurrences INTEGER DEFAULT 0,
+            	retry_attempts INTEGER DEFAULT 0,
+              started_at TIMESTAMP DEFAULT NULL,
+              updated_at TIMESTAMP DEFAULT NULL,
             	CONSTRAINT ${primaryKey} PRIMARY KEY (task_id)
             );
         """)
-            //TODO: CHECK CONSTRAINT!!
             .withVariable("table", getTemporaryJobTableName())
             .withVariable("schema", schema)
             .withVariable("primaryKey", getTemporaryJobTableName() + "_primKey");
@@ -54,15 +59,17 @@ public class TaskedSpaceBasedQueryBuilder extends DatabaseStepQueryBuilder {
   public SQLQuery buildUpdateTaskItemOutputStatement(SpaceBasedTaskUpdate update) {
     return new SQLQuery("""
             UPDATE ${schema}.${table}
-            SET task_output = (
-                COALESCE(task_output, '{}'::JSONB) || #{taskUpdate}::JSONB
-            ) || jsonb_build_object(
-                'taskOutput',
-                COALESCE(task_output->'taskOutput', '{}'::JSONB)
-                || COALESCE((#{taskUpdate}::JSONB)->'taskOutput', '{}'::JSONB)
-            )
-            WHERE task_id = #{taskId};
-        """)
+                  SET
+                    updated_at = now() AT TIME ZONE 'UTC',
+                    task_output = (
+                      COALESCE(task_output, '{}'::JSONB) || #{taskUpdate}::JSONB
+                  ) || jsonb_build_object(
+                      'taskOutput',
+                      COALESCE(task_output->'taskOutput', '{}'::JSONB)
+                      || COALESCE((#{taskUpdate}::JSONB)->'taskOutput', '{}'::JSONB)
+                  )
+                  WHERE task_id = #{taskId};
+            """)
             .withVariable("schema", schema)
             .withVariable("table", getTemporaryJobTableName())
             .withNamedParameter("taskId", update.taskId)
@@ -72,7 +79,8 @@ public class TaskedSpaceBasedQueryBuilder extends DatabaseStepQueryBuilder {
   public SQLQuery buildResetTaskItemWhichAreNotFinalizedStatement() {
     return new SQLQuery("""
             UPDATE ${schema}.${table} t
-                SET started = false
+                SET started = false,
+                updated_at = now() AT TIME ZONE 'UTC'
                 WHERE started = true AND finalized = false;
         """)
             .withVariable("schema", schema)
@@ -89,7 +97,8 @@ public class TaskedSpaceBasedQueryBuilder extends DatabaseStepQueryBuilder {
     return new SQLQuery("""
             SELECT COUNT(1) as total,
                 SUM((started = true)::int) as started,
-                SUM((finalized = true)::int) as finalized
+                SUM((finalized = true)::int) as finalized,
+                ARRAY_AGG(task_id) FILTER (WHERE started = true AND finalized = false) as started_not_finalized_task_ids
                 FROM ${schema}.${table};
         """)
             .withVariable("schema", schema)
@@ -142,6 +151,42 @@ public class TaskedSpaceBasedQueryBuilder extends DatabaseStepQueryBuilder {
     return new SQLQuery("DROP TABLE IF EXISTS ${schema}.${table};")
             .withVariable("table", getTemporaryJobTableName())
             .withVariable("schema", schema);
+  }
+
+  public SQLQuery buildIncrementUnknownQueryStateStatement(Set<Integer> unknownStateTaskIds, int maxUnknownTaskQueryChecks) {
+    return new SQLQuery("""
+            WITH updated AS (
+                UPDATE ${schema}.${table}
+                   SET unknown_query_state_occurrences = COALESCE(unknown_query_state_occurrences, 0) + 1,
+                   updated_at = now() AT TIME ZONE 'UTC'
+                 WHERE task_id IN (
+                     SELECT value::INT
+                       FROM jsonb_array_elements_text(#{missingTaskIds}::JSONB)
+                 )
+                RETURNING task_id, unknown_query_state_occurrences
+            )
+            SELECT task_id
+              FROM updated
+             WHERE unknown_query_state_occurrences >= #{maxUnknownTaskQueryChecks};
+        """)
+            .withVariable("schema", schema)
+            .withVariable("table", getTemporaryJobTableName())
+            .withNamedParameter("missingTaskIds", XyzSerializable.serialize(unknownStateTaskIds))
+            .withNamedParameter("maxUnknownTaskQueryChecks", maxUnknownTaskQueryChecks);
+  }
+
+  public SQLQuery buildResetTaskForRetryStatement(int taskId) {
+    return new SQLQuery("""
+                UPDATE ${schema}.${table}
+                   SET unknown_query_state_occurrences = 0,
+                       updated_at = now() AT TIME ZONE 'UTC',
+                       retry_attempts = retry_attempts + 1
+                 WHERE task_id = #{taskId}
+                 RETURNING task_id, task_input, retry_attempts;
+            """)
+            .withVariable("schema", schema)
+            .withVariable("table", getTemporaryJobTableName())
+            .withNamedParameter("taskId", taskId);
   }
 
   private String getTemporaryJobTableName(String stepId) {

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/tools/TaskedSpaceBasedQueryBuilder.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/tools/TaskedSpaceBasedQueryBuilder.java
@@ -60,7 +60,7 @@ public class TaskedSpaceBasedQueryBuilder extends DatabaseStepQueryBuilder {
     return new SQLQuery("""
             UPDATE ${schema}.${table}
                   SET
-                    updated_at = now() AT TIME ZONE 'UTC',
+                    updated_at = now(),
                     task_output = (
                       COALESCE(task_output, '{}'::JSONB) || #{taskUpdate}::JSONB
                   ) || jsonb_build_object(
@@ -80,7 +80,7 @@ public class TaskedSpaceBasedQueryBuilder extends DatabaseStepQueryBuilder {
     return new SQLQuery("""
             UPDATE ${schema}.${table} t
                 SET started = false,
-                updated_at = now() AT TIME ZONE 'UTC'
+                updated_at = now()
                 WHERE started = true AND finalized = false;
         """)
             .withVariable("schema", schema)
@@ -158,7 +158,7 @@ public class TaskedSpaceBasedQueryBuilder extends DatabaseStepQueryBuilder {
             WITH updated AS (
                 UPDATE ${schema}.${table}
                    SET unknown_query_state_occurrences = COALESCE(unknown_query_state_occurrences, 0) + 1,
-                   updated_at = now() AT TIME ZONE 'UTC'
+                   updated_at = now()
                  WHERE task_id IN (
                      SELECT value::INT
                        FROM jsonb_array_elements_text(#{missingTaskIds}::JSONB)
@@ -179,7 +179,7 @@ public class TaskedSpaceBasedQueryBuilder extends DatabaseStepQueryBuilder {
     return new SQLQuery("""
                 UPDATE ${schema}.${table}
                    SET unknown_query_state_occurrences = 0,
-                       updated_at = now() AT TIME ZONE 'UTC',
+                       updated_at = now(),
                        retry_attempts = retry_attempts + 1
                  WHERE task_id = #{taskId}
                  RETURNING task_id, task_input, retry_attempts;

--- a/xyz-jobs/xyz-job-steps/src/main/resources/jobs/transport.sql
+++ b/xyz-jobs/xyz-job-steps/src/main/resources/jobs/transport.sql
@@ -569,7 +569,7 @@ BEGIN
     IF task_item.task_id IS NOT NULL THEN
         EXECUTE format(
             'UPDATE %1$s C
-                SET started = true
+                SET started = true, started_at = now() AT TIME ZONE ''UTC''
             WHERE C.task_id = %2$L;',
             get_table_reference(ctx->>'schema', ctx->>'stepId' ,'JOB_TABLE'),
             task_item.task_id
@@ -663,7 +663,7 @@ BEGIN
                     COALESCE(t.task_output->''taskOutput'', ''{}''::JSONB)
                     || COALESCE((%2$L::JSONB)->''taskOutput'', ''{}''::JSONB)
                 ),
-                finalized = %3$L
+                updated_at = now() AT TIME ZONE ''UTC'', finalized = %3$L
           WHERE task_id = %4$L;',
         get_table_reference(ctx->>'schema', ctx->>'stepId', 'JOB_TABLE'),
         p_task_output::TEXT,

--- a/xyz-jobs/xyz-job-steps/src/main/resources/jobs/transport.sql
+++ b/xyz-jobs/xyz-job-steps/src/main/resources/jobs/transport.sql
@@ -569,7 +569,7 @@ BEGIN
     IF task_item.task_id IS NOT NULL THEN
         EXECUTE format(
             'UPDATE %1$s C
-                SET started = true, started_at = now() AT TIME ZONE ''UTC''
+                SET started = true, started_at = now()
             WHERE C.task_id = %2$L;',
             get_table_reference(ctx->>'schema', ctx->>'stepId' ,'JOB_TABLE'),
             task_item.task_id
@@ -663,7 +663,7 @@ BEGIN
                     COALESCE(t.task_output->''taskOutput'', ''{}''::JSONB)
                     || COALESCE((%2$L::JSONB)->''taskOutput'', ''{}''::JSONB)
                 ),
-                updated_at = now() AT TIME ZONE ''UTC'', finalized = %3$L
+                updated_at = now(), finalized = %3$L
           WHERE task_id = %4$L;',
         get_table_reference(ctx->>'schema', ctx->>'stepId', 'JOB_TABLE'),
         p_task_output::TEXT,

--- a/xyz-util/src/main/java/com/here/xyz/util/db/SQLQuery.java
+++ b/xyz-util/src/main/java/com/here/xyz/util/db/SQLQuery.java
@@ -911,11 +911,22 @@ public class SQLQuery {
   }
 
   private static SQLQuery buildLabelMatchQuery(String labelIdentifier, String labelValue) {
-    return new SQLQuery("strpos(query, '/*labels(') > 0 AND substring(query, "
-        + "strpos(query, '/*labels(') + 9, "
-        + "strpos(query, ')*/') - 9 - strpos(query, '/*labels('))::json->>#{labelIdentifier} = #{labelValue}")
-        .withNamedParameter("labelIdentifier", labelIdentifier)
+    return new SQLQuery("strpos(query, '/*labels(') > 0 AND ${{extractedLabelValue}} = #{labelValue}")
+        .withQueryFragment("extractedLabelValue", buildLabelValueExtraction(labelIdentifier))
         .withNamedParameter("labelValue", labelValue);
+  }
+
+  /**
+   * Builds the SQL fragment that extracts the value of the label with the specified identifier from the {@code /*labels(...)*}{@code /}
+   * comment prefix of a query in {@code pg_stat_activity}.
+   * @param labelIdentifier The label identifier whose value should be extracted (e.g. taskId).
+   * @return The SQL fragment resolving to the label value as text.
+   */
+  private static SQLQuery buildLabelValueExtraction(String labelIdentifier) {
+    return new SQLQuery("substring(query, "
+        + "strpos(query, '/*labels(') + 9, "
+        + "strpos(query, ')*/') - 9 - strpos(query, '/*labels('))::json->>#{labelIdentifier}")
+        .withNamedParameter("labelIdentifier", labelIdentifier);
   }
 
   public static boolean isRunning(DataSourceProvider dataSourceProvider, boolean useReplica, String queryId) throws SQLException {
@@ -954,10 +965,7 @@ public class SQLQuery {
     return new SQLQuery("""
         WITH expected_values AS (${{expectedValues}}),
              active_values AS (
-               SELECT substring(query,
-                        strpos(query, '/*labels(') + 9,
-                        strpos(query, ')*/') - 9 - strpos(query, '/*labels(')
-                      )::json->>#{labelIdentifier} AS label_value
+               SELECT ${{labelValue}} AS label_value
                  FROM pg_stat_activity
                 WHERE state = 'active'
                   AND pid != pg_backend_pid()
@@ -969,7 +977,7 @@ public class SQLQuery {
             ON a.label_value = e.label_value
         """)
         .withQueryFragment("expectedValues", buildLabelValuesQuery(labelValues))
-        .withNamedParameter("labelIdentifier", labelIdentifier)
+        .withQueryFragment("labelValue", buildLabelValueExtraction(labelIdentifier))
         .withLoggingEnabled(false)
         .run(dataSourceProvider, rs -> {
           Set<String> runningValues = new LinkedHashSet<>();

--- a/xyz-util/src/main/java/com/here/xyz/util/db/SQLQuery.java
+++ b/xyz-util/src/main/java/com/here/xyz/util/db/SQLQuery.java
@@ -40,6 +40,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -936,6 +937,62 @@ public class SQLQuery {
         .withQueryFragment("labelMatching", buildLabelMatchQuery(labelIdentifier, labelValue))
         .withLoggingEnabled(false)
         .run(dataSourceProvider, rs -> rs.next(), useReplica);
+  }
+
+  /**
+   * Checks which of the provided values are currently running for one label identifier.
+   *
+   * @param labelIdentifier The label identifier to check (e.g. taskId).
+   * @param labelValues The set of values to check for the given label identifier.
+   * @return The subset of provided label values that are currently running.
+   */
+  public static Set<String> areRunning(DataSourceProvider dataSourceProvider, boolean useReplica,
+      String labelIdentifier, Set<String> labelValues) throws SQLException {
+    if (labelValues == null || labelValues.isEmpty())
+      return Set.of();
+
+    return new SQLQuery("""
+        WITH expected_values AS (${{expectedValues}}),
+             active_values AS (
+               SELECT substring(query,
+                        strpos(query, '/*labels(') + 9,
+                        strpos(query, ')*/') - 9 - strpos(query, '/*labels(')
+                      )::json->>#{labelIdentifier} AS label_value
+                 FROM pg_stat_activity
+                WHERE state = 'active'
+                  AND pid != pg_backend_pid()
+                  AND strpos(query, '/*labels(') > 0
+             )
+        SELECT DISTINCT e.label_value
+          FROM expected_values e
+          JOIN active_values a
+            ON a.label_value = e.label_value
+        """)
+        .withQueryFragment("expectedValues", buildLabelValuesQuery(labelValues))
+        .withNamedParameter("labelIdentifier", labelIdentifier)
+        .withLoggingEnabled(false)
+        .run(dataSourceProvider, rs -> {
+          Set<String> runningValues = new LinkedHashSet<>();
+          while (rs.next())
+            runningValues.add(rs.getString("label_value"));
+          return runningValues;
+        }, useReplica);
+  }
+
+  private static SQLQuery buildLabelValuesQuery(Set<String> labelValues) {
+    if (labelValues == null || labelValues.isEmpty())
+      return new SQLQuery("SELECT NULL::text AS label_value WHERE FALSE");
+
+    List<SQLQuery> values = new ArrayList<>();
+    int i = 0;
+    for (String labelValue : labelValues) {
+      String valueParam = "labelValue" + i;
+      values.add(new SQLQuery("SELECT #{" + valueParam + "} AS label_value")
+              .withNamedParameter(valueParam, labelValue));
+      i++;
+    }
+
+    return SQLQuery.join(values, " UNION ALL ");
   }
 
   private static String getClashing(Map<String, ?> map1, Map<String, ?> map2) {

--- a/xyz-util/src/test/java/com/here/xyz/test/sql/base/SQLQueryIT.java
+++ b/xyz-util/src/test/java/com/here/xyz/test/sql/base/SQLQueryIT.java
@@ -27,6 +27,8 @@ import com.here.xyz.util.db.SQLQuery;
 import com.here.xyz.util.db.datasource.DataSourceProvider;
 import java.sql.SQLException;
 import java.util.Map;
+import java.util.Set;
+
 import org.junit.jupiter.api.Test;
 
 public class SQLQueryIT extends SQLITBase {

--- a/xyz-util/src/test/java/com/here/xyz/test/sql/base/SQLQueryIT.java
+++ b/xyz-util/src/test/java/com/here/xyz/test/sql/base/SQLQueryIT.java
@@ -65,6 +65,70 @@ public class SQLQueryIT extends SQLITBase {
   }
 
   @Test
+  public void areRunningCheckMultipleValuesForSameLabel() throws Exception {
+    try (DataSourceProvider dsp = getDataSourceProvider()) {
+      SQLQuery longRunningQuery1 = new SQLQuery("SELECT pg_sleep(500)")
+          .withLabel("taskId", "1");
+      SQLQuery longRunningQuery2 = new SQLQuery("SELECT pg_sleep(500)")
+          .withLabel("taskId", "2");
+
+      new Thread(() -> {
+        try {
+          longRunningQuery1.run(dsp);
+        }
+        catch (SQLException e) {
+          //Ignore
+        }
+      }).start();
+
+      new Thread(() -> {
+        try {
+          longRunningQuery2.run(dsp);
+        }
+        catch (SQLException e) {
+          //Ignore
+        }
+      }).start();
+
+      //Wait until both queries are visible in pg_stat_activity.
+      long deadline = System.currentTimeMillis() + 5_000;
+      while (System.currentTimeMillis() < deadline && SQLQuery.areRunning(dsp, false, "taskId", Set.of("1", "2")).size() < 2)
+        Thread.sleep(100);
+
+      //Check that both taskIds are currently running
+      assertEquals(Set.of(
+              "1",
+              "2"
+      ), SQLQuery.areRunning(dsp, false, "taskId", Set.of(
+              "1",
+              "2"
+      )));
+
+      assertEquals(Set.of(
+              "1"
+      ), SQLQuery.areRunning(dsp, false, "taskId", Set.of(
+              "1"
+      )));
+
+      assertEquals(Set.of(
+              "2"
+      ), SQLQuery.areRunning(dsp, false, "taskId", Set.of(
+              "2"
+      )));
+
+      //Kill the long-running queries
+      longRunningQuery1.kill();
+      longRunningQuery2.kill();
+
+      //Check that the original queries are not running anymore
+      assertFalse(SQLQuery.isRunning(dsp, false, longRunningQuery1.getQueryId()));
+      assertFalse(SQLQuery.isRunning(dsp, false, longRunningQuery2.getQueryId()));
+      assertEquals(Set.of(), SQLQuery.areRunning(dsp, false, "taskId", Set.of(
+             "1","2")));
+    }
+  }
+
+  @Test
   public void runAsyncQuery() throws Exception {
     SQLQuery longRunningAsyncQuery = new SQLQuery("SELECT pg_sleep(10)").withAsync(true);
 


### PR DESCRIPTION
…rside killed queries.

Change job_data table layout - add new columns: unknown_query_state_cnt,retry_attempts,started_at,updated_at. TaskProgress: extend Model with startedNotFinalizedTaskIds - to be able to know the exact running taksIds. SQLQuery: add areRunning() method to check multiple queries if they are running. TaskedSpaceBasedStep:
* update all job_data write queries to maintain new timestamps
* add a new taskId label to the running taskQueries
* improve getExecutionState() handling. Use expected taskIds to check if the related Queries are running. Add a retry mechanism for queries which are disappeared (eg. server side termination)