### PR TITLE
Fix performance issue with property selection

### DIFF
--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/DecompressedSizeIT.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/DecompressedSizeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2024 HERE Europe B.V.
+ * Copyright (C) 2017-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,12 +19,15 @@
 
 package com.here.xyz.hub.rest;
 
+import static com.here.xyz.Payload.isGzipped;
 import static com.here.xyz.util.service.BaseHttpServerVerticle.HeaderValues.APPLICATION_GEO_JSON;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
+import io.restassured.response.ValidatableResponse;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.junit.AfterClass;
@@ -47,14 +50,21 @@ public class DecompressedSizeIT extends TestSpaceWithFeature {
 
   @Test
   public void testHeaderOutputSizeReporting() {
-    given()
+    final ValidatableResponse response = given()
         .accept(APPLICATION_GEO_JSON)
         .headers(getAuthHeaders(AuthProfile.ACCESS_OWNER_1_ADMIN))
         .when()
         .get(getSpacesPath() + "/x-psql-test/tile/quadkey/2100300120310022")
-        .then()
+        .then();
+
+    byte[] body = response
         .header("X-Decompressed-Input-Size", "0")
-        .header("X-Decompressed-Output-Size", "591");
+        .extract()
+        .body()
+        .asByteArray();
+
+    response.header("X-Decompressed-Output-Size", "" + body.length);
+    assertThat("Response body was not gzipped", isGzipped(body), is(false));
   }
 
   @Test

--- a/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/ReadFeatureApiIT.java
+++ b/xyz-hub-test/src/test/java/com/here/xyz/hub/rest/ReadFeatureApiIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2025 HERE Europe B.V.
+ * Copyright (C) 2017-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -382,23 +382,26 @@ public class ReadFeatureApiIT extends TestSpaceWithFeature {
 
   @Test
   public void testFeatureByIdWithSelection() {
-    given().
-        urlEncodingEnabled(false).
-        accept(APPLICATION_GEO_JSON).
-        headers(getAuthHeaders(AuthProfile.ACCESS_OWNER_1_ADMIN)).
-         when().
-          get(getSpacesPath() + "/x-psql-test/features/Q2838923?selection=p.name,p.selectionTest.a,p.selectionTest.b.1,p.selectionTest.d.d1").
-         then().
-          statusCode(OK.code()).
-           body("id", equalTo("Q2838923")).
-           body("properties.name", equalTo("Estadio Universidad San Marcos")).
-           body("properties.sport", equalTo(null)).
-           body("properties.selectionTest.a", equalTo("aString")).
-           body("properties.selectionTest.b.size()", equalTo(1)).
-           body("properties.selectionTest.b[0]", equalTo("bval2")).
-           body("properties.selectionTest.c", equalTo(null)).
-           body("properties.selectionTest.d.d1", equalTo("d1val")).
-           body("properties.selectionTest.d.d2", equalTo(null));
+    given()
+        .urlEncodingEnabled(false)
+        .accept(APPLICATION_GEO_JSON)
+        .headers(getAuthHeaders(AuthProfile.ACCESS_OWNER_1_ADMIN))
+        .when()
+        .get(getSpacesPath() + "/x-psql-test/features/Q2838923?"
+            + "selection=p.name,p.selectionTest.a,p.selectionTest.b.1,p.selectionTest.d.d1,p.selectionTest.e.1.v2")
+        .then()
+        .statusCode(OK.code())
+        .body("id", equalTo("Q2838923"))
+        .body("properties.name", equalTo("Estadio Universidad San Marcos"))
+        .body("properties.sport", equalTo(null))
+        .body("properties.selectionTest.a", equalTo("aString"))
+        .body("properties.selectionTest.b.size()", equalTo(1))
+        .body("properties.selectionTest.b[0]", equalTo("bval2"))
+        .body("properties.selectionTest.c", equalTo(null))
+        .body("properties.selectionTest.d.d1", equalTo("d1val"))
+        .body("properties.selectionTest.d.d2", equalTo(null))
+        .body("properties.selectionTest.e.size()", equalTo(1))
+        .body("properties.selectionTest.e[0].v2", equalTo("test1.1"));
   }
 
   @Test

--- a/xyz-hub-test/src/test/resources/xyz/hub/processedData.json
+++ b/xyz-hub-test/src/test/resources/xyz/hub/processedData.json
@@ -1456,9 +1456,10 @@
                 "sport": "association football",
                 "capacity": 67469,
                 "selectionTest" : { "a": "aString",
-                                    "b" : ["bval1","bval2","bval3"],
-                                    "c" : "cString",
-                                    "d" : { "d1": "d1val", "d2": "d2val" }
+                                    "b": ["bval1","bval2","bval3"],
+                                    "c": "cString",
+                                    "d": { "d1": "d1val", "d2": "d2val" },
+                                    "e": [{"v1":  "test0.0", "v2": "test0.1"}, {"v1":  "test1.0", "v2": "test1.1"}]
                                   }
             }
         },

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeatures.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/GetFeatures.java
@@ -467,10 +467,10 @@ public abstract class GetFeatures<E extends ContextAwareEvent, R extends XyzResp
       selection.add("type");
 
       jsonData = selection.isEmpty() ? new SQLQuery("jsondata") : new SQLQuery("(SELECT "
-          + "CASE WHEN prj_build->'properties' IS NOT NULL THEN prj_build "
-          + "ELSE jsonb_set(prj_build, '{properties}', '{}'::jsonb) "
+          + "CASE WHEN projected::JSONB->'properties' IS NOT NULL THEN projected::JSONB "
+          + "ELSE jsonb_set(projected::JSONB, '{properties}', '{}'::jsonb) "
           + "END "
-          + "FROM prj_build(#{selection}, jsondata))")
+          + "FROM prj_build(#{selection}, jsondata::TEXT) AS projected)")
           .withNamedParameter("selection", selection.toArray(new String[0]));
     }
     return jsonData;

--- a/xyz-psql-connector/src/main/resources/sql/ext.sql
+++ b/xyz-psql-connector/src/main/resources/sql/ext.sql
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2025 HERE Europe B.V.
+ * Copyright (C) 2017-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  * License-Filename: LICENSE
  */
+
 
 ---------------------------------------------------------------------------------
 -- xyz_index_status							:	select * from xyz_index_status();
@@ -1618,99 +1619,81 @@ $body$
  select * from _prj_flatten( jdoc, 100 )
 $body$
 LANGUAGE sql IMMUTABLE PARALLEL SAFE;
+
 ------------------------------------------------
 ------------------------------------------------
 
-create or replace function prj_build(jpaths text[], indata jsonb)
-returns jsonb as
+CREATE OR REPLACE FUNCTION prj_build(jpaths TEXT[], indata TEXT)
+RETURNS TEXT AS
 $body$
-  /**
-   * Extract and preserve only properties from a JSON object that match
-   * given JSONPath-like expressions (supports $.a.b.0.c)
-   * and merges overlapping paths.
-   */
-	function removePrefixedStrings(strings) {
 
-  const uniqueStrings = [...new Set(strings)];
+  function buildPathTree(allowedPaths) {
+    const root = { terminal: false, children: {} };
 
-  uniqueStrings.sort((a, b) => a.localeCompare(b));
-
-  const result = [];
-
-  for (const current of uniqueStrings) {
-    const isPrefixed = result.some(prefix => current.startsWith(prefix));
-    if (!isPrefixed) {
-      result.push(current);
-    }
-  }
-
-  return result;
-  }
-
-  function includePaths(obj, allowedPaths) {
-    const result = {};
-
-    const inputPaths = removePrefixedStrings(allowedPaths);
-
-    for (const path of inputPaths || []) {
+    for (const path of allowedPaths || []) {
       const parts = path
-        .replace(/^\$\./, '')        // remove leading "$."
-        .split(/\./)                 // split by .
+        .split('.')                  // normal dot-path, e.g. "a.b.c"
         .filter(Boolean);
 
-      let src = obj;
-      let exists = true;
+      if (parts.length === 0) continue;
 
-      // Check if path fully exists in source
+      let node = root;
       for (const key of parts) {
-        const isIndex = /^\d+$/.test(key);
-        const srcKey = isIndex ? parseInt(key, 10) : key;
-        if (src == null || (Array.isArray(src) && src[srcKey] === undefined) || (!Array.isArray(src) && !(srcKey in src))) {
-          exists = false;
-          break;
-        }
-        src = src[srcKey];
+        // A terminal ancestor already preserves this whole subtree,
+        // so there is no need to descend any deeper.
+        if (node.terminal) break;
+        if (!node.children[key])
+          node.children[key] = { terminal: false, children: {} };
+        node = node.children[key];
       }
-
-      if (!exists) continue; // skip missing leaf paths
-
-      // Reset traversal for building result
-      src = obj;
-      let dst = result;
-
-      for (let i = 0; i < parts.length; i++) {
-        const key = parts[i];
-        const isIndex = /^\d+$/.test(key);
-        const srcKey = isIndex ? parseInt(key, 10) : key;
-        const isLast = i === parts.length - 1;
-
-        if (isLast) {
-          // assign only if leaf exists (checked earlier)
-            dst[srcKey] = src[srcKey];
-        } else {
-          // create or reuse existing branch
-          const nextIsArray = /^\d+$/.test(parts[i + 1]);
-          if (Array.isArray(dst)) {
-            dst[srcKey] = dst[srcKey] ?? (nextIsArray ? [] : {});
-          } else {
-            if (!(srcKey in dst)) {
-              dst[srcKey] = nextIsArray ? [] : {};
-            }
-          }
-
-          src = src[srcKey];
-          dst = dst[srcKey];
-        }
-      }
+      node.terminal = true; // whole subtree below this path is preserved
     }
 
-    return result;
+    return root;
   }
 
-  return includePaths(indata, jpaths);
+  function prune(obj, node) {
+    // A terminal node means: keep this value (and everything below) untouched.
+    if (node.terminal) return;
+    if (obj == null || typeof obj !== 'object') return;
+
+    if (Array.isArray(obj)) {
+      // Array aware: keep only the explicitly allowed indices (e.g. "b.1")
+      // and compact the array so the kept elements move to the front.
+      const keepKeys = Object.keys(node.children)
+        .filter(key => /^\d+$/.test(key) && key < obj.length)
+        .sort((a, b) => a - b); // numeric order via implicit coercion
+
+      const kept = [];
+      for (const key of keepKeys) {
+        // On an allowed path -> descend and prune deeper.
+        prune(obj[key], node.children[key]);
+        kept.push(obj[key]);
+      }
+
+      obj.length = 0;
+      obj.push(...kept);
+      return;
+    }
+
+    for (const key of Object.keys(obj)) {
+      const child = node.children[key];
+      if (child === undefined) {
+        // Not on any allowed path -> drop it.
+        delete obj[key];
+      }
+      else
+        // On an allowed path -> descend and prune deeper.
+        prune(obj[key], child);
+    }
+  }
+
+  const data = JSON.parse(indata);
+  prune(data, buildPathTree(jpaths));
+  return JSON.stringify(data);
 
 $body$
-language plv8 immutable PARALLEL SAFE;
+LANGUAGE plv8 IMMUTABLE PARALLEL SAFE;
 
 
 ------------------------------------------------


### PR DESCRIPTION
- improved the algorithm that is being used for properties-selection in the databases.
    - PLV8 function `prj_build()` now expects TEXT and produces TEXT to prevent slow DB native JSONB serialization & parsing
    - Improved the algorithm to not copy all data into a new object, but rather mutate the original object by deleting all unwanted fields (also lower memory footprint)
    - Also enhance test to also check nesting of objects within arrays