### PR TITLE
Fix resource locking to detect conflicts at space level

### DIFF
--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/datasets/DatasetDescription.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/datasets/DatasetDescription.java
@@ -45,6 +45,7 @@ import com.here.xyz.util.web.XyzWebClient.ErrorResponseException;
 import com.here.xyz.util.web.XyzWebClient.WebClientException;
 import io.vertx.core.Future;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -86,6 +87,8 @@ public abstract class DatasetDescription implements Typed {
 
   public static class Map extends Identifiable implements VersionedSource<Map> {
     private Ref versionRef = new Ref(Ref.HEAD);
+    @JsonView({Public.class, Static.class})
+    private List<String> layerIds;
 
     @Override
     public Ref getVersionRef() {
@@ -101,6 +104,30 @@ public abstract class DatasetDescription implements Typed {
     public Map withVersionRef(Ref versionRef) {
       setVersionRef(versionRef);
       return this;
+    }
+
+    public List<String> getLayerIds() {
+      return layerIds;
+    }
+
+    public void setLayerIds(List<String> layerIds) {
+      this.layerIds = layerIds;
+    }
+
+    public Map withLayerIds(List<String> layerIds) {
+      setLayerIds(layerIds);
+      return this;
+    }
+
+    @Override
+    public Set<String> getResourceKeys() {
+      Set<String> resourceKeys = new HashSet<>(super.getResourceKeys());
+      //Add individual space-level resource keys derived from the catalog HRN + layer IDs
+      if (layerIds != null && getId() != null) {
+        for (String layerId : layerIds)
+          resourceKeys.add(getId() + ":" + layerId);
+      }
+      return resourceKeys;
     }
   }
 

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/execution/JobExecutor.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/execution/JobExecutor.java
@@ -414,15 +414,20 @@ public abstract class JobExecutor implements Initializable {
     if (!isSingleJobPerResourceEnabled())
       return Future.succeededFuture(true);
 
-    String resourceKey = job.getResourceKey();
-    if (resourceKey == null || resourceKey.isEmpty())
+    Set<String> jobResourceKeys = job.getResourceKeys();
+    if (jobResourceKeys == null || jobResourceKeys.isEmpty())
       return Future.succeededFuture(true);
 
     //Filter the pre-loaded RUNNING jobs to those sharing at
     //least one resource key (and excluding the job itself)
     List<Job> conflictingRunning = runningJobs.stream()
         .filter(other -> !job.getId().equals(other.getId()))
-        .filter(other -> resourceKey.equals(other.getResourceKey()))
+        .filter(other -> {
+          Set<String> otherKeys = other.getResourceKeys();
+          if (otherKeys == null || otherKeys.isEmpty())
+            return false;
+          return otherKeys.stream().anyMatch(jobResourceKeys::contains);
+        })
         .toList();
 
     if (!conflictingRunning.isEmpty()) {
@@ -437,7 +442,7 @@ public abstract class JobExecutor implements Initializable {
     //NOTE: This check is still needed even though checkPendingJobs() sorts by createdAt, because:
     // 1. A job directly submitted via startExecution() (outside the poll loop) has no ordering guarantee.
     // 2. An older job blocked by insufficient virtual units stays PENDING while a newer job could otherwise jump ahead.
-    return JobConfigClient.getInstance().loadJobs(resourceKey, PENDING)
+    return JobConfigClient.getInstance().loadJobs(jobResourceKeys, PENDING)
         .map(pendingJobs -> {
           List<Job> olderPendingConflicts = pendingJobs.stream()
               .filter(other -> !job.getId().equals(other.getId()))

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseHandler.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/DatabaseHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2025 HERE Europe B.V.
+ * Copyright (C) 2017-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
The singleJobPerResource protection compared jobs using only the primary resource key (e.g. Map sources). This missed
conflicts when two jobs operated on the same space but were defined differently (one as Map with layerIds, another as Space with a direct space ID), allowing concurrent execution on the same underlying data.