### PR TITLE
DS-2381 Persist targetVersion to fix -1 version occurrences on non-empty layer imports.

### DIFF
--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/execution/db/DatabaseBasedStep.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/execution/db/DatabaseBasedStep.java
@@ -143,9 +143,6 @@ public abstract class DatabaseBasedStep<T extends DatabaseBasedStep> extends Lam
     else if (query.getTimeout() == Integer.MAX_VALUE)
       query.setTimeout(300);
 
-    //add retry settings
-    query.withRetryableErrorCodesAndMaximumRetries(RETRYABLE_SQL_CODES, MAXIMUM_RETRIES);
-
     Object result;
     if (query.isBatch() && isWriteQuery)
       result = query.writeBatch(requestResource(db, estimatedMaxAcuLoad));
@@ -156,6 +153,9 @@ public abstract class DatabaseBasedStep<T extends DatabaseBasedStep> extends Lam
 
     if (async)
       runningQueries.add(new RunningQuery(query.getQueryId(), db.getName(), db.getId()));
+    else
+      //add retry settings
+      query.withRetryableErrorCodesAndMaximumRetries(RETRYABLE_SQL_CODES, MAXIMUM_RETRIES);
 
     return result;
   }

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/TaskedImportFilesToSpace.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/TaskedImportFilesToSpace.java
@@ -416,6 +416,10 @@ public class TaskedImportFilesToSpace extends TaskedSpaceBasedStep<TaskedImportF
 
   private SQLQuery buildImportFromTmpTableTaskQuery(int taskId, long rangeStart, long targetVersion, String failureCallback)
           throws WebClientException {
+
+    if(targetVersion < 0)
+      throw new StepException("Invalid targetVersion: " + targetVersion + "!");
+
     return getQueryBuilder().buildImportFromTmpTableTaskQuery(
             taskId,
             rangeStart,

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/TaskedImportFilesToSpace.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/TaskedImportFilesToSpace.java
@@ -213,19 +213,37 @@ public class TaskedImportFilesToSpace extends TaskedSpaceBasedStep<TaskedImportF
   }
 
   @Override
-  protected void initialSetup() throws SQLException, TooManyResourcesClaimed, WebClientException {
-    targetVersion = getOrIncreaseVersionSequence();
+  protected void initialSetup(boolean resume) throws SQLException, TooManyResourcesClaimed, WebClientException {
 
-    if(useFeatureWriter()) {
+    if(useFeatureWriter()){
       infoLog(STEP_EXECUTE,  "initialSetup - Using FeatureWriter for import!");
-
-      //Pre-create two spare history partitions to avoid concurrency issue with hub requests.
+      //Pre-create two spare history partitions to avoid concurrency issue with hub requests. (also for resumes)
       createSpareHistoryPartitions(targetVersion);
-    }else{
-      infoLog(STEP_EXECUTE,  "initialSetup - Import into empty layer detected!");
+    }
 
-      if(format.equals(FAST_IMPORT_INTO_EMPTY))
-        return;
+    if(resume){
+      long persistedVersion = loadTargetVersionFromTaskInput();
+      long maxVersion = loadSpaceMaxVersion();
+      //check if the targetVersion is outdated
+      boolean versionIsOutdated = maxVersion > persistedVersion;
+
+      if(versionIsOutdated) {
+        //we need to get a new version to ensure consistency
+        targetVersion = increaseVersionSequence();
+        infoLog(STEP_EXECUTE, "initialSetup - resume: maxVersion (" + maxVersion + ") is higher than persisted "
+                + "targetVersion (" + persistedVersion + "). Allocated new targetVersion " + targetVersion
+                + " and resetting the task inputs.");
+        runWriteQuerySync(getQueryBuilder().buildUpdateTaskItemsTargetVersionStatement(targetVersion), db(), 0);
+      }else
+        infoLog(STEP_EXECUTE, "initialSetup - resume: reusing persisted targetVersion " + targetVersion
+                + " (maxVersion=" + maxVersion + ").");
+    }else{
+      //resume=false => retrieve new version
+      targetVersion = getOrIncreaseVersionSequence();
+    }
+
+    if(!useFeatureWriter() && !format.equals(FAST_IMPORT_INTO_EMPTY)) {
+      infoLog(STEP_EXECUTE,  "initialSetup(" + resume + ") - Import into empty layer detected! Create Trigger.");
       //import into an empty, non-composite, layer - targetVersion got persisted in trigger
       runWriteQuerySync(getQueryBuilder().buildCreateImportTriggerForEmptyLayers(space().getOwner(), targetVersion, retainMetadata),
               db(), 0);
@@ -488,10 +506,29 @@ public class TaskedImportFilesToSpace extends TaskedSpaceBasedStep<TaskedImportF
       return version.getVersion();
     }
 
+    return increaseVersionSequence();
+  }
+
+  private long increaseVersionSequence() throws SQLException, TooManyResourcesClaimed, WebClientException {
     return runReadQuerySync(getQueryBuilder().buildNextVersionQuery(), db(), 0, rs -> {
       rs.next();
       return rs.getLong(1);
     });
+  }
+
+  private long loadTargetVersionFromTaskInput() throws SQLException, TooManyResourcesClaimed, WebClientException {
+    return runReadQuerySync(getQueryBuilder().buildLoadTargetVersionFromTaskInputStatement(), db(), 0, rs -> {
+      if (!rs.next())
+        return -1L;
+      long version = rs.getLong(1);
+      return rs.wasNull() ? -1L : version;
+    });
+  }
+
+  private long loadSpaceMaxVersion() throws WebClientException {
+    StatisticsResponse statistics = loadSpaceStatistics(getSpaceId(), EXTENSION, true);
+    return statistics.getMaxVersion() != null && statistics.getMaxVersion().getValue() != null
+            ? statistics.getMaxVersion().getValue() : -1;
   }
 
   public boolean useFeatureWriter() throws WebClientException {

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/TaskedImportFilesToSpace.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/TaskedImportFilesToSpace.java
@@ -226,7 +226,7 @@ public class TaskedImportFilesToSpace extends TaskedSpaceBasedStep<TaskedImportF
 
       if(format.equals(FAST_IMPORT_INTO_EMPTY))
         return;
-      //import into an empty, non-composite, layer
+      //import into an empty, non-composite, layer - targetVersion got persisted in trigger
       runWriteQuerySync(getQueryBuilder().buildCreateImportTriggerForEmptyLayers(space().getOwner(), targetVersion, retainMetadata),
               db(), 0);
     }
@@ -268,7 +268,7 @@ public class TaskedImportFilesToSpace extends TaskedSpaceBasedStep<TaskedImportF
       if (input instanceof S3DataFile) {
         taskItems.add(
                 new ImportInput(input.getS3Bucket(), input.getS3Key(), bucketRegion(input.getS3Bucket()),
-                        input.getByteSize())
+                        input.getByteSize(), targetVersion)
         );
       }
     }
@@ -351,12 +351,9 @@ public class TaskedImportFilesToSpace extends TaskedSpaceBasedStep<TaskedImportF
 
   @Override
   protected void onTaskProgress(int taskId, ImportOutput output) throws WebClientException, SQLException, TooManyResourcesClaimed {
-    //TODO: CHECK
-    //String superRootTable = space().getExtension() != null ? getRootTableName(superSpace()) : null;
-
-    long rangeStart = output.progress() == null ? 1 : output.progress().endI() + 1; //TBD check
+    long rangeStart = output.progress() == null ? 1 : output.progress().endI() + 1;
     String failureCallback = buildFailureCallbackQuery().substitute().text().replaceAll("'", "''");
-    runReadQueryAsync(buildImportFromTmpTableTaskQuery(taskId, rangeStart, failureCallback)
+    runReadQueryAsync(buildImportFromTmpTableTaskQuery(taskId, rangeStart, output.targetVersion(), failureCallback)
             , dbWriter(), 0, false);
   }
 
@@ -403,7 +400,7 @@ public class TaskedImportFilesToSpace extends TaskedSpaceBasedStep<TaskedImportF
           infoLog(STEP_EXECUTE, "Resume task " + taskId + " - skipping phase 1, " +
                   "starting phase 2 at startI=" + resumeStartI);
 
-          return buildImportFromTmpTableTaskQuery(taskId, resumeStartI, failureCallback);
+          return buildImportFromTmpTableTaskQuery(taskId, resumeStartI, taskInput.targetVersion(), failureCallback);
         }
       } catch (SQLException | TooManyResourcesClaimed e) {
         //Resume detection failed -> fall back to normal phase 1 start
@@ -417,7 +414,7 @@ public class TaskedImportFilesToSpace extends TaskedSpaceBasedStep<TaskedImportF
                     useFeatureWriter(), failureCallback);
   }
 
-  private SQLQuery buildImportFromTmpTableTaskQuery(int taskId, long rangeStart, String failureCallback)
+  private SQLQuery buildImportFromTmpTableTaskQuery(int taskId, long rangeStart, long targetVersion, String failureCallback)
           throws WebClientException {
     return getQueryBuilder().buildImportFromTmpTableTaskQuery(
             taskId,
@@ -483,6 +480,7 @@ public class TaskedImportFilesToSpace extends TaskedSpaceBasedStep<TaskedImportF
 
     if(versionInput.isPresent()) {
       CreatedVersion version = (CreatedVersion) ((InputFromOutput) versionInput.get()).getDelegate();
+      infoLog(STEP_EXECUTE, "Using provided version from input: " + version.getVersion());
       return version.getVersion();
     }
 

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/TaskedSpaceBasedStep.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/TaskedSpaceBasedStep.java
@@ -273,13 +273,16 @@ public abstract class TaskedSpaceBasedStep<T extends TaskedSpaceBasedStep, I ext
    * <p>
    * This method can be overridden by subclasses to implement any required initialization logic,
    * such as preparing resources, validating prerequisites, or configuring the environment.
+   * The hook is invoked for both fresh executions and resumed executions.
    * </p>
    *
+   * @param resume {@code true} when the step is resumed after a previous attempt and should restore
+   *               or rebuild any required state accordingly; {@code false} for a fresh execution.
    * @throws SQLException If a database access error occurs.
    * @throws TooManyResourcesClaimed If too many resources are claimed during setup.
    * @throws WebClientException If an error occurs while interacting with the web client.
    */
-  protected void initialSetup() throws SQLException, TooManyResourcesClaimed, WebClientException {};
+  protected void initialSetup(boolean resume) throws SQLException, TooManyResourcesClaimed, WebClientException {};
 
   /**
    * Performs final cleanup after all tasks have completed.
@@ -496,12 +499,13 @@ public abstract class TaskedSpaceBasedStep<T extends TaskedSpaceBasedStep, I ext
   @Override
   public void execute(boolean resume) throws Exception {
     //The following code is running synchronously till the first task is getting started.
-
     if (!resume) {
-      initialSetup();
+      initialSetup(false);
       createAndInsertTaskItems();
     }else{
       try {
+        //we need to do the initialSetup here to be able to cover the case that the table does not already exists.
+        initialSetup(true);
         //Reset all items which are not finalized to be able to restart them
         runWriteQuerySyncUnkillable(resetTaskItemWhichAreNotFinalized(), db(WRITER), 0);
       }catch (SQLException e){
@@ -518,7 +522,7 @@ public abstract class TaskedSpaceBasedStep<T extends TaskedSpaceBasedStep, I ext
           }
           //Can not retrieve output - start from scratch
           infoLog(STEP_EXECUTE, "Reset of taskItems failed cause job_data table is missing! Recreating it!");
-          initialSetup();
+          initialSetup(false);
           createAndInsertTaskItems();
         }else
           throw e;

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/TaskedSpaceBasedStep.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/TaskedSpaceBasedStep.java
@@ -82,7 +82,6 @@ import org.apache.logging.log4j.Logger;
  */
 public abstract class TaskedSpaceBasedStep<T extends TaskedSpaceBasedStep, I extends TaskPayload, O extends TaskPayload>
         extends SpaceBasedStep<T> {
-  private static final String JOB_DATA_PREFIX = "job_data_";
   private static final Logger logger = LogManager.getLogger();
   public static final String FINALIZATION_MARKER = "finalized_marker";
   private TaskedSpaceBasedQueryBuilder taskedSpaceBasedQueryBuilder;
@@ -497,13 +496,10 @@ public abstract class TaskedSpaceBasedStep<T extends TaskedSpaceBasedStep, I ext
   @Override
   public void execute(boolean resume) throws Exception {
     //The following code is running synchronously till the first task is getting started.
-    String schema = getSchema(db());
-    List<I> taskDataList = createTaskItems();
-    taskItemCount = taskDataList.size();
 
     if (!resume) {
-      insertTaskItemsInTaskTable(taskDataList);
       initialSetup();
+      createAndInsertTaskItems();
     }else{
       try {
         //Reset all items which are not finalized to be able to restart them
@@ -522,15 +518,20 @@ public abstract class TaskedSpaceBasedStep<T extends TaskedSpaceBasedStep, I ext
           }
           //Can not retrieve output - start from scratch
           infoLog(STEP_EXECUTE, "Reset of taskItems failed cause job_data table is missing! Recreating it!");
-          insertTaskItemsInTaskTable(taskDataList);
           initialSetup();
-
+          createAndInsertTaskItems();
         }else
           throw e;
       }
     }
     startInitialTasks();
     noTasksCreated = taskItemCount == 0;
+  }
+
+  private void createAndInsertTaskItems() throws SQLException, TooManyResourcesClaimed, QueryBuildingException, WebClientException {
+    List<I> taskDataList = createTaskItems();
+    taskItemCount = taskDataList.size();
+    insertTaskItemsInTaskTable(taskDataList);
   }
 
   /**

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/tasks/inputs/ImportInput.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/tasks/inputs/ImportInput.java
@@ -20,6 +20,6 @@ package com.here.xyz.jobs.steps.impl.transport.tasks.inputs;
 
 import com.here.xyz.jobs.steps.impl.transport.tasks.TaskPayload;
 
-public record ImportInput(String s3Bucket, String s3Key, String s3Region, long fileByteSize)
+public record ImportInput(String s3Bucket, String s3Key, String s3Region, long fileByteSize, long targetVersion)
         implements TaskPayload {
 }

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/tasks/outputs/ImportOutput.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/tasks/outputs/ImportOutput.java
@@ -27,15 +27,15 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_DEFAULT;
 
 @JsonInclude(NON_DEFAULT)
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record ImportOutput(String importStatistics, long fileBytes,
+public record ImportOutput(String importStatistics, long fileBytes,  long targetVersion,
                            ImportProgress progress) implements TaskPayload {
 
-  public ImportOutput(String importStatistics, long fileBytes) {
-    this(importStatistics, fileBytes, null);
+  public ImportOutput(String importStatistics, long fileBytes,  long targetVersion) {
+    this(importStatistics, fileBytes, targetVersion, null);
   }
 
   public ImportOutput(ImportProgress progress) {
-    this(null, -1, progress);
+    this(null, -1, -1, progress);
   }
 
   //@TODO: shift this extraction to SQL function "perform_import_from_s3_task()"

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/tools/ImportQueryBuilder.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/tools/ImportQueryBuilder.java
@@ -152,4 +152,44 @@ public class ImportQueryBuilder extends DatabaseStepQueryBuilder {
             .withNamedParameter("lambdaRegion", ownLambdaRegion)
             .withQueryFragment("failureCallback", failureCallback);
   }
+
+  /**
+   * Builds a query to load the target version from one non-finalized task item.
+   * <p>
+   * During resume, non-finalized task items may have a newer target version than finalized ones.
+   * Restricting the lookup to pending work ensures that resumed tasks keep writing with a consistent version.
+   * </p>
+   *
+   * @return The SQL query selecting a single pending task item's {@code targetVersion}.
+   */
+  public SQLQuery buildLoadTargetVersionFromTaskInputStatement() {
+    return withRetryPolicy(new SQLQuery("""
+            SELECT (task_input->>'targetVersion')::BIGINT AS target_version
+                FROM ${schema}.${table}
+            WHERE finalized = false
+                LIMIT 1;
+        """)
+            .withVariable("schema", schema)
+            .withVariable("table", getTemporaryJobTableName()));
+  }
+
+  /**
+   * Builds a query to update the target version in task inputs of all non-finalized task items.
+   * <p>
+   * Finalized items are intentionally excluded because their data was already written with their original version.
+   * </p>
+   *
+   * @param targetVersion The new target version to store in pending task inputs.
+   * @return The SQL query updating pending task items.
+   */
+  public SQLQuery buildUpdateTaskItemsTargetVersionStatement(long targetVersion) {
+    return withRetryPolicy(new SQLQuery("""
+            UPDATE ${schema}.${table}
+                SET task_input = jsonb_set(task_input, '{targetVersion}', to_jsonb(#{targetVersion}::BIGINT))
+                WHERE finalized = false;
+        """)
+            .withVariable("schema", schema)
+            .withVariable("table", getTemporaryJobTableName())
+            .withNamedParameter("targetVersion", targetVersion));
+  }
 }

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/tools/ImportQueryBuilder.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/tools/ImportQueryBuilder.java
@@ -54,7 +54,7 @@ public class ImportQueryBuilder extends DatabaseStepQueryBuilder {
 
     return new SQLQuery(
             "SELECT perform_import_from_s3_task(#{taskId}, #{schema}, to_regclass(#{targetTable}), #{format}, " +
-                    "#{s3Bucket}, #{s3Key}, #{s3Region}, #{filesize}, #{stepPayload}::JSON->'step', " +
+                    "#{s3Bucket}, #{s3Key}, #{s3Region}, #{filesize}, #{targetVersion}, #{stepPayload}::JSON->'step', " +
                     "#{lambdaFunctionArn}, #{lambdaRegion}, '${{failureCallback}}')")
             .withContext(getQueryContext())
             .withAsync(true)
@@ -66,6 +66,7 @@ public class ImportQueryBuilder extends DatabaseStepQueryBuilder {
             .withNamedParameter("s3Key", taskInput.s3Key())
             .withNamedParameter("s3Region", taskInput.s3Region())
             .withNamedParameter("filesize", taskInput.fileByteSize())
+            .withNamedParameter("targetVersion",taskInput.targetVersion())
             .withNamedParameter("stepPayload", serializedImportStep)
             .withNamedParameter("lambdaFunctionArn", lambdaArn)
             .withNamedParameter("lambdaRegion", ownLambdaRegion)

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/tools/ImportQueryBuilder.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/tools/ImportQueryBuilder.java
@@ -163,14 +163,14 @@ public class ImportQueryBuilder extends DatabaseStepQueryBuilder {
    * @return The SQL query selecting a single pending task item's {@code targetVersion}.
    */
   public SQLQuery buildLoadTargetVersionFromTaskInputStatement() {
-    return withRetryPolicy(new SQLQuery("""
+    return new SQLQuery("""
             SELECT (task_input->>'targetVersion')::BIGINT AS target_version
                 FROM ${schema}.${table}
             WHERE finalized = false
                 LIMIT 1;
         """)
             .withVariable("schema", schema)
-            .withVariable("table", getTemporaryJobTableName()));
+            .withVariable("table", getTemporaryJobTableName());
   }
 
   /**
@@ -183,13 +183,13 @@ public class ImportQueryBuilder extends DatabaseStepQueryBuilder {
    * @return The SQL query updating pending task items.
    */
   public SQLQuery buildUpdateTaskItemsTargetVersionStatement(long targetVersion) {
-    return withRetryPolicy(new SQLQuery("""
+    return new SQLQuery("""
             UPDATE ${schema}.${table}
                 SET task_input = jsonb_set(task_input, '{targetVersion}', to_jsonb(#{targetVersion}::BIGINT))
                 WHERE finalized = false;
         """)
             .withVariable("schema", schema)
             .withVariable("table", getTemporaryJobTableName())
-            .withNamedParameter("targetVersion", targetVersion));
+            .withNamedParameter("targetVersion", targetVersion);
   }
 }

--- a/xyz-jobs/xyz-job-steps/src/main/resources/jobs/transport.sql
+++ b/xyz-jobs/xyz-job-steps/src/main/resources/jobs/transport.sql
@@ -851,6 +851,7 @@ CREATE OR REPLACE FUNCTION perform_import_from_s3_task(
         format TEXT,
         s3_bucket TEXT, s3_key TEXT, s3_region TEXT,
         file_bytes BIGINT,
+        target_version BIGINT,
         step_payload JSON,
         lambda_function_arn TEXT,
         lambda_region TEXT,
@@ -876,6 +877,7 @@ BEGIN
 		s3_key TEXT := '$wrappedouter$||s3_key||$wrappedouter$'::TEXT;
 		s3_region TEXT := '$wrappedouter$||s3_region||$wrappedouter$'::TEXT;
         file_bytes BIGINT := '$wrappedouter$||file_bytes||$wrappedouter$'::BIGINT;
+        target_version BIGINT := '$wrappedouter$||target_version||$wrappedouter$'::BIGINT;
 		step_payload JSON := '$wrappedouter$||(step_payload::TEXT)||$wrappedouter$'::JSON;
 		lambda_function_arn TEXT := '$wrappedouter$||lambda_function_arn||$wrappedouter$'::TEXT;
 		lambda_region TEXT := '$wrappedouter$||lambda_region||$wrappedouter$'::TEXT;
@@ -897,6 +899,7 @@ BEGIN
 		     jsonb_build_object(
                 'importStatistics', import_statistics,
                 'fileBytes', file_bytes,
+		        'targetVersion', target_version,
                 'type', 'ImportOutput'
             )
 		);

--- a/xyz-util/src/main/java/com/here/xyz/util/db/SQLQuery.java
+++ b/xyz-util/src/main/java/com/here/xyz/util/db/SQLQuery.java
@@ -1216,7 +1216,7 @@ public class SQLQuery {
 
     public boolean mayRetry(Exception e) {
       int usedTimeForAttempt = (int) (System.currentTimeMillis() - lastAttemptTime) / 1000;
-      return remainingQueryTimeout > usedTimeForAttempt / 1000 && isRecoverable(e);
+      return remainingQueryTimeout > usedTimeForAttempt && isRecoverable(e);
     }
 
     /**


### PR DESCRIPTION
DS-2381: Persist targetVersion to fix -1 version occurrences on non-empty layer imports. Improve resume of imports. If the head version of the target space has changed, we use a new version for the resume to ensure consistency.