### PR TITLE
DS-2461: Add IterateChangesets query builder

### DIFF
--- a/xyz-connectors/src/main/java/com/here/xyz/connectors/StorageConnector.java
+++ b/xyz-connectors/src/main/java/com/here/xyz/connectors/StorageConnector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2025 HERE Europe B.V.
+ * Copyright (C) 2017-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,12 +51,11 @@ import com.here.xyz.models.geojson.implementation.FeatureCollection;
 import com.here.xyz.responses.BinaryResponse;
 import com.here.xyz.responses.ChangesetsStatisticsResponse;
 import com.here.xyz.responses.ErrorResponse;
+import com.here.xyz.responses.ModifiedBranchResponse;
 import com.here.xyz.responses.StatisticsResponse;
 import com.here.xyz.responses.StorageStatistics;
-import com.here.xyz.responses.ModifiedBranchResponse;
 import com.here.xyz.responses.SuccessResponse;
 import com.here.xyz.responses.XyzResponse;
-import com.here.xyz.responses.changesets.ChangesetCollection;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -245,7 +244,7 @@ public abstract class StorageConnector extends EntryConnectorHandler {
 
   protected abstract SuccessResponse processDeleteChangesetsEvent(DeleteChangesetsEvent event) throws Exception;
 
-  protected abstract ChangesetCollection processIterateChangesetsEvent(IterateChangesetsEvent event) throws Exception;
+  protected abstract XyzResponse processIterateChangesetsEvent(IterateChangesetsEvent event) throws Exception;
 
   protected abstract ChangesetsStatisticsResponse processGetChangesetsStatisticsEvent(GetChangesetStatisticsEvent event) throws Exception;
 

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/test/InMemoryStorage.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/test/InMemoryStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2024 HERE Europe B.V.
+ * Copyright (C) 2017-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ import com.here.xyz.responses.StatisticsResponse;
 import com.here.xyz.responses.StorageStatistics;
 import com.here.xyz.responses.SuccessResponse;
 import com.here.xyz.responses.XyzError;
-import com.here.xyz.responses.changesets.ChangesetCollection;
+import com.here.xyz.responses.XyzResponse;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -153,7 +153,7 @@ public class InMemoryStorage extends StorageConnector {
   }
 
   @Override
-  protected ChangesetCollection processIterateChangesetsEvent(IterateChangesetsEvent event) throws Exception {
+  protected XyzResponse processIterateChangesetsEvent(IterateChangesetsEvent event) throws Exception {
     throw new UnsupportedOperationException(event.getClass().getSimpleName() + " not implemented.");
   }
 

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/test/MockDelayStorageConnector.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/test/MockDelayStorageConnector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2024 HERE Europe B.V.
+ * Copyright (C) 2017-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ import com.here.xyz.responses.StatisticsResponse;
 import com.here.xyz.responses.StorageStatistics;
 import com.here.xyz.responses.SuccessResponse;
 import com.here.xyz.responses.XyzError;
-import com.here.xyz.responses.changesets.ChangesetCollection;
+import com.here.xyz.responses.XyzResponse;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -159,7 +159,7 @@ public class MockDelayStorageConnector extends StorageConnector {
   }
 
   @Override
-  protected ChangesetCollection processIterateChangesetsEvent(IterateChangesetsEvent event) throws Exception {
+  protected XyzResponse processIterateChangesetsEvent(IterateChangesetsEvent event) throws Exception {
     throw new UnsupportedOperationException(event.getClass().getSimpleName() + " not implemented.");
   }
 

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/test/TestStorageConnector.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/connectors/test/TestStorageConnector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2024 HERE Europe B.V.
+ * Copyright (C) 2017-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,7 +53,7 @@ import com.here.xyz.responses.StatisticsResponse;
 import com.here.xyz.responses.StorageStatistics;
 import com.here.xyz.responses.SuccessResponse;
 import com.here.xyz.responses.XyzError;
-import com.here.xyz.responses.changesets.ChangesetCollection;
+import com.here.xyz.responses.XyzResponse;
 import com.here.xyz.util.service.Core;
 import java.util.Arrays;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -176,7 +176,7 @@ public class TestStorageConnector extends StorageConnector {
   }
 
   @Override
-  protected ChangesetCollection processIterateChangesetsEvent(IterateChangesetsEvent event) throws Exception {
+  protected XyzResponse processIterateChangesetsEvent(IterateChangesetsEvent event) throws Exception {
     throw new ErrorResponseException(event.getStreamId(), XyzError.forValue(event.getSpace()), event.getSpace() + " message.");
   }
 

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/ChangesetApi.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/ChangesetApi.java
@@ -80,15 +80,13 @@ public class ChangesetApi extends SpaceBasedApi {
     if (endVersion != -1 && startVersion > endVersion)
       throw new IllegalArgumentException("The parameter \"" + START_VERSION + "\" needs to be smaller than or equal to \"" + END_VERSION + "\".");
 
-    boolean squashed = isSquashed(context);
-
     IterateChangesetsEvent event = buildIterateChangesetsEvent(context, ref)
-        .withSquashed(squashed)
+        .withSquashed(isSquashed(context))
         .withOperation(getOperation(context));
     //TODO: Add static caching to this endpoint, once the execution pipelines have been refactored.
     SpaceConnectorBasedHandler.execute(getMarker(context),
             space -> Authorization.authorizeManageSpacesRights(context, space.getId(), space.getOwner()).map(space), event)
-        .onSuccess(result -> sendResponse(context, result, squashed))
+        .onSuccess(result -> sendResponse(context, result))
         .onFailure(t -> sendErrorResponse(context, t));
   }
 
@@ -109,7 +107,7 @@ public class ChangesetApi extends SpaceBasedApi {
           if (changesets.getVersions().isEmpty())
             sendErrorResponse(context, new HttpException(NOT_FOUND, "No changeset was found for version " + version));
           else
-            sendResponse(context, changesets.getVersions().get(version).withNextPageToken(changesets.getNextPageToken()), false);
+            sendResponse(context, changesets.getVersions().get(version).withNextPageToken(changesets.getNextPageToken()));
         })
         .onFailure(t -> sendErrorResponse(context, t));
   }
@@ -229,11 +227,11 @@ public class ChangesetApi extends SpaceBasedApi {
     }
   }
 
-  private void sendResponse(final RoutingContext context, Object result, boolean squashed) {
-    if (!squashed && result instanceof Changeset && ((Changeset) result).getVersion() == -1)
+  private void sendResponse(final RoutingContext context, Object result) {
+    if (result instanceof Changeset cs && cs.getVersion() == -1 && cs.getVersionRef() == null)
       sendErrorResponse(context, new HttpException(NOT_FOUND, "The requested resource does not exist."));
-    else if (result instanceof ChangesetCollection && ((ChangesetCollection) result).getStartVersion() == -1 &&
-        ((ChangesetCollection) result).getEndVersion() == -1)
+    else if (result instanceof ChangesetCollection csc && csc.getStartVersion() == -1 &&
+        csc.getEndVersion() == -1)
       sendErrorResponse(context, new HttpException(NOT_FOUND, "The requested resource does not exist."));
     else
       sendResponse(context, OK.code(), result);

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/ChangesetApi.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/ChangesetApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2025 HERE Europe B.V.
+ * Copyright (C) 2017-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import static com.here.xyz.models.hub.Ref.HEAD;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 
+import com.here.xyz.FeatureChange.Operation;
 import com.here.xyz.events.DeleteChangesetsEvent;
 import com.here.xyz.events.GetChangesetStatisticsEvent;
 import com.here.xyz.events.IterateChangesetsEvent;
@@ -54,6 +55,9 @@ import org.apache.logging.log4j.Marker;
 
 public class ChangesetApi extends SpaceBasedApi {
 
+  public static final String SQUASHED = "squashed";
+  public static final String OPERATION = "operation";
+
   public ChangesetApi(RouterBuilder rb) {
     rb.getRoute("getChangesets").setDoValidation(false).addHandler(handleErrors(this::getChangesets));
     rb.getRoute("getChangeset").setDoValidation(false).addHandler(handleErrors(this::getChangeset));
@@ -76,7 +80,11 @@ public class ChangesetApi extends SpaceBasedApi {
     if (endVersion != -1 && startVersion > endVersion)
       throw new IllegalArgumentException("The parameter \"" + START_VERSION + "\" needs to be smaller than or equal to \"" + END_VERSION + "\".");
 
-    IterateChangesetsEvent event = buildIterateChangesetsEvent(context, ref);
+    boolean squashed = isSquashed(context);
+
+    IterateChangesetsEvent event = buildIterateChangesetsEvent(context, ref)
+        .withSquashed(squashed)
+        .withOperation(getOperation(context));
     //TODO: Add static caching to this endpoint, once the execution pipelines have been refactored.
     SpaceConnectorBasedHandler.execute(getMarker(context),
             space -> Authorization.authorizeManageSpacesRights(context, space.getId(), space.getOwner()).map(space), event)
@@ -247,5 +255,16 @@ public class ChangesetApi extends SpaceBasedApi {
   public static Future<ChangesetsStatisticsResponse> getChangesetStatistics(Marker marker,
       Function<Space, Future<Space>> authorizationFunction, String spaceId) {
     return SpaceConnectorBasedHandler.execute(marker, authorizationFunction, new GetChangesetStatisticsEvent().withSpace(spaceId));
+  }
+
+  protected boolean isSquashed(RoutingContext context) {
+    return Query.getBoolean(context, SQUASHED, false);
+  }
+
+  protected Operation getOperation(RoutingContext context) {
+    String operation = Query.getString(context, OPERATION, null);
+    if (operation == null)
+      return null;
+    return Operation.valueOf(operation.toUpperCase());
   }
 }

--- a/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/ChangesetApi.java
+++ b/xyz-hub-service/src/main/java/com/here/xyz/hub/rest/ChangesetApi.java
@@ -88,7 +88,7 @@ public class ChangesetApi extends SpaceBasedApi {
     //TODO: Add static caching to this endpoint, once the execution pipelines have been refactored.
     SpaceConnectorBasedHandler.execute(getMarker(context),
             space -> Authorization.authorizeManageSpacesRights(context, space.getId(), space.getOwner()).map(space), event)
-        .onSuccess(result -> sendResponse(context, result))
+        .onSuccess(result -> sendResponse(context, result, squashed))
         .onFailure(t -> sendErrorResponse(context, t));
   }
 
@@ -109,7 +109,7 @@ public class ChangesetApi extends SpaceBasedApi {
           if (changesets.getVersions().isEmpty())
             sendErrorResponse(context, new HttpException(NOT_FOUND, "No changeset was found for version " + version));
           else
-            sendResponse(context, changesets.getVersions().get(version).withNextPageToken(changesets.getNextPageToken()));
+            sendResponse(context, changesets.getVersions().get(version).withNextPageToken(changesets.getNextPageToken()), false);
         })
         .onFailure(t -> sendErrorResponse(context, t));
   }
@@ -229,8 +229,8 @@ public class ChangesetApi extends SpaceBasedApi {
     }
   }
 
-  private void sendResponse(final RoutingContext context, Object result) {
-    if (result instanceof Changeset && ((Changeset) result).getVersion() == -1)
+  private void sendResponse(final RoutingContext context, Object result, boolean squashed) {
+    if (!squashed && result instanceof Changeset && ((Changeset) result).getVersion() == -1)
       sendErrorResponse(context, new HttpException(NOT_FOUND, "The requested resource does not exist."));
     else if (result instanceof ChangesetCollection && ((ChangesetCollection) result).getStartVersion() == -1 &&
         ((ChangesetCollection) result).getEndVersion() == -1)

--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/Job.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/Job.java
@@ -132,7 +132,7 @@ public class Job implements XyzSerializable {
 
   private static final Async ASYNC = new Async(100, Job.class);
   private static final Logger logger = LogManager.getLogger();
-  private static final long DEFAULT_JOB_TTL = TimeUnit.DAYS.toMillis(2 * 7); //4 weeks
+  private static final long DEFAULT_JOB_TTL = TimeUnit.DAYS.toMillis(2 * 7); //2 weeks
 
   /**
    * Creates a new Job.

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/ExportChangedTiles.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/ExportChangedTiles.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2017-2026 HERE Europe B.V.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -22,14 +23,12 @@ import static com.here.xyz.events.ContextAwareEvent.SpaceContext.DEFAULT;
 import static com.here.xyz.events.ContextAwareEvent.SpaceContext.EXTENSION;
 import static com.here.xyz.events.ContextAwareEvent.SpaceContext.SUPER;
 import static com.here.xyz.jobs.steps.Step.Visibility.SYSTEM;
-import static com.here.xyz.jobs.steps.Step.Visibility.USER;
 import static com.here.xyz.jobs.steps.impl.SpaceBasedStep.LogPhase.STEP_EXECUTE;
 import static com.here.xyz.jobs.steps.impl.SpaceBasedStep.LogPhase.STEP_ON_ASYNC_SUCCESS;
 import static com.here.xyz.util.web.XyzWebClient.WebClientException;
 
 import com.fasterxml.jackson.annotation.JsonView;
 import com.here.xyz.events.ContextAwareEvent.SpaceContext;
-import com.here.xyz.models.filters.SpatialFilter;
 import com.here.xyz.jobs.steps.StepExecution;
 import com.here.xyz.jobs.steps.impl.transport.tasks.inputs.ExportInput;
 import com.here.xyz.jobs.steps.impl.transport.tasks.outputs.ExportOutput;
@@ -37,6 +36,7 @@ import com.here.xyz.jobs.steps.outputs.DownloadUrl;
 import com.here.xyz.jobs.steps.outputs.FeatureStatistics;
 import com.here.xyz.jobs.steps.outputs.TileInvalidations;
 import com.here.xyz.jobs.steps.resources.TooManyResourcesClaimed;
+import com.here.xyz.models.filters.SpatialFilter;
 import com.here.xyz.models.geojson.HQuad;
 import com.here.xyz.models.geojson.WebMercatorTile;
 import com.here.xyz.models.geojson.coordinates.BBox;

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/ExportChangedTiles.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/ExportChangedTiles.java
@@ -22,6 +22,7 @@ package com.here.xyz.jobs.steps.impl.transport;
 import static com.here.xyz.events.ContextAwareEvent.SpaceContext.DEFAULT;
 import static com.here.xyz.events.ContextAwareEvent.SpaceContext.EXTENSION;
 import static com.here.xyz.events.ContextAwareEvent.SpaceContext.SUPER;
+import static com.here.xyz.events.ContextAwareEvent.SpaceContext.X;
 import static com.here.xyz.jobs.steps.Step.Visibility.SYSTEM;
 import static com.here.xyz.jobs.steps.impl.SpaceBasedStep.LogPhase.STEP_EXECUTE;
 import static com.here.xyz.jobs.steps.impl.SpaceBasedStep.LogPhase.STEP_ON_ASYNC_SUCCESS;
@@ -46,6 +47,7 @@ import com.here.xyz.models.geojson.coordinates.Position;
 import com.here.xyz.models.geojson.exceptions.InvalidGeometryException;
 import com.here.xyz.models.geojson.implementation.Polygon;
 import com.here.xyz.models.hub.Ref;
+import com.here.xyz.models.hub.Space;
 import com.here.xyz.psql.query.GetFeaturesByGeometryBuilder;
 import com.here.xyz.psql.query.GetFeaturesByGeometryBuilder.GetFeaturesByGeometryInput;
 import com.here.xyz.psql.query.GetFeaturesByIdsBuilder;
@@ -415,8 +417,9 @@ public class ExportChangedTiles extends ExportSpaceToFiles {
 
     GetFeaturesByGeometryBuilder queryBuilder = new GetFeaturesByGeometryBuilder()
             .withDataSourceProvider(requestResource(dbReader(), 0));
-
-    GetFeaturesByGeometryInput input = createGetFeaturesByGeometryInput(context, spatialFilter, versionRef);
+    Space space = context == SUPER ? superSpace() : space();
+    SpaceContext targetContext = context == null ? DEFAULT : context == EXTENSION ? X : context;
+    GetFeaturesByGeometryInput input = createGetFeaturesByGeometryInput(space, targetContext, spatialFilter, versionRef);
 
     return queryBuilder
             .withSelectClauseOverride(selectClauseOverride)
@@ -439,7 +442,8 @@ public class ExportChangedTiles extends ExportSpaceToFiles {
             .withGeometry(getTileBBOX(tileId))
             .withClip(clipOnTileBoundaries);
 
-    GetFeaturesByGeometryInput input = createGetFeaturesByGeometryInput(context, tileBBOXFilter, versionRef);
+    Space space = context == SUPER ? superSpace() : space();
+    GetFeaturesByGeometryInput input = createGetFeaturesByGeometryInput(space, context, tileBBOXFilter, versionRef);
 
     SQLQuery contentQuery = queryBuilder
             .withClippingGeometry(spatialFilter != null && spatialFilter.isClip() ? spatialFilter.getGeometry() : null)

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/ExportSpaceToFiles.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/ExportSpaceToFiles.java
@@ -19,6 +19,10 @@
 
 package com.here.xyz.jobs.steps.impl.transport;
 
+import static com.here.xyz.FeatureChange.Operation;
+import static com.here.xyz.FeatureChange.Operation.DELETE;
+import static com.here.xyz.FeatureChange.Operation.INSERT;
+import static com.here.xyz.FeatureChange.Operation.UPDATE;
 import static com.here.xyz.events.ContextAwareEvent.SpaceContext.DEFAULT;
 import static com.here.xyz.events.ContextAwareEvent.SpaceContext.EXTENSION;
 import static com.here.xyz.events.ContextAwareEvent.SpaceContext.SUPER;
@@ -29,6 +33,9 @@ import static com.here.xyz.jobs.steps.impl.SpaceBasedStep.LogPhase.JOB_EXECUTOR;
 import static com.here.xyz.jobs.steps.impl.SpaceBasedStep.LogPhase.JOB_VALIDATE;
 import static com.here.xyz.jobs.steps.impl.SpaceBasedStep.LogPhase.STEP_EXECUTE;
 import static com.here.xyz.jobs.steps.impl.SpaceBasedStep.LogPhase.STEP_ON_ASYNC_SUCCESS;
+import static com.here.xyz.jobs.steps.impl.transport.ExportSpaceToFiles.OutputType.FLAT_PATCH;
+import static com.here.xyz.jobs.steps.impl.transport.ExportSpaceToFiles.OutputType.FOLDER_PATCH;
+import static com.here.xyz.psql.query.IterateChangesetsBuilder.IterateChangesetsInput;
 
 import com.fasterxml.jackson.annotation.JsonView;
 import com.here.xyz.events.ContextAwareEvent.SpaceContext;
@@ -66,17 +73,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 import javax.xml.crypto.dsig.TransformException;
-
 import org.geotools.api.referencing.FactoryException;
 import org.locationtech.jts.geom.Geometry;
-
-import static com.here.xyz.jobs.steps.impl.transport.ExportSpaceToFiles.OutputType.FLAT_PATCH;
-import static com.here.xyz.psql.query.IterateChangesetsBuilder.IterateChangesetsInput;
-import static com.here.xyz.jobs.steps.impl.transport.ExportSpaceToFiles.OutputType.FOLDER_PATCH;
-import static com.here.xyz.FeatureChange.Operation;
-import static com.here.xyz.FeatureChange.Operation.INSERT;
-import static com.here.xyz.FeatureChange.Operation.UPDATE;
-import static com.here.xyz.FeatureChange.Operation.DELETE;
 
 /**
  * The {@code ExportSpaceToFiles} class represents a step in a data processing workflow that exports data
@@ -439,7 +437,7 @@ public class ExportSpaceToFiles extends TaskedSpaceBasedStep<ExportSpaceToFiles,
 
   private List<ExportInput> createExportInputs(int taskListCount, IRange iRange, long iRangeSize) {
     List<ExportInput> taskDataList = new ArrayList<>();
-    
+
     for (int i = 0; i < taskListCount; i++) {
       long startI = iRange.minI() + i * iRangeSize;
       long endI = startI + iRangeSize - 1;
@@ -590,33 +588,35 @@ public class ExportSpaceToFiles extends TaskedSpaceBasedStep<ExportSpaceToFiles,
             .toExecutableQueryString();
   }
 
-  private String getFolderPatchQuery(Space space, SpaceContext targetContext, ExportInput taskInput) throws TooManyResourcesClaimed, WebClientException, QueryBuildingException {
+  private String getFolderPatchQuery(Space space, SpaceContext targetContext, ExportInput taskInput)
+      throws TooManyResourcesClaimed, WebClientException, QueryBuildingException {
     IterateChangesetsBuilder queryBuilder = new IterateChangesetsBuilder()
-            .withDataSourceProvider(requestResource(dbReader(), 0));
+        .withDataSourceProvider(requestResource(dbReader(), 0));
 
-    IterateChangesetsInput input = createIterateChangesetsInput(space, targetContext, versionRef, taskInput.operation());
+    IterateChangesetsInput input = createIterateChangesetsInput(space, targetContext, versionRef, taskInput.operation(), taskInput.startI(),
+        taskInput.endI());
 
     return queryBuilder
-            //TDB
-            //.withAdditionalFilterFragment(getQueryBuilder().buildIRangeFragment(taskInput.startI(), taskInput.endI()))
-            .buildQuery(input)
-            .toExecutableQueryString();
+        .buildQuery(input)
+        .toExecutableQueryString();
   }
 
-  protected IterateChangesetsInput createIterateChangesetsInput(Space space, SpaceContext targetContext, Ref versionRef, Operation operation)
-          throws WebClientException {
+  private IterateChangesetsInput createIterateChangesetsInput(Space space, SpaceContext targetContext, Ref versionRef, Operation operation,
+      long startI, long endI) throws WebClientException {
     return new IterateChangesetsInput(
-            space.getId(),
-            hubWebClient().loadConnector(space.getStorage().getId()).params,
-            space().getExtension() != null ? space().resolveCompositeParams(superSpace()) : null,
-            targetContext,
-            space.getVersionsToKeep(),
-            minSpaceVersion,
-            versionRef,
-            -1L, //startTime TBD
-            -1L, //endTime TBD
-            squashedData,
-            operation);
+        space.getId(),
+        hubWebClient().loadConnector(space.getStorage().getId()).params,
+        space().getExtension() != null ? space().resolveCompositeParams(superSpace()) : null,
+        targetContext,
+        space.getVersionsToKeep(),
+        minSpaceVersion,
+        versionRef,
+        -1L, //startTime TBD
+        -1L, //endTime TBD
+        squashedData,
+        operation,
+        startI,
+        endI);
   }
 
   private ExportQueryBuilder getQueryBuilder() {

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/ExportSpaceToFiles.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/ExportSpaceToFiles.java
@@ -51,6 +51,7 @@ import com.here.xyz.models.hub.Ref;
 import com.here.xyz.models.hub.Space;
 import com.here.xyz.psql.query.GetFeaturesByGeometryBuilder;
 import com.here.xyz.psql.query.GetFeaturesByGeometryBuilder.GetFeaturesByGeometryInput;
+import com.here.xyz.psql.query.IterateChangesetsBuilder;
 import com.here.xyz.psql.query.QueryBuilder.QueryBuildingException;
 import com.here.xyz.responses.StatisticsResponse;
 import com.here.xyz.util.db.SQLQuery;
@@ -65,11 +66,17 @@ import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 import javax.xml.crypto.dsig.TransformException;
+
 import org.geotools.api.referencing.FactoryException;
 import org.locationtech.jts.geom.Geometry;
 
-import static com.here.xyz.jobs.steps.impl.transport.ExportSpaceToFiles.OutputType.FolderPatch;
-
+import static com.here.xyz.jobs.steps.impl.transport.ExportSpaceToFiles.OutputType.FLAT_PATCH;
+import static com.here.xyz.psql.query.IterateChangesetsBuilder.IterateChangesetsInput;
+import static com.here.xyz.jobs.steps.impl.transport.ExportSpaceToFiles.OutputType.FOLDER_PATCH;
+import static com.here.xyz.FeatureChange.Operation;
+import static com.here.xyz.FeatureChange.Operation.INSERT;
+import static com.here.xyz.FeatureChange.Operation.UPDATE;
+import static com.here.xyz.FeatureChange.Operation.DELETE;
 
 /**
  * The {@code ExportSpaceToFiles} class represents a step in a data processing workflow that exports data
@@ -112,9 +119,9 @@ public class ExportSpaceToFiles extends TaskedSpaceBasedStep<ExportSpaceToFiles,
   private int estimatedSeconds = -1;
 
   @JsonView({Internal.class, Static.class})
-  protected boolean squashedData;
+  protected boolean squashedData = true;
   @JsonView({Internal.class, Static.class})
-  protected OutputType outputType = FolderPatch;
+  protected OutputType outputType = FLAT_PATCH;
 
   @JsonView({Internal.class, Static.class})
   protected SpatialFilter spatialFilter;
@@ -427,11 +434,21 @@ public class ExportSpaceToFiles extends TaskedSpaceBasedStep<ExportSpaceToFiles,
     IRange iRange = resolveIRange();
     long iRangeSize = (long) Math.ceil((double) (iRange.maxI() - iRange.minI() + 1) / (double) taskListCount);
 
+    return createExportInputs(taskListCount, iRange, iRangeSize);
+  }
+
+  private List<ExportInput> createExportInputs(int taskListCount, IRange iRange, long iRangeSize) {
     List<ExportInput> taskDataList = new ArrayList<>();
+    
     for (int i = 0; i < taskListCount; i++) {
       long startI = iRange.minI() + i * iRangeSize;
       long endI = startI + iRangeSize - 1;
-      taskDataList.add(new ExportInput(i, startI, endI));
+      if(outputType.equals(FOLDER_PATCH)) {
+        taskDataList.add(new ExportInput(i, startI, endI, INSERT));
+        taskDataList.add(new ExportInput(i, startI, endI, UPDATE));
+        taskDataList.add(new ExportInput(i, startI, endI, DELETE));
+      }else
+        taskDataList.add(new ExportInput(i, startI, endI));
     }
     return taskDataList;
   }
@@ -451,8 +468,19 @@ public class ExportSpaceToFiles extends TaskedSpaceBasedStep<ExportSpaceToFiles,
   @Override
   protected SQLQuery buildTaskQuery(Integer taskId, ExportInput taskInput, String failureCallback)
           throws QueryBuildingException, TooManyResourcesClaimed, WebClientException, InvalidGeometryException {
-    return buildExportToS3PluginQuery(getSchema(db()), taskId,
+    return buildExportToS3PluginQuery(
+            buildDownloadUrlForTaskInput(taskInput),
+            taskId,
             generateContentQueryForExportPlugin(taskInput), failureCallback);
+  }
+
+  private DownloadUrl buildDownloadUrlForTaskInput(ExportInput taskInput) {
+    if(outputType.equals(FLAT_PATCH))
+      return new DownloadUrl().withS3Key(toS3Path(getOutputSet(EXPORTED_DATA)) + "/" + taskInput.threadId() + "/" + UUID.randomUUID() + ".json");
+    else if(outputType.equals(FOLDER_PATCH))
+      return new DownloadUrl().withS3Key(toS3Path(getOutputSet(EXPORTED_DATA)) + "/" + taskInput.operation() + "/" + taskInput.threadId() + "/"  + UUID.randomUUID() + ".json");
+    else
+      throw new StepException("Invalid outputType: " + outputType);
   }
 
   @Override
@@ -478,20 +506,16 @@ public class ExportSpaceToFiles extends TaskedSpaceBasedStep<ExportSpaceToFiles,
     ), STATISTICS);
   }
 
-  protected GetFeaturesByGeometryInput createGetFeaturesByGeometryInput(SpaceContext context, SpatialFilter spatialFilter, Ref versionRef)
+  protected GetFeaturesByGeometryInput createGetFeaturesByGeometryInput(Space space, SpaceContext targetContext, SpatialFilter spatialFilter, Ref versionRef)
       throws WebClientException {
-    Space space = context == SUPER ? superSpace() : space();
 
     return new GetFeaturesByGeometryInput(space.getId(), hubWebClient().loadConnector(space.getStorage().getId()).params,
-        space().getExtension() != null ? space().resolveCompositeParams(superSpace()) : null, context, space.getVersionsToKeep(), minSpaceVersion,
+        space().getExtension() != null ? space().resolveCompositeParams(superSpace()) : null, targetContext, space.getVersionsToKeep(), minSpaceVersion,
         versionRef, spatialFilter != null ? spatialFilter.getGeometry() : null, spatialFilter != null ? spatialFilter.getRadius() : 0,
         spatialFilter != null && spatialFilter.isClip(), propertyFilter);
   }
 
-  private SQLQuery buildExportToS3PluginQuery(String schema, int taskId, String contentQuery, String failureCallback) throws WebClientException {
-    //TODO Group by threadId
-    DownloadUrl downloadUrl = new DownloadUrl().withS3Key(toS3Path(getOutputSet(EXPORTED_DATA)) + "/" + taskId + "/" + UUID.randomUUID() + ".json");
-
+  private SQLQuery buildExportToS3PluginQuery(DownloadUrl downloadUrl, int taskId, String contentQuery, String failureCallback) {
     return getQueryBuilder().buildExportToS3PluginQuery(
             taskId,
             downloadUrl,
@@ -534,7 +558,6 @@ public class ExportSpaceToFiles extends TaskedSpaceBasedStep<ExportSpaceToFiles,
 
   private record IRange(long minI, long maxI) {}
 
-
   /**
    * Generates a content query for the export plugin based on the task data and context. This method
    * can get overridden easily from other ExportProcesses.
@@ -549,20 +572,51 @@ public class ExportSpaceToFiles extends TaskedSpaceBasedStep<ExportSpaceToFiles,
    */
   protected String generateContentQueryForExportPlugin(ExportInput taskInput) throws WebClientException, TooManyResourcesClaimed,
       QueryBuildingException, InvalidGeometryException {
+    Space space = context == SUPER ? superSpace() : space();
+    SpaceContext targetContext = context == null ? DEFAULT : context == EXTENSION ? X : context;
 
+    return outputType.equals(FOLDER_PATCH) ? getFolderPatchQuery(space, targetContext, taskInput) : getFlatPatchQuery(space, targetContext, taskInput);
+  }
+
+  private String getFlatPatchQuery(Space space, SpaceContext targetContext, ExportInput taskInput) throws TooManyResourcesClaimed, WebClientException, QueryBuildingException {
     GetFeaturesByGeometryBuilder queryBuilder = new GetFeaturesByGeometryBuilder()
         .withDataSourceProvider(requestResource(dbReader(), 0));
 
-    GetFeaturesByGeometryInput input = createGetFeaturesByGeometryInput(context == null ? DEFAULT : context == EXTENSION ? X : context, spatialFilter, versionRef);
+    GetFeaturesByGeometryInput input = createGetFeaturesByGeometryInput(space, targetContext, spatialFilter, versionRef);
+    return queryBuilder
+            //Thread Condition (based on I)
+            .withAdditionalFilterFragment(getQueryBuilder().buildIRangeFragment(taskInput.startI(), taskInput.endI()))
+            .buildQuery(input)
+            .toExecutableQueryString();
+  }
 
-    SQLQuery threadCondition = new SQLQuery("i >= #{startI} AND i <= #{endI}")
-        .withNamedParameter("startI", taskInput.startI())
-        .withNamedParameter("endI", taskInput.endI());
+  private String getFolderPatchQuery(Space space, SpaceContext targetContext, ExportInput taskInput) throws TooManyResourcesClaimed, WebClientException, QueryBuildingException {
+    IterateChangesetsBuilder queryBuilder = new IterateChangesetsBuilder()
+            .withDataSourceProvider(requestResource(dbReader(), 0));
+
+    IterateChangesetsInput input = createIterateChangesetsInput(space, targetContext, versionRef, taskInput.operation());
 
     return queryBuilder
-        .withAdditionalFilterFragment(threadCondition)
-        .buildQuery(input)
-        .toExecutableQueryString();
+            //TDB
+            //.withAdditionalFilterFragment(getQueryBuilder().buildIRangeFragment(taskInput.startI(), taskInput.endI()))
+            .buildQuery(input)
+            .toExecutableQueryString();
+  }
+
+  protected IterateChangesetsInput createIterateChangesetsInput(Space space, SpaceContext targetContext, Ref versionRef, Operation operation)
+          throws WebClientException {
+    return new IterateChangesetsInput(
+            space.getId(),
+            hubWebClient().loadConnector(space.getStorage().getId()).params,
+            space().getExtension() != null ? space().resolveCompositeParams(superSpace()) : null,
+            targetContext,
+            space.getVersionsToKeep(),
+            minSpaceVersion,
+            versionRef,
+            -1L, //startTime TBD
+            -1L, //endTime TBD
+            squashedData,
+            operation);
   }
 
   private ExportQueryBuilder getQueryBuilder() {
@@ -574,7 +628,7 @@ public class ExportSpaceToFiles extends TaskedSpaceBasedStep<ExportSpaceToFiles,
   private record TransportStatistics(long rowCount, long byteSize, int fileCount) {}
 
   public enum OutputType {
-    FolderPatch,
-    FlatPatch
+    FOLDER_PATCH,
+    FLAT_PATCH
   }
 }

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/ExportSpaceToFiles.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/ExportSpaceToFiles.java
@@ -68,6 +68,8 @@ import javax.xml.crypto.dsig.TransformException;
 import org.geotools.api.referencing.FactoryException;
 import org.locationtech.jts.geom.Geometry;
 
+import static com.here.xyz.jobs.steps.impl.transport.ExportSpaceToFiles.OutputType.FolderPatch;
+
 
 /**
  * The {@code ExportSpaceToFiles} class represents a step in a data processing workflow that exports data
@@ -108,6 +110,11 @@ public class ExportSpaceToFiles extends TaskedSpaceBasedStep<ExportSpaceToFiles,
 
   @JsonView({Internal.class, Static.class})
   private int estimatedSeconds = -1;
+
+  @JsonView({Internal.class, Static.class})
+  protected boolean squashedData;
+  @JsonView({Internal.class, Static.class})
+  protected OutputType outputType = FolderPatch;
 
   @JsonView({Internal.class, Static.class})
   protected SpatialFilter spatialFilter;
@@ -187,6 +194,19 @@ public class ExportSpaceToFiles extends TaskedSpaceBasedStep<ExportSpaceToFiles,
   @Override
   protected boolean queryRunsOnWriter() throws WebClientException, SQLException, TooManyResourcesClaimed {
     return false;
+  }
+
+  public OutputType getOutputType() {
+    return outputType;
+  }
+
+  public void setOutputType(OutputType outputType) {
+    this.outputType = outputType;
+  }
+
+  public ExportSpaceToFiles withOutputType(OutputType outputType) {
+    setOutputType(outputType);
+    return this;
   }
 
   /**
@@ -401,15 +421,17 @@ public class ExportSpaceToFiles extends TaskedSpaceBasedStep<ExportSpaceToFiles,
       taskListCount = (int) Math.min(calculatedTaskCount, MAX_TASK_COUNT);
     }
 
-    //Resolve the i-range once and persist it - together with the task count - into each task input. This keeps the
-    //thread partitioning stable across resumes, even if writes happened in between, instead of recomputing minI/maxI
-    //against a changed table state (see generateContentQueryForExportPlugin).
+    //Resolve the i-range once and pre-calculate the i-range boundaries per task, persisting startI / endI into each task
+    //input. This keeps the thread partitioning stable across resumes, even if writes happened in between, instead of
+    //recomputing it against a changed table state (see generateContentQueryForExportPlugin).
     IRange iRange = resolveIRange();
+    long iRangeSize = (long) Math.ceil((double) (iRange.maxI() - iRange.minI() + 1) / (double) taskListCount);
 
     List<ExportInput> taskDataList = new ArrayList<>();
     for (int i = 0; i < taskListCount; i++) {
-      //TODO: write only minI and maxI for each task
-      taskDataList.add(new ExportInput(i, iRange.minI(), iRange.maxI(), taskListCount));
+      long startI = iRange.minI() + i * iRangeSize;
+      long endI = startI + iRangeSize - 1;
+      taskDataList.add(new ExportInput(i, startI, endI));
     }
     return taskDataList;
   }
@@ -528,24 +550,14 @@ public class ExportSpaceToFiles extends TaskedSpaceBasedStep<ExportSpaceToFiles,
   protected String generateContentQueryForExportPlugin(ExportInput taskInput) throws WebClientException, TooManyResourcesClaimed,
       QueryBuildingException, InvalidGeometryException {
 
-    //We use the thread number as a condition for the query
-    int taskNumber = taskInput.threadId();
-
     GetFeaturesByGeometryBuilder queryBuilder = new GetFeaturesByGeometryBuilder()
         .withDataSourceProvider(requestResource(dbReader(), 0));
 
     GetFeaturesByGeometryInput input = createGetFeaturesByGeometryInput(context == null ? DEFAULT : context == EXTENSION ? X : context, spatialFilter, versionRef);
 
-    minI = taskInput.minI();
-    maxI = taskInput.maxI();
-    final int itemCount = taskInput.taskItemCount();
-
-    long iRangeSize = (long) Math.ceil((double) (maxI - minI + 1) / (double) itemCount);
-
-    SQLQuery threadCondition = new SQLQuery("i >= #{minI} + #{taskNumber} * #{iRangeSize} AND i < #{minI} + (#{taskNumber} + 1) * #{iRangeSize}")
-        .withNamedParameter("minI", minI)
-        .withNamedParameter("taskNumber", taskNumber)
-        .withNamedParameter("iRangeSize", iRangeSize);
+    SQLQuery threadCondition = new SQLQuery("i >= #{startI} AND i <= #{endI}")
+        .withNamedParameter("startI", taskInput.startI())
+        .withNamedParameter("endI", taskInput.endI());
 
     return queryBuilder
         .withAdditionalFilterFragment(threadCondition)
@@ -560,4 +572,9 @@ public class ExportSpaceToFiles extends TaskedSpaceBasedStep<ExportSpaceToFiles,
   }
 
   private record TransportStatistics(long rowCount, long byteSize, int fileCount) {}
+
+  public enum OutputType {
+    FolderPatch,
+    FlatPatch
+  }
 }

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/ExportSpaceToFiles.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/ExportSpaceToFiles.java
@@ -476,9 +476,17 @@ public class ExportSpaceToFiles extends TaskedSpaceBasedStep<ExportSpaceToFiles,
     if(outputType.equals(FLAT_PATCH))
       return new DownloadUrl().withS3Key(toS3Path(getOutputSet(EXPORTED_DATA)) + "/" + taskInput.threadId() + "/" + UUID.randomUUID() + ".json");
     else if(outputType.equals(FOLDER_PATCH))
-      return new DownloadUrl().withS3Key(toS3Path(getOutputSet(EXPORTED_DATA)) + "/" + taskInput.operation() + "/" + taskInput.threadId() + "/"  + UUID.randomUUID() + ".json");
+      return new DownloadUrl().withS3Key(toS3Path(getOutputSet(EXPORTED_DATA)) + "/" + toFolderName(taskInput.operation()) + "/" + taskInput.threadId() + "/"  + UUID.randomUUID() + ".json");
     else
       throw new StepException("Invalid outputType: " + outputType);
+  }
+
+  private static String toFolderName(Operation operation) {
+    return switch (operation) {
+      case INSERT -> "inserted";
+      case UPDATE -> "updated";
+      case DELETE -> "deleted";
+    };
   }
 
   @Override

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/TaskedSpaceBasedStep.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/TaskedSpaceBasedStep.java
@@ -1006,7 +1006,7 @@ public abstract class TaskedSpaceBasedStep<T extends TaskedSpaceBasedStep, I ext
               superSpace == null ? null : getRootTableName(superSpace));
     }
     catch (WebClientException e) {
-      throw new StepException("Unable to load resource.", e.getCause());
+      throw new StepException("Unable to load resource.", e);
     }
   }
 

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/tasks/inputs/ExportInput.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/tasks/inputs/ExportInput.java
@@ -19,22 +19,13 @@
 package com.here.xyz.jobs.steps.impl.transport.tasks.inputs;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.here.xyz.XyzSerializable;
-import com.here.xyz.jobs.steps.impl.transport.TaskedSpaceBasedStep;
 import com.here.xyz.jobs.steps.impl.transport.tasks.TaskPayload;
-import com.here.xyz.jobs.steps.impl.transport.tasks.outputs.ExportOutput;
+import static com.here.xyz.FeatureChange.Operation;
 
 @JsonTypeName("ExportInput")
-public record ExportInput(Integer threadId, String tileId, Long startI, Long endI) implements TaskPayload {
-  public ExportInput(){
-    this(null, null, null, null);
-  }
-  public ExportInput(Integer threadId) {
-    this(threadId, null, null, null);
-  }
+public record ExportInput(Integer threadId, String tileId, Long startI, Long endI, Operation operation) implements TaskPayload {
   public ExportInput(String tileId) {
-    this(null, tileId, null, null);
+    this(null, tileId, null, null, null);
   }
 
   /**
@@ -43,6 +34,10 @@ public record ExportInput(Integer threadId, String tileId, Long startI, Long end
    * even if writes happened in between - instead of being recomputed against a changed table state.
    */
   public ExportInput(Integer threadId, long startI, long endI) {
-    this(threadId, null, startI, endI);
+    this(threadId, null, startI, endI, null);
+  }
+
+  public ExportInput(Integer threadId, long startI, long endI,  Operation operation) {
+    this(threadId, null, startI, endI, operation);
   }
 }

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/tasks/inputs/ExportInput.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/tasks/inputs/ExportInput.java
@@ -26,23 +26,23 @@ import com.here.xyz.jobs.steps.impl.transport.tasks.TaskPayload;
 import com.here.xyz.jobs.steps.impl.transport.tasks.outputs.ExportOutput;
 
 @JsonTypeName("ExportInput")
-public record ExportInput(Integer threadId, String tileId, Long minI, Long maxI, Integer taskItemCount) implements TaskPayload {
+public record ExportInput(Integer threadId, String tileId, Long startI, Long endI) implements TaskPayload {
   public ExportInput(){
-    this(null, null, null, null, null);
+    this(null, null, null, null);
   }
   public ExportInput(Integer threadId) {
-    this(threadId, null, null, null, null);
+    this(threadId, null, null, null);
   }
   public ExportInput(String tileId) {
-    this(null, tileId, null, null, null);
+    this(null, tileId, null, null);
   }
 
   /**
-   * Persists the i-range partitioning parameters together with the task input. Storing them here ensures they are kept
-   * inside the {@code task_input} column of the job data table and therefore stay stable across resumes - even if writes
-   * happened in between - instead of being recomputed against a changed table state.
+   * Persists the pre-calculated i-range boundaries of this task together with the task input. Storing them here ensures
+   * they are kept inside the {@code task_input} column of the job data table and therefore stay stable across resumes -
+   * even if writes happened in between - instead of being recomputed against a changed table state.
    */
-  public ExportInput(Integer threadId, long minI, long maxI, int taskItemCount) {
-    this(threadId, null, minI, maxI, taskItemCount);
+  public ExportInput(Integer threadId, long startI, long endI) {
+    this(threadId, null, startI, endI);
   }
 }

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/tools/ExportQueryBuilder.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/tools/ExportQueryBuilder.java
@@ -55,4 +55,10 @@ public class ExportQueryBuilder extends DatabaseStepQueryBuilder{
             .withNamedParameter("contentQuery", contentQuery)
             .withQueryFragment("failureCallback",  failureCallback);
   }
+
+  public SQLQuery buildIRangeFragment(long startI, long endI) {
+    return new SQLQuery("i >= #{startI} AND i <= #{endI}")
+            .withNamedParameter("startI", startI)
+            .withNamedParameter("endI", endI);
+  }
 }

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/util/test/StepTestBase.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/util/test/StepTestBase.java
@@ -45,7 +45,6 @@ import com.here.xyz.jobs.steps.impl.DropIndexes;
 import com.here.xyz.jobs.steps.impl.transport.CountSpace;
 import com.here.xyz.jobs.steps.impl.transport.ExportSpaceToFiles;
 import com.here.xyz.jobs.steps.impl.transport.TaskedImportFilesToSpace;
-import com.here.xyz.jobs.steps.impl.transport.tools.DatabaseStepQueryBuilder;
 import com.here.xyz.jobs.steps.impl.transport.tools.ImportQueryBuilder;
 import com.here.xyz.jobs.steps.outputs.DownloadUrl;
 import com.here.xyz.jobs.steps.outputs.Output;
@@ -59,7 +58,6 @@ import com.here.xyz.models.hub.Branch;
 import com.here.xyz.models.hub.Ref;
 import com.here.xyz.models.hub.Space;
 import com.here.xyz.models.hub.Tag;
-import com.here.xyz.psql.query.QueryBuilder;
 import com.here.xyz.responses.StatisticsResponse;
 import com.here.xyz.util.db.SQLQuery;
 import com.here.xyz.util.db.datasource.DataSourceProvider;
@@ -499,7 +497,7 @@ public class StepTestBase {
     uploadFileToS3(Output.stepOutputS3Prefix(jobId, stepId, outputSetName) + "/" + UUID.randomUUID(), contentType, bytes, false);
   }
 
-  protected List<Feature> downloadFileAndDeSerializeFeatures(DownloadUrl output) throws IOException {
+  protected List<Feature> downloadFileAndDeserializeFeatures(DownloadUrl output) throws IOException {
     logger.info("Check file: {}", output.getS3Key());
     List<Feature> features = new ArrayList<>();
 

--- a/xyz-jobs/xyz-job-steps/src/test/java/com/here/xyz/jobs/steps/impl/export/ExportChangedTilesStepTest.java
+++ b/xyz-jobs/xyz-job-steps/src/test/java/com/here/xyz/jobs/steps/impl/export/ExportChangedTilesStepTest.java
@@ -20,6 +20,12 @@ package com.here.xyz.jobs.steps.impl.export;
 
 import com.here.xyz.XyzSerializable;
 import com.here.xyz.events.PropertiesQuery;
+import com.here.xyz.jobs.steps.impl.transport.ExportChangedTiles;
+import com.here.xyz.jobs.steps.impl.transport.ExportSpaceToFiles;
+import com.here.xyz.jobs.steps.outputs.DownloadUrl;
+import com.here.xyz.jobs.steps.outputs.FeatureStatistics;
+import com.here.xyz.jobs.steps.outputs.Output;
+import com.here.xyz.jobs.steps.outputs.TileInvalidations;
 import com.here.xyz.models.filters.SpatialFilter;
 import com.here.xyz.jobs.steps.impl.transport.ExportChangedTiles.QuadType;
 import com.here.xyz.models.geojson.coordinates.LinearRingCoordinates;
@@ -31,15 +37,24 @@ import com.here.xyz.models.geojson.implementation.FeatureCollection;
 import com.here.xyz.models.geojson.implementation.Polygon;
 import com.here.xyz.models.hub.Ref;
 import com.here.xyz.models.hub.Space;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.here.xyz.jobs.steps.Step.Visibility.SYSTEM;
+import static com.here.xyz.jobs.steps.Step.Visibility.USER;
 
 public class ExportChangedTilesStepTest extends ExportTestBase {
+    private static final Logger logger = LogManager.getLogger();
     private final static int VERSIONS_TO_KEEP = 100;
     private final String SPACE_ID_EXT = SPACE_ID + "_ext";
 
@@ -364,4 +379,65 @@ public class ExportChangedTilesStepTest extends ExportTestBase {
                         .withClip(false), null,
                 List.of(), new FeatureCollection());
     }
+
+  protected void executeExportChangedTilesStepAndCheckResults(String spaceId, int targetLevel,
+                                                              ExportChangedTiles.QuadType quadType, Ref versionRef,
+                                                              List<String> expectedTileInvalidations, FeatureCollection expectedFeatures)
+          throws IOException, InterruptedException {
+    executeExportChangedTilesStepAndCheckResults(spaceId, targetLevel, quadType, versionRef, null, null, expectedTileInvalidations, expectedFeatures);
+  }
+
+  protected void executeExportChangedTilesStepAndCheckResults(String spaceId, int targetLevel,
+                                                              ExportChangedTiles.QuadType quadType, Ref versionRef, SpatialFilter spatialFilter, PropertiesQuery propertiesQuery,
+                                                              List<String> expectedTileInvalidations, FeatureCollection expectedFeatures)
+          throws IOException, InterruptedException {
+
+    //Create Step definition
+    ExportSpaceToFiles step = new ExportChangedTiles()
+            .withQuadType(quadType)
+            .withTargetLevel(targetLevel)
+            .withVersionRef(versionRef)
+            .withPropertyFilter(propertiesQuery)
+            .withSpatialFilter(spatialFilter)
+            .withSpaceId(spaceId)
+            .withJobId(JOB_ID);
+
+    //Send Lambda Requests
+    sendLambdaStepRequestBlock(step, true);
+    checkExportChangedTilesOutputs(expectedFeatures, step.loadOutputs(USER), step.loadOutputs(SYSTEM), expectedTileInvalidations);
+  }
+
+  protected void checkExportChangedTilesOutputs(FeatureCollection expectedFeatures, List<Output> userOutputs,
+                                                List<Output> systemOutputs, List<String> expectedTileInvalidations) throws IOException {
+    List<Feature> exportedFeatures = new ArrayList<>();
+    boolean foundTileInvalidations = false;
+
+    List<Output> allOutputs = new ArrayList<>();
+    allOutputs.addAll(userOutputs);
+    allOutputs.addAll(systemOutputs);
+
+    for (Output output : allOutputs) {
+      if (output instanceof DownloadUrl downloadUrl)
+        exportedFeatures.addAll(downloadFileAndDeserializeFeatures(downloadUrl));
+        //TODO: FeatureStatistics could get only checked if we also support during simulation "UPDATE_CALLBACK"
+      else if (output instanceof FeatureStatistics statistics) {
+        System.out.println(statistics.getFeatureCount());
+        Assertions.assertEquals(expectedFeatures.getFeatures().size(), statistics.getFeatureCount());
+      } else if (output instanceof TileInvalidations tileInvalidations) {
+        foundTileInvalidations = true;
+        logger.info("TileInvalidations {} vs {}", expectedTileInvalidations, tileInvalidations.getTileIds());
+        Assertions.assertEquals(expectedTileInvalidations.size(), tileInvalidations.getTileIds().size());
+        Assertions.assertTrue(expectedTileInvalidations.containsAll(tileInvalidations.getTileIds()));
+      }
+    }
+    if (!expectedTileInvalidations.isEmpty())
+      Assertions.assertTrue(foundTileInvalidations);
+
+    List<String> expectedFeaturesIdList = expectedFeatures.getFeatures().stream().map(Feature::getId).collect(Collectors.toList());
+    List<String> exportedFeaturesFeaturesIdList = exportedFeatures.stream().map(Feature::getId).collect(Collectors.toList());
+
+    logger.info("FeaturesFeaturesIdList {} vs {}", expectedFeaturesIdList, exportedFeaturesFeaturesIdList);
+    Assertions.assertEquals(expectedFeaturesIdList.size(), exportedFeaturesFeaturesIdList.size());
+    Assertions.assertTrue(exportedFeaturesFeaturesIdList.containsAll(expectedFeaturesIdList));
+  }
 }

--- a/xyz-jobs/xyz-job-steps/src/test/java/com/here/xyz/jobs/steps/impl/export/ExportStepValidationTest.java
+++ b/xyz-jobs/xyz-job-steps/src/test/java/com/here/xyz/jobs/steps/impl/export/ExportStepValidationTest.java
@@ -142,7 +142,7 @@ public class ExportStepValidationTest extends StepTest {
         //TODO: Deduplicate the following from ExportTestBase
         for (Output output : userOutputs) {
             if (output instanceof DownloadUrl downloadUrl)
-                exportedFeatures.addAll(downloadFileAndDeSerializeFeatures(downloadUrl));
+                exportedFeatures.addAll(downloadFileAndDeserializeFeatures(downloadUrl));
             else if (output instanceof FeatureStatistics statistics)
                 Assertions.assertEquals(expectedFeatures.getFeatures().size(), statistics.getFeatureCount());
         }

--- a/xyz-jobs/xyz-job-steps/src/test/java/com/here/xyz/jobs/steps/impl/export/ExportTestBase.java
+++ b/xyz-jobs/xyz-job-steps/src/test/java/com/here/xyz/jobs/steps/impl/export/ExportTestBase.java
@@ -19,147 +19,186 @@
 
 package com.here.xyz.jobs.steps.impl.export;
 
-import static com.here.xyz.jobs.steps.Step.Visibility.SYSTEM;
-import static com.here.xyz.jobs.steps.Step.Visibility.USER;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.here.xyz.XyzSerializable;
 import com.here.xyz.events.ContextAwareEvent;
 import com.here.xyz.events.PropertiesQuery;
 import com.here.xyz.jobs.steps.impl.StepTest;
-import com.here.xyz.jobs.steps.impl.transport.ExportChangedTiles;
 import com.here.xyz.jobs.steps.impl.transport.ExportSpaceToFiles;
 import com.here.xyz.jobs.steps.outputs.DownloadUrl;
 import com.here.xyz.jobs.steps.outputs.FeatureStatistics;
 import com.here.xyz.jobs.steps.outputs.Output;
-import com.here.xyz.jobs.steps.outputs.TileInvalidations;
 import com.here.xyz.models.filters.SpatialFilter;
 import com.here.xyz.models.geojson.implementation.Feature;
 import com.here.xyz.models.geojson.implementation.FeatureCollection;
 import com.here.xyz.models.hub.Ref;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.Set;
-import java.util.stream.Collectors;
+import com.here.xyz.models.hub.Space;
+import com.here.xyz.models.hub.Tag;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
 
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 public class ExportTestBase extends StepTest {
-    private static final Logger logger = LogManager.getLogger();
+  private static final Logger logger = LogManager.getLogger();
 
-    protected void executeExportStepAndCheckResults(String spaceId, ContextAwareEvent.SpaceContext context,
-                                                    SpatialFilter spatialFilter, PropertiesQuery propertiesQuery,
-                                                    Ref versionRef,
-                                                    String hubPathAndQuery)
-            throws IOException, InterruptedException {
-        //Retrieve all Features from Space
-        FeatureCollection allExpectedFeatures = customReadFeaturesQuery(spaceId, hubPathAndQuery);
+  protected void executeExportStepAndCheckResults(String spaceId, ContextAwareEvent.SpaceContext context,
+                                                  SpatialFilter spatialFilter, PropertiesQuery propertiesQuery,
+                                                  Ref versionRef,
+                                                  String hubPathAndQuery)
+          throws IOException, InterruptedException {
+    //Retrieve all Features from Space
+    FeatureCollection allExpectedFeatures = customReadFeaturesQuery(spaceId, hubPathAndQuery);
 
-        //Create Step definition
-        ExportSpaceToFiles step = new ExportSpaceToFiles()
+    //Create Step definition
+    ExportSpaceToFiles step = new ExportSpaceToFiles()
+            .withThreadCount(10)
             .withSpaceId(spaceId)
             .withJobId(JOB_ID);
 
-        if(context != null)
-            step.setContext(context);
-        if(propertiesQuery != null)
-            step.setPropertyFilter(propertiesQuery);
-        if(spaceId != null)
-            step.setSpatialFilter(spatialFilter);
-        if(versionRef != null)
-            step.setVersionRef(versionRef);
+    if (context != null)
+      step.setContext(context);
+    if (propertiesQuery != null)
+      step.setPropertyFilter(propertiesQuery);
+    if (spaceId != null)
+      step.setSpatialFilter(spatialFilter);
+    if (versionRef != null)
+      step.setVersionRef(versionRef);
 
-        //Send Lambda Requests
-        sendLambdaStepRequestBlock(step, true);
-        checkOutputs(new HashSet<>(allExpectedFeatures.getFeatures()), step.loadOutputs());
+    //Send Lambda Requests
+    sendLambdaStepRequestBlock(step, true);
+    checkOutputs(new HashSet<>(allExpectedFeatures.getFeatures()), step.loadOutputs());
+  }
+
+  protected void checkOutputs(Set<Feature> expectedFeatures, List<Output> allOutputs)
+          throws IOException {
+    Assertions.assertNotEquals(0, allOutputs.size());
+
+    Set<Feature> exportedFeatures = new HashSet<>();
+    Set<FeatureStatistics> statistics = new HashSet<>();
+
+    for (Output output : allOutputs) {
+      if (output instanceof DownloadUrl downloadUrl)
+        exportedFeatures.addAll(downloadFileAndDeserializeFeatures(downloadUrl));
+        //TODO: FeatureStatistics could get only checked if we also support during simulation "UPDATE_CALLBACK"
+      else if (output instanceof FeatureStatistics s)
+        statistics.add(s);
     }
 
-    protected void checkOutputs(Set<Feature> expectedFeatures, List<Output> allOutputs)
-            throws IOException {
-        Assertions.assertNotEquals(0, allOutputs.size());
+    checkFeatures(exportedFeatures, expectedFeatures);
+    checkStatistics(statistics, expectedFeatures.size());
+  }
 
-        Set<Feature> exportedFeatures = new HashSet<>();
-        Set<FeatureStatistics> statistics = new HashSet<>();
+  protected static void checkFeatures(Set<Feature> exportedFeatures, Set<Feature> expectedFeatures) {
+    assertEquals(expectedFeatures.size(), exportedFeatures.size(), "Expected features count should match exported features");
 
-        for (Output output : allOutputs) {
-            if (output instanceof DownloadUrl downloadUrl)
-                exportedFeatures.addAll(downloadFileAndDeSerializeFeatures(downloadUrl));
-            //TODO: FeatureStatistics could get only checked if we also support during simulation "UPDATE_CALLBACK"
-            else if (output instanceof FeatureStatistics s)
-                statistics.add(s);
-        }
+    for (Feature f : expectedFeatures)
+      assertEquals(f, exportedFeatures.stream().filter(feature -> feature.getId().equals(f.getId())).findFirst().orElseThrow(() -> new NoSuchElementException("Expected feature with id \"" + f.getId() + "\" was not exported.")));
 
-        for (Feature f : expectedFeatures)
-            assertEquals(f, exportedFeatures.stream().filter(feature -> feature.getId().equals(f.getId())).findFirst().orElseThrow(() -> new NoSuchElementException("Expected feature with id \"" + f.getId() + "\" was not exported.")));
+    for (Feature f : exportedFeatures)
+      assertEquals(expectedFeatures.stream().filter(feature -> feature.getId().equals(f.getId())).findFirst().orElseThrow(() -> new NoSuchElementException("Exported feature with id \"" + f.getId() + "\" was not expected")), f);
+  }
 
-        for (Feature f : exportedFeatures)
-            assertEquals(expectedFeatures.stream().filter(feature -> feature.getId().equals(f.getId())).findFirst().orElseThrow(() -> new NoSuchElementException("Exported feature with id \"" + f.getId() + "\" was not expected")), f);
+  protected static void checkStatistics(Set<FeatureStatistics> statistics, int expectedCount) {
+    for (FeatureStatistics s : statistics)
+      assertEquals(s.getFeatureCount(), expectedCount);
+  }
 
-        for (FeatureStatistics s : statistics)
-            assertEquals(s.getFeatureCount(), expectedFeatures.size());
+  void createTestData(int v2k, boolean createTag) throws JsonProcessingException {
+    createSpace(new Space().withId(SPACE_ID).withVersionsToKeep(v2k), false);
+    //Add two new Features //TODO: Do not create FeatureCollections out of a String, create them using the Model instead
+    FeatureCollection fc1 = XyzSerializable.deserialize("""
+            {
+                 "type": "FeatureCollection",
+                 "features": [
+                     {
+                         "type": "Feature",
+                         "id": "point1",
+                         "properties": {
+                            "value" : "1"
+                         },
+                         "geometry": {
+                             "coordinates": [
+                                 8.43,
+                                 50.06
+                             ],
+                             "type": "Point"
+                         }
+                     },
+                     {
+                         "type": "Feature",
+                         "id": "point2",
+                         "properties": {
+                            "value" : "2"
+                         },
+                         "geometry": {
+                             "coordinates": [
+                                 8.49,
+                                 50.07
+                             ],
+                             "type": "Point"
+                         }
+                     }
+                 ]
+             }
+            """, FeatureCollection.class);
+
+    FeatureCollection fc2 = XyzSerializable.deserialize("""
+            {
+                 "type": "FeatureCollection",
+                 "features": [
+                     {
+                         "type": "Feature",
+                         "id": "point1",
+                         "properties": {
+                            "value" : "new"
+                         },
+                         "geometry": {
+                             "coordinates": [
+                                 8.43,
+                                 50.06
+                             ],
+                             "type": "Point"
+                         }
+                     },
+                     {
+                         "type": "Feature",
+                         "id": "point3",
+                         "properties": {
+                            "value" : "3"
+                         },
+                         "geometry": {
+                             "coordinates": [
+                                 8.49,
+                                 50.07
+                             ],
+                             "type": "Point"
+                         }
+                     }
+                 ]
+             }
+            """, FeatureCollection.class);
+
+    putFeatureCollectionToSpace(SPACE_ID, fc1);
+    //=> Version 1
+    deleteFeaturesInSpace(SPACE_ID, List.of("point2"));
+    //=> Version 2
+    putFeatureCollectionToSpace(SPACE_ID, fc2);
+    //=> Version 3
+    for (int i = 0; i < 10 ; i++) {
+      putRandomFeatureCollectionToSpace(SPACE_ID, 2);
     }
+    //=> Version 4-13
 
-    protected void executeExportChangedTilesStepAndCheckResults(String spaceId, int targetLevel,
-                                                                ExportChangedTiles.QuadType quadType, Ref versionRef,
-                                                                List<String> expectedTileInvalidations, FeatureCollection expectedFeatures)
-            throws IOException, InterruptedException {
-        executeExportChangedTilesStepAndCheckResults(spaceId, targetLevel, quadType, versionRef, null, null, expectedTileInvalidations, expectedFeatures);
-    }
-
-    protected void executeExportChangedTilesStepAndCheckResults(String spaceId, int targetLevel,
-                    ExportChangedTiles.QuadType quadType, Ref versionRef, SpatialFilter spatialFilter, PropertiesQuery propertiesQuery,
-                    List<String> expectedTileInvalidations, FeatureCollection expectedFeatures)
-            throws IOException, InterruptedException {
-
-        //Create Step definition
-        ExportSpaceToFiles step = new ExportChangedTiles()
-                .withQuadType(quadType)
-                .withTargetLevel(targetLevel)
-                .withVersionRef(versionRef)
-                .withPropertyFilter(propertiesQuery)
-                .withSpatialFilter(spatialFilter)
-                .withSpaceId(spaceId)
-                .withJobId(JOB_ID);
-
-        //Send Lambda Requests
-        sendLambdaStepRequestBlock(step, true);
-        checkExportChangedTilesOutputs(expectedFeatures, step.loadOutputs(USER), step.loadOutputs(SYSTEM), expectedTileInvalidations);
-    }
-
-    protected void checkExportChangedTilesOutputs(FeatureCollection expectedFeatures, List<Output> userOutputs,
-                                                  List<Output> systemOutputs, List<String> expectedTileInvalidations) throws IOException {
-        List<Feature>  exportedFeatures = new ArrayList<>();
-        boolean foundTileInvalidations = false;
-
-        List<Output> allOutputs = new ArrayList<>();
-        allOutputs.addAll(userOutputs);
-        allOutputs.addAll(systemOutputs);
-
-        for (Output output : allOutputs) {
-            if (output instanceof DownloadUrl downloadUrl)
-                exportedFeatures.addAll(downloadFileAndDeSerializeFeatures(downloadUrl));
-                //TODO: FeatureStatistics could get only checked if we also support during simulation "UPDATE_CALLBACK"
-            else if (output instanceof FeatureStatistics statistics) {
-                System.out.println(statistics.getFeatureCount());
-                Assertions.assertEquals(expectedFeatures.getFeatures().size(), statistics.getFeatureCount());
-            }else if (output instanceof TileInvalidations tileInvalidations) {
-                foundTileInvalidations = true;
-                logger.info("TileInvalidations {} vs {}",expectedTileInvalidations, tileInvalidations.getTileIds());
-                Assertions.assertEquals(expectedTileInvalidations.size(), tileInvalidations.getTileIds().size());
-                Assertions.assertTrue(expectedTileInvalidations.containsAll(tileInvalidations.getTileIds()));
-            }
-        }
-        if(!expectedTileInvalidations.isEmpty())
-          Assertions.assertTrue(foundTileInvalidations);
-
-        List<String> expectedFeaturesIdList = expectedFeatures.getFeatures().stream().map(Feature::getId).collect(Collectors.toList());
-        List<String> exportedFeaturesFeaturesIdList = exportedFeatures.stream().map(Feature::getId).collect(Collectors.toList());
-
-        logger.info("FeaturesFeaturesIdList {} vs {}",expectedFeaturesIdList, exportedFeaturesFeaturesIdList);
-        Assertions.assertEquals(expectedFeaturesIdList.size(), exportedFeaturesFeaturesIdList.size());
-        Assertions.assertTrue(exportedFeaturesFeaturesIdList.containsAll(expectedFeaturesIdList));
-    }
+    if(createTag)
+      //Tag prevents deletion of versions >=2
+      createTag(SPACE_ID, new Tag().withId("tag1").withVersion(2));
+  }
 }

--- a/xyz-jobs/xyz-job-steps/src/test/java/com/here/xyz/jobs/steps/impl/export/VersionRangeExportStepTest.java
+++ b/xyz-jobs/xyz-job-steps/src/test/java/com/here/xyz/jobs/steps/impl/export/VersionRangeExportStepTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2017-2026 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.xyz.jobs.steps.impl.export;
+
+import com.here.xyz.FeatureChange;
+import com.here.xyz.jobs.steps.impl.transport.ExportSpaceToFiles;
+import com.here.xyz.jobs.steps.outputs.DownloadUrl;
+import com.here.xyz.jobs.steps.outputs.FeatureStatistics;
+import com.here.xyz.jobs.steps.outputs.Output;
+import com.here.xyz.models.geojson.implementation.Feature;
+import com.here.xyz.models.hub.Ref;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static com.here.xyz.FeatureChange.Operation.DELETE;
+import static com.here.xyz.FeatureChange.Operation.INSERT;
+import static com.here.xyz.FeatureChange.Operation.UPDATE;
+import static com.here.xyz.events.ContextAwareEvent.SpaceContext;
+import static com.here.xyz.jobs.steps.impl.transport.ExportSpaceToFiles.OutputType;
+import static com.here.xyz.jobs.steps.impl.transport.ExportSpaceToFiles.OutputType.FOLDER_PATCH;
+
+public class VersionRangeExportStepTest extends ExportTestBase {
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    createTestData(100,false);
+  }
+
+  @Test
+  public void exportWithVersionRangeTest() throws IOException, InterruptedException {
+    Ref versionRef = new Ref("0..HEAD");
+
+    executeExportStepAndCheckResults(null, versionRef,
+            "changesets?versionRef=" + versionRef + "&squashed=true", FOLDER_PATCH);
+  }
+
+  protected void executeExportStepAndCheckResults(SpaceContext context, Ref versionRef, String hubPathAndQuery, OutputType outputType)
+          throws IOException, InterruptedException {
+
+    //Create Step definition
+    ExportSpaceToFiles step = new ExportSpaceToFiles()
+            .withSpaceId(SPACE_ID)
+            .withJobId(JOB_ID);
+    if (context != null)
+      step.setContext(context);
+    if (versionRef != null)
+      step.setVersionRef(versionRef);
+    if(outputType != null)
+      step.setOutputType(outputType);
+
+    //Send Lambda Requests
+    sendLambdaStepRequestBlock(step, true);
+    checkOutputs(step.loadOutputs(), hubPathAndQuery);
+  }
+
+  protected void checkOutputs(List<Output> allOutputs, String hubPathAndQuery)
+          throws IOException {
+
+    //Retrieve all Features from Space
+    Set<Feature> allExpectedInsertedFeatures = new HashSet<>(customReadFeaturesQuery(SPACE_ID, hubPathAndQuery + "&operation="+ FeatureChange.Operation.INSERT).getFeatures());
+    Set<Feature> allExpectedUpdatedFeatures = new HashSet<>(customReadFeaturesQuery(SPACE_ID, hubPathAndQuery  + "&operation="+ FeatureChange.Operation.UPDATE).getFeatures());
+    Set<Feature> allExpectedDeletedFeatures = new HashSet<>(customReadFeaturesQuery(SPACE_ID, hubPathAndQuery  + "&operation="+ FeatureChange.Operation.DELETE).getFeatures());
+
+    Assertions.assertNotEquals(0, allOutputs.size());
+    Set<Feature> exportedInsertedFeatures = new HashSet<>();
+    Set<Feature> exportedUpdatedFeatures = new HashSet<>();
+    Set<Feature> exportedDeletedFeatures = new HashSet<>();
+
+    Set<FeatureStatistics> statistics = new HashSet<>();
+
+    for (Output output : allOutputs) {
+      if (output instanceof DownloadUrl downloadUrl) {
+        if(downloadUrl.getUrl().toString().contains(INSERT.toString())) {
+          exportedInsertedFeatures.addAll(downloadFileAndDeserializeFeatures(downloadUrl));
+        }
+        if(downloadUrl.getUrl().toString().contains(UPDATE.toString())) {
+          exportedUpdatedFeatures.addAll(downloadFileAndDeserializeFeatures(downloadUrl));
+        }
+        if(downloadUrl.getUrl().toString().contains(DELETE.toString())) {
+          exportedDeletedFeatures.addAll(downloadFileAndDeserializeFeatures(downloadUrl));
+        }
+      }
+    }
+
+    checkFeatures(exportedInsertedFeatures, allExpectedInsertedFeatures);
+    checkFeatures(exportedUpdatedFeatures, allExpectedUpdatedFeatures);
+    checkFeatures(exportedDeletedFeatures, allExpectedDeletedFeatures);
+
+    checkStatistics(statistics, allExpectedInsertedFeatures.size() + allExpectedUpdatedFeatures.size() + allExpectedDeletedFeatures.size());
+  }
+}

--- a/xyz-jobs/xyz-job-steps/src/test/java/com/here/xyz/jobs/steps/impl/export/VersionRangeExportStepTest.java
+++ b/xyz-jobs/xyz-job-steps/src/test/java/com/here/xyz/jobs/steps/impl/export/VersionRangeExportStepTest.java
@@ -19,28 +19,26 @@
 
 package com.here.xyz.jobs.steps.impl.export;
 
-import com.here.xyz.FeatureChange;
-import com.here.xyz.jobs.steps.impl.transport.ExportSpaceToFiles;
-import com.here.xyz.jobs.steps.outputs.DownloadUrl;
-import com.here.xyz.jobs.steps.outputs.FeatureStatistics;
-import com.here.xyz.jobs.steps.outputs.Output;
-import com.here.xyz.models.geojson.implementation.Feature;
-import com.here.xyz.models.hub.Ref;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
-import java.io.IOException;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
 import static com.here.xyz.FeatureChange.Operation.DELETE;
 import static com.here.xyz.FeatureChange.Operation.INSERT;
 import static com.here.xyz.FeatureChange.Operation.UPDATE;
 import static com.here.xyz.events.ContextAwareEvent.SpaceContext;
 import static com.here.xyz.jobs.steps.impl.transport.ExportSpaceToFiles.OutputType;
 import static com.here.xyz.jobs.steps.impl.transport.ExportSpaceToFiles.OutputType.FOLDER_PATCH;
+
+import com.here.xyz.jobs.steps.impl.transport.ExportSpaceToFiles;
+import com.here.xyz.jobs.steps.outputs.DownloadUrl;
+import com.here.xyz.jobs.steps.outputs.FeatureStatistics;
+import com.here.xyz.jobs.steps.outputs.Output;
+import com.here.xyz.models.geojson.implementation.Feature;
+import com.here.xyz.models.hub.Ref;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class VersionRangeExportStepTest extends ExportTestBase {
 
@@ -80,9 +78,9 @@ public class VersionRangeExportStepTest extends ExportTestBase {
           throws IOException {
 
     //Retrieve all Features from Space
-    Set<Feature> allExpectedInsertedFeatures = new HashSet<>(customReadFeaturesQuery(SPACE_ID, hubPathAndQuery + "&operation="+ FeatureChange.Operation.INSERT).getFeatures());
-    Set<Feature> allExpectedUpdatedFeatures = new HashSet<>(customReadFeaturesQuery(SPACE_ID, hubPathAndQuery  + "&operation="+ FeatureChange.Operation.UPDATE).getFeatures());
-    Set<Feature> allExpectedDeletedFeatures = new HashSet<>(customReadFeaturesQuery(SPACE_ID, hubPathAndQuery  + "&operation="+ FeatureChange.Operation.DELETE).getFeatures());
+    Set<Feature> allExpectedInsertedFeatures = new HashSet<>(customReadFeaturesQuery(SPACE_ID, hubPathAndQuery + "&operation="+ INSERT).getFeatures());
+    Set<Feature> allExpectedUpdatedFeatures = new HashSet<>(customReadFeaturesQuery(SPACE_ID, hubPathAndQuery  + "&operation="+ UPDATE).getFeatures());
+    Set<Feature> allExpectedDeletedFeatures = new HashSet<>(customReadFeaturesQuery(SPACE_ID, hubPathAndQuery  + "&operation="+ DELETE).getFeatures());
 
     Assertions.assertNotEquals(0, allOutputs.size());
     Set<Feature> exportedInsertedFeatures = new HashSet<>();
@@ -93,13 +91,13 @@ public class VersionRangeExportStepTest extends ExportTestBase {
 
     for (Output output : allOutputs) {
       if (output instanceof DownloadUrl downloadUrl) {
-        if(downloadUrl.getUrl().toString().contains(INSERT.toString())) {
+        if (downloadUrl.getUrl().toString().contains("inserted")) {
           exportedInsertedFeatures.addAll(downloadFileAndDeserializeFeatures(downloadUrl));
         }
-        if(downloadUrl.getUrl().toString().contains(UPDATE.toString())) {
+        if (downloadUrl.getUrl().toString().contains("updated")) {
           exportedUpdatedFeatures.addAll(downloadFileAndDeserializeFeatures(downloadUrl));
         }
-        if(downloadUrl.getUrl().toString().contains(DELETE.toString())) {
+        if (downloadUrl.getUrl().toString().contains("deleted")) {
           exportedDeletedFeatures.addAll(downloadFileAndDeserializeFeatures(downloadUrl));
         }
       }

--- a/xyz-jobs/xyz-job-steps/src/test/java/com/here/xyz/jobs/steps/impl/export/VersionRefExportStepTest.java
+++ b/xyz-jobs/xyz-job-steps/src/test/java/com/here/xyz/jobs/steps/impl/export/VersionRefExportStepTest.java
@@ -19,109 +19,19 @@
 
 package com.here.xyz.jobs.steps.impl.export;
 
-import com.here.xyz.XyzSerializable;
-import com.here.xyz.models.geojson.implementation.FeatureCollection;
 import com.here.xyz.models.hub.Ref;
-import com.here.xyz.models.hub.Space;
-import com.here.xyz.models.hub.Tag;
-import java.io.IOException;
-import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+
 public class VersionRefExportStepTest extends ExportTestBase {
 
   @BeforeEach
   public void setUp() throws Exception {
-    createSpace(new Space().withId(SPACE_ID).withVersionsToKeep(2), false);
-    //Add two new Features //TODO: Do not create FeatureCollections out of a String, create them using the Model instead
-    FeatureCollection fc1 = XyzSerializable.deserialize("""
-            {
-                 "type": "FeatureCollection",
-                 "features": [
-                     {
-                         "type": "Feature",
-                         "id": "point1",
-                         "properties": {
-                            "value" : "1"
-                         },
-                         "geometry": {
-                             "coordinates": [
-                                 8.43,
-                                 50.06
-                             ],
-                             "type": "Point"
-                         }
-                     },
-                     {
-                         "type": "Feature",
-                         "id": "point2",
-                         "properties": {
-                            "value" : "2"
-                         },
-                         "geometry": {
-                             "coordinates": [
-                                 8.49,
-                                 50.07
-                             ],
-                             "type": "Point"
-                         }
-                     }
-                 ]
-             }
-            """, FeatureCollection.class);
-
-    FeatureCollection fc2 = XyzSerializable.deserialize("""
-            {
-                 "type": "FeatureCollection",
-                 "features": [
-                     {
-                         "type": "Feature",
-                         "id": "point1",
-                         "properties": {
-                            "value" : "new"
-                         },
-                         "geometry": {
-                             "coordinates": [
-                                 8.43,
-                                 50.06
-                             ],
-                             "type": "Point"
-                         }
-                     },
-                     {
-                         "type": "Feature",
-                         "id": "point3",
-                         "properties": {
-                            "value" : "3"
-                         },
-                         "geometry": {
-                             "coordinates": [
-                                 8.49,
-                                 50.07
-                             ],
-                             "type": "Point"
-                         }
-                     }
-                 ]
-             }
-            """, FeatureCollection.class);
-
-    putFeatureCollectionToSpace(SPACE_ID, fc1);
-    //=> Version 1
-    deleteFeaturesInSpace(SPACE_ID, List.of("point2"));
-    //=> Version 2
-    putFeatureCollectionToSpace(SPACE_ID, fc2);
-    //=> Version 3
-    for (int i = 0; i < 10 ; i++) {
-      putRandomFeatureCollectionToSpace(SPACE_ID, 2);
-    }
-    //=> Version 4-13
-
-    //Tag prevents deletion of versions >=2
-    createTag(SPACE_ID, new Tag().withId("tag1").withVersion(2));
+    createTestData(2,true);
   }
 
   @Test

--- a/xyz-models/src/main/java/com/here/xyz/events/IterateChangesetsEvent.java
+++ b/xyz-models/src/main/java/com/here/xyz/events/IterateChangesetsEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2025 HERE Europe B.V.
+ * Copyright (C) 2017-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ package com.here.xyz.events;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.here.xyz.FeatureChange.Operation;
 import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -29,6 +30,8 @@ public final class IterateChangesetsEvent extends IterateFeaturesEvent<IterateCh
   private List<String> authors;
   private long startTime;
   private long endTime;
+  private Operation operation;
+  private boolean squashed;
 
   public List<String> getAuthors() {
     return authors;
@@ -66,6 +69,32 @@ public final class IterateChangesetsEvent extends IterateFeaturesEvent<IterateCh
 
   public IterateChangesetsEvent withEndTime(long endTime) {
     setEndTime(endTime);
+    return this;
+  }
+
+  public Operation getOperation() {
+    return operation;
+  }
+
+  public void setOperation(Operation operation) {
+    this.operation = operation;
+  }
+
+  public IterateChangesetsEvent withOperation(Operation operation) {
+    setOperation(operation);
+    return this;
+  }
+
+  public boolean isSquashed() {
+    return squashed;
+  }
+
+  public void setSquashed(boolean squashed) {
+    this.squashed = squashed;
+  }
+
+  public IterateChangesetsEvent withSquashed(boolean squashed) {
+    setSquashed(squashed);
     return this;
   }
 }

--- a/xyz-models/src/main/java/com/here/xyz/events/IterateFeaturesEvent.java
+++ b/xyz-models/src/main/java/com/here/xyz/events/IterateFeaturesEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2025 HERE Europe B.V.
+ * Copyright (C) 2017-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public class IterateFeaturesEvent<T extends IterateFeaturesEvent> extends SearchForFeaturesEvent<T> {
 
   private String nextPageToken;
+  private long startI = -1; //NOTE: Not to be used in combination with nextPageToken
+  private long endI = -1; //NOTE: Not to be used in combination with nextPageToken
 
   @SuppressWarnings("unused")
   public String getNextPageToken() {
@@ -41,6 +43,32 @@ public class IterateFeaturesEvent<T extends IterateFeaturesEvent> extends Search
   @SuppressWarnings("unused")
   public T withNextPageToken(String nextPageToken) {
     setNextPageToken(nextPageToken);
+    return (T) this;
+  }
+
+  public long getStartI() {
+    return startI;
+  }
+
+  public void setStartI(long startI) {
+    this.startI = startI;
+  }
+
+  public T withStartI(long startI) {
+    setStartI(startI);
+    return (T) this;
+  }
+
+  public long getEndI() {
+    return endI;
+  }
+
+  public void setEndI(long endI) {
+    this.endI = endI;
+  }
+
+  public T withEndI(long endI) {
+    setEndI(endI);
     return (T) this;
   }
 }

--- a/xyz-models/src/main/java/com/here/xyz/responses/changesets/Changeset.java
+++ b/xyz-models/src/main/java/com/here/xyz/responses/changesets/Changeset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2025 HERE Europe B.V.
+ * Copyright (C) 2017-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ package com.here.xyz.responses.changesets;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.here.xyz.events.UpdateStrategy;
 import com.here.xyz.events.UpdateStrategy.OnExists;
@@ -28,8 +29,8 @@ import com.here.xyz.events.UpdateStrategy.OnMergeConflict;
 import com.here.xyz.events.UpdateStrategy.OnNotExists;
 import com.here.xyz.events.UpdateStrategy.OnVersionConflict;
 import com.here.xyz.events.WriteFeaturesEvent.Modification;
-import com.fasterxml.jackson.annotation.JsonView;
 import com.here.xyz.models.geojson.implementation.FeatureCollection;
+import com.here.xyz.models.hub.Ref;
 import com.here.xyz.responses.XyzResponse;
 import java.util.HashSet;
 import java.util.Set;
@@ -40,8 +41,15 @@ import java.util.Set;
  */
 @JsonInclude(Include.NON_DEFAULT)
 public class Changeset extends XyzResponse<Changeset> {
+
+  /**
+   * @deprecated Please use {@link #versionRef} instead
+   */
+  @Deprecated
   @JsonView({Public.class})
   long version = -1;
+  @JsonView({Public.class})
+  Ref versionRef;
   @JsonView({Public.class})
   String author;
   @JsonView({Public.class})
@@ -55,16 +63,41 @@ public class Changeset extends XyzResponse<Changeset> {
   @JsonView({Public.class})
   private String nextPageToken;
 
+  /**
+   * @deprecated Please use {@link #versionRef} instead
+   */
+  @Deprecated
   public long getVersion() {
     return version;
   }
 
+  /**
+   * @deprecated Please use {@link #versionRef} instead
+   */
+  @Deprecated
   public void setVersion(long version) {
     this.version = version;
   }
 
+  /**
+   * @deprecated Please use {@link #versionRef} instead
+   */
+  @Deprecated
   public Changeset withVersion(long version) {
     setVersion(version);
+    return this;
+  }
+
+  public Ref getVersionRef() {
+    return versionRef;
+  }
+
+  public void setVersionRef(Ref versionRef) {
+    this.versionRef = versionRef;
+  }
+
+  public Changeset withVersionRef(Ref versionRef) {
+    setVersionRef(versionRef);
     return this;
   }
 

--- a/xyz-models/src/main/java/com/here/xyz/responses/changesets/ChangesetCollection.java
+++ b/xyz-models/src/main/java/com/here/xyz/responses/changesets/ChangesetCollection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2025 HERE Europe B.V.
+ * Copyright (C) 2017-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonView;
+import com.here.xyz.models.hub.Ref;
 import com.here.xyz.responses.XyzResponse;
 import java.util.Map;
 
@@ -31,10 +32,20 @@ import java.util.Map;
 @JsonTypeName(value = "ChangesetCollection")
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class ChangesetCollection extends XyzResponse<ChangesetCollection> {
+  /**
+   * @deprecated Please use {@link #versionRef} instead
+   */
+  @Deprecated
   @JsonView({Public.class})
   private long startVersion;
+  /**
+   * @deprecated Please use {@link #versionRef} instead
+   */
+  @Deprecated
   @JsonView({Public.class})
   private long endVersion;
+  @JsonView({Public.class})
+  private Ref versionRef;
 
   @JsonView({Public.class})
   @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
@@ -58,29 +69,67 @@ public class ChangesetCollection extends XyzResponse<ChangesetCollection> {
     setNextPageToken(nextPageToken);
     return this;
   }
+
+  /**
+   * @deprecated Please use {@link #versionRef} instead
+   */
+  @Deprecated
   public long getStartVersion() {
     return startVersion;
   }
 
+  /**
+   * @deprecated Please use {@link #versionRef} instead
+   */
+  @Deprecated
   public void setStartVersion(long startVersion) {
     this.startVersion = startVersion;
   }
 
+  /**
+   * @deprecated Please use {@link #versionRef} instead
+   */
+  @Deprecated
   public ChangesetCollection withStartVersion(long startVersion) {
     setStartVersion(startVersion);
     return this;
   }
 
+  /**
+   * @deprecated Please use {@link #versionRef} instead
+   */
+  @Deprecated
   public long getEndVersion() {
     return endVersion;
   }
 
+  /**
+   * @deprecated Please use {@link #versionRef} instead
+   */
+  @Deprecated
   public void setEndVersion(long endVersion) {
     this.endVersion = endVersion;
   }
 
+  /**
+   * @deprecated Please use {@link #versionRef} instead
+   */
+  @Deprecated
   public ChangesetCollection withEndVersion(long withEndVersion) {
     setEndVersion(withEndVersion);
+    return this;
+  }
+
+  public Ref getVersionRef() {
+    return versionRef;
+  }
+
+  public void setVersionRef(Ref versionRef) {
+    this.versionRef = versionRef;
+  }
+
+  public ChangesetCollection withVersionRef(Ref versionRef) {
+    setVersionRef(versionRef);
     return this;
   }
 

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/NLConnector.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/NLConnector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2025 HERE Europe B.V.
+ * Copyright (C) 2017-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,14 @@
  */
 
 package com.here.xyz.psql;
+
+import static com.here.xyz.events.UpdateStrategy.OnExists;
+import static com.here.xyz.events.UpdateStrategy.OnNotExists;
+import static com.here.xyz.responses.XyzError.NOT_IMPLEMENTED;
+import static com.here.xyz.util.db.ConnectorParameters.TableLayout.NEW_LAYOUT;
+import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.GLOBAL_VERSION_PROPERTY_KEY;
+import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.REFERENCES_PROPERTY_KEY;
+import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.REF_QUAD_PROPERTY_KEY;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.here.xyz.XyzSerializable;
@@ -43,16 +51,10 @@ import com.here.xyz.events.PropertyQueryList;
 import com.here.xyz.events.SearchForFeaturesEvent;
 import com.here.xyz.events.UpdateStrategy;
 import com.here.xyz.events.WriteFeaturesEvent;
-import com.here.xyz.models.geojson.WebMercatorTile;
-import com.here.xyz.models.geojson.coordinates.BBox;
-import com.here.xyz.models.geojson.coordinates.LinearRingCoordinates;
-import com.here.xyz.models.geojson.coordinates.PolygonCoordinates;
-import com.here.xyz.models.geojson.coordinates.Position;
 import com.here.xyz.models.geojson.implementation.Feature;
 import com.here.xyz.models.geojson.implementation.FeatureCollection;
 import com.here.xyz.models.geojson.implementation.FeatureCollection.ModificationFailure;
 import com.here.xyz.models.geojson.implementation.Geometry;
-import com.here.xyz.models.geojson.implementation.Polygon;
 import com.here.xyz.models.geojson.implementation.Properties;
 import com.here.xyz.models.geojson.implementation.XyzNamespace;
 import com.here.xyz.psql.query.EraseSpace;
@@ -69,15 +71,9 @@ import com.here.xyz.responses.BinaryResponse;
 import com.here.xyz.responses.ChangesetsStatisticsResponse;
 import com.here.xyz.responses.StatisticsResponse;
 import com.here.xyz.responses.SuccessResponse;
-import com.here.xyz.responses.changesets.ChangesetCollection;
+import com.here.xyz.responses.XyzResponse;
 import com.here.xyz.util.Random;
 import io.vertx.core.json.JsonObject;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.locationtech.jts.geom.Coordinate;
-import org.locationtech.jts.io.WKBWriter;
-import org.postgresql.util.PGobject;
-
 import java.sql.Array;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -88,15 +84,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-
-import static com.here.xyz.util.db.ConnectorParameters.TableLayout.NEW_LAYOUT;
-import static com.here.xyz.events.UpdateStrategy.OnExists;
-import static com.here.xyz.events.UpdateStrategy.OnNotExists;
-import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.REF_QUAD_PROPERTY_KEY;
-import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.GLOBAL_VERSION_PROPERTY_KEY;
-import static com.here.xyz.util.db.pg.XyzSpaceTableHelper.REFERENCES_PROPERTY_KEY;
-
-import static com.here.xyz.responses.XyzError.NOT_IMPLEMENTED;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.io.WKBWriter;
+import org.postgresql.util.PGobject;
 
 public class NLConnector extends PSQLXyzConnector {
   private static final Logger logger = LogManager.getLogger();
@@ -359,7 +351,7 @@ public class NLConnector extends PSQLXyzConnector {
   }
 
   @Override
-  protected ChangesetCollection processIterateChangesetsEvent(IterateChangesetsEvent event) throws Exception {
+  protected XyzResponse processIterateChangesetsEvent(IterateChangesetsEvent event) throws Exception {
     throw new ErrorResponseException(NOT_IMPLEMENTED, "Method not implemented in NLConnector!");
   }
 

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/PSQLXyzConnector.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/PSQLXyzConnector.java
@@ -229,7 +229,7 @@ public class PSQLXyzConnector extends DatabaseHandler {
 
   @Override
   protected XyzResponse processIterateChangesetsEvent(IterateChangesetsEvent event) throws Exception {
-    //TBD: check why this is needed
+    //TBD: check why the cast is necessary
     return (XyzResponse) run(new IterateChangesets(event));
   }
 

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/PSQLXyzConnector.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/PSQLXyzConnector.java
@@ -229,7 +229,8 @@ public class PSQLXyzConnector extends DatabaseHandler {
 
   @Override
   protected XyzResponse processIterateChangesetsEvent(IterateChangesetsEvent event) throws Exception {
-    return run(new IterateChangesets(event));
+    //TBD: check why this is needed
+    return (XyzResponse) run(new IterateChangesets(event));
   }
 
   @Override

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/PSQLXyzConnector.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/PSQLXyzConnector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2025 HERE Europe B.V.
+ * Copyright (C) 2017-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,7 +79,6 @@ import com.here.xyz.responses.StatisticsResponse;
 import com.here.xyz.responses.StorageStatistics;
 import com.here.xyz.responses.SuccessResponse;
 import com.here.xyz.responses.XyzResponse;
-import com.here.xyz.responses.changesets.ChangesetCollection;
 import com.here.xyz.util.db.SQLQuery;
 import java.sql.SQLException;
 import java.util.List;
@@ -229,7 +228,7 @@ public class PSQLXyzConnector extends DatabaseHandler {
   }
 
   @Override
-  protected ChangesetCollection processIterateChangesetsEvent(IterateChangesetsEvent event) throws Exception {
+  protected XyzResponse processIterateChangesetsEvent(IterateChangesetsEvent event) throws Exception {
     return run(new IterateChangesets(event));
   }
 

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/IterateChangesets.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/IterateChangesets.java
@@ -321,7 +321,7 @@ public class IterateChangesets<R  extends XyzResponse> extends IterateFeatures<I
       nextPageToken = createNextPageToken();
 
     if (event.isSquashed())
-      return (R) versions.get(-1);
+      return (R) versions.get(-1l);
 
     return (R) new ChangesetCollection()
         .withStartVersion(startVersion)

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/IterateChangesets.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/IterateChangesets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2025 HERE Europe B.V.
+ * Copyright (C) 2017-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import com.here.xyz.models.geojson.implementation.Feature;
 import com.here.xyz.models.hub.Ref;
 import com.here.xyz.psql.query.helpers.versioning.GetHeadVersion;
 import com.here.xyz.psql.query.helpers.versioning.GetMinVersion;
+import com.here.xyz.responses.XyzResponse;
 import com.here.xyz.responses.changesets.Changeset;
 import com.here.xyz.responses.changesets.ChangesetCollection;
 import com.here.xyz.util.db.SQLQuery;
@@ -40,12 +41,15 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class IterateChangesets extends IterateFeatures<IterateChangesetsEvent, ChangesetCollection> {
+public class IterateChangesets<R  extends XyzResponse> extends IterateFeatures<IterateChangesetsEvent, R> {
   public static long DEFAULT_LIMIT = 1_000l;
   private long limit;
   private IterateChangesetsEvent event; //TODO: Do not store the whole event during the request phase
   private long nextTokenVersion;
   private String nextTokenId;
+
+  //TODO: use i for pagination in case of squashing
+
 
   public IterateChangesets(IterateChangesetsEvent event) throws SQLException, ErrorResponseException {
     super(event);
@@ -60,6 +64,10 @@ public class IterateChangesets extends IterateFeatures<IterateChangesetsEvent, C
 
   @Override
   protected String buildOrderByFragment(ContextAwareEvent event) {
+    if (this.event.isSquashed())
+      //No sorting by version is necessary when squashing
+      return super.buildOrderByFragment(event);
+
     if( event.getBranchPath() == null || event.getBranchPath().isEmpty() )
      return "ORDER BY ${schema}.${table}.version, id";
     else
@@ -103,7 +111,7 @@ public class IterateChangesets extends IterateFeatures<IterateChangesetsEvent, C
   }
 
   @Override
-  public ChangesetCollection run(DataSourceProvider dataSourceProvider) throws SQLException, ErrorResponseException {
+  public R run(DataSourceProvider dataSourceProvider) throws SQLException, ErrorResponseException {
     long headVersion = new GetHeadVersion<>(event).withDataSourceProvider(dataSourceProvider).run();
     long minAvailableVersion = headVersion - event.getVersionsToKeep() + 1;
 
@@ -140,6 +148,9 @@ public class IterateChangesets extends IterateFeatures<IterateChangesetsEvent, C
   }
 
   protected SQLQuery buildFilterWhereClause(IterateChangesetsEvent event) {
+
+    //TODO: Enhance filter clause to filter by specified operation
+
     SQLQuery authorsFilter = null, startTimeFilter = null, endTimeFilter = null;
 
     if (event.getAuthors() != null && !event.getAuthors().isEmpty())
@@ -186,6 +197,9 @@ public class IterateChangesets extends IterateFeatures<IterateChangesetsEvent, C
   //TODO: Check if that mechanism for preventing the last empty page (edge case) can be prevented also for IterateFeatures by pulling this up
   @Override
   protected SQLQuery buildLimitFragment(IterateChangesetsEvent event) {
+    if (event.ignoreLimit)
+      return new SQLQuery("");
+
     //Query one more feature as requested, to be able to determine if we need to include a nextPageToken
     return new SQLQuery("LIMIT #{limit}").withNamedParameter("limit", event.getLimit() + 1);
   }
@@ -196,7 +210,12 @@ public class IterateChangesets extends IterateFeatures<IterateChangesetsEvent, C
     return new SQLQuery("");
   }
 
-  public ChangesetCollection handle(ResultSet rs) throws SQLException {
+  @Override
+  public R handle(ResultSet rs) throws SQLException {
+    //Respond with a simple FeatureCollection for squashed changesets were requested for a single operation
+    if (event.isSquashed() && event.getOperation() != null)
+      return super.handle(rs);
+
     Map<Long, Changeset> versions = new HashMap<>();
 
     long numFeatures = 0;
@@ -217,7 +236,7 @@ public class IterateChangesets extends IterateFeatures<IterateChangesetsEvent, C
         break;
 
       String operation = rs.getString("operation");
-      long version = rs.getLong("version");
+      long version = event.isSquashed() ? -1 : rs.getLong("version");
 
       if (!writeStarted) {
         startVersion = version;
@@ -247,7 +266,8 @@ public class IterateChangesets extends IterateFeatures<IterateChangesetsEvent, C
           createdAt = firstFeature.getProperties().getXyzNamespace().getUpdatedAt();
         }
         catch (JsonProcessingException e) {
-          throw new SQLException("Can't read feature json from database!", e);
+          //TODO: Throw ErrorResponseException instead
+          throw new SQLException("Can't parse feature json from database!", e);
         }
       }
 
@@ -289,7 +309,10 @@ public class IterateChangesets extends IterateFeatures<IterateChangesetsEvent, C
     if (numFeatures > 0 && numFeatures == limit + 1 && numFeatures > limit)
       nextPageToken = createNextPageToken();
 
-    return new ChangesetCollection()
+    if (event.isSquashed())
+      return (R) versions.get(-1);
+
+    return (R) new ChangesetCollection()
         .withStartVersion(startVersion)
         .withEndVersion(prevVersion)
         .withVersions(versions)

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/IterateChangesets.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/IterateChangesets.java
@@ -321,7 +321,8 @@ public class IterateChangesets<R  extends XyzResponse> extends IterateFeatures<I
       nextPageToken = createNextPageToken();
 
     if (event.isSquashed())
-      return (R) versions.get(-1l);
+      return (R) versions.get(-1l)
+          .withVersionRef(event.getRef());
 
     return (R) new ChangesetCollection()
         .withStartVersion(startVersion)

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/IterateChangesets.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/IterateChangesets.java
@@ -66,7 +66,7 @@ public class IterateChangesets<R  extends XyzResponse> extends IterateFeatures<I
   protected String buildOrderByFragment(ContextAwareEvent event) {
     if (this.event.isSquashed())
       //No sorting by version is necessary when squashing
-      return super.buildOrderByFragment(event);
+      return ""; //TODO: Activate again, once i is used for iteration
 
     if( event.getBranchPath() == null || event.getBranchPath().isEmpty() )
      return "ORDER BY ${schema}.${table}.version, id";

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/IterateChangesets.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/IterateChangesets.java
@@ -49,9 +49,6 @@ public class IterateChangesets<R  extends XyzResponse> extends IterateFeatures<I
   private long nextTokenVersion;
   private String nextTokenId;
 
-  //TODO: use i for pagination in case of squashing
-
-
   public IterateChangesets(IterateChangesetsEvent event) throws SQLException, ErrorResponseException {
     super(event);
     this.event = event;
@@ -77,6 +74,9 @@ public class IterateChangesets<R  extends XyzResponse> extends IterateFeatures<I
 
   @Override
   protected SQLQuery buildOffsetFilterFragment(IterateFeaturesEvent event, int dataset) {
+    if (event instanceof IterateChangesetsEvent ice && ice.isSquashed() && (ice.getStartI() >= 0 || event.getEndI() >= 0))
+      return super.buildOffsetFilterFragment(event, dataset);
+
     if (event.getNextPageToken() == null)
       return new SQLQuery("");
 

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/IterateChangesets.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/IterateChangesets.java
@@ -21,6 +21,7 @@ package com.here.xyz.psql.query;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.Lists;
+import com.here.xyz.FeatureChange;
 import com.here.xyz.XyzSerializable;
 import com.here.xyz.connectors.ErrorResponseException;
 import com.here.xyz.events.ContextAwareEvent;
@@ -148,14 +149,15 @@ public class IterateChangesets<R  extends XyzResponse> extends IterateFeatures<I
   }
 
   protected SQLQuery buildFilterWhereClause(IterateChangesetsEvent event) {
-
-    //TODO: Enhance filter clause to filter by specified operation
-
-    SQLQuery authorsFilter = null, startTimeFilter = null, endTimeFilter = null;
+    SQLQuery authorsFilter = null, operationFilter = null, startTimeFilter = null, endTimeFilter = null;
 
     if (event.getAuthors() != null && !event.getAuthors().isEmpty())
       authorsFilter = new SQLQuery("author = ANY(#{authors})")
           .withNamedParameter("authors", event.getAuthors().toArray(String[]::new));
+
+    if (event.getOperation() != null)
+      operationFilter = new SQLQuery("operation = ANY(#{operations})")
+          .withNamedParameter("operations", toDbOperations(event.getOperation()));
 
     if (event.getStartTime() > 0)
       startTimeFilter = buildTimeFilter()
@@ -173,13 +175,22 @@ public class IterateChangesets<R  extends XyzResponse> extends IterateFeatures<I
           .withQueryFragment("versionOperand", "0")
           .withQueryFragment("timeOperand", "" + event.getEndTime());
 
-    List<SQLQuery> filters = Lists.newArrayList(authorsFilter, startTimeFilter, endTimeFilter).stream()
+    List<SQLQuery> filters = Lists.newArrayList(authorsFilter, operationFilter, startTimeFilter, endTimeFilter).stream()
         .filter(q -> q != null)
         .toList();
 
     return filters.isEmpty()
         ? super.buildFilterWhereClause(event)
         : SQLQuery.join(filters, " AND ");
+  }
+
+  //Maps a logical FeatureChange.Operation to its corresponding database operation codes
+  private static String[] toDbOperations(FeatureChange.Operation operation) {
+    return switch (operation) {
+      case INSERT -> new String[] {"I", "H"};
+      case UPDATE -> new String[] {"U", "J"};
+      case DELETE -> new String[] {"D"};
+    };
   }
 
   private static SQLQuery buildTimeFilter() {

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/IterateChangesets.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/IterateChangesets.java
@@ -136,7 +136,7 @@ public class IterateChangesets<R  extends XyzResponse> extends IterateFeatures<I
   @Override
   protected SQLQuery buildNextVersionFragment(Ref ref, boolean historyEnabled, String versionParamName, long baseVersion) {
     //TODO: Check if this check could be pulled up, because when requesting history versions from a range, the next-version anyways should not play any role
-    if (ref.isRange())
+    if (ref.isRange() && !event.isSquashed())
       return new SQLQuery("");
     return super.buildNextVersionFragment(ref, historyEnabled, versionParamName, baseVersion);
   }

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/IterateChangesets.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/IterateChangesets.java
@@ -321,7 +321,7 @@ public class IterateChangesets<R  extends XyzResponse> extends IterateFeatures<I
 
     //Only create a nextPageToken if there are further results
     String nextPageToken = null;
-    if (numFeatures > 0 && numFeatures == limit + 1 && numFeatures > limit)
+    if (!event.ignoreLimit && numFeatures > 0 && numFeatures == limit + 1 && numFeatures > limit)
       nextPageToken = createNextPageToken();
 
     if (event.isSquashed())

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/IterateChangesets.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/IterateChangesets.java
@@ -57,14 +57,18 @@ public class IterateChangesets<R  extends XyzResponse> extends IterateFeatures<I
 
   @Override
   protected String buildOuterOrderByFragment(ContextAwareEvent event) {
-    return this.buildOrderByFragment(event);
+    return buildOrderByFragment(event);
   }
 
   @Override
   protected String buildOrderByFragment(ContextAwareEvent event) {
     if (this.event.isSquashed())
-      //No sorting by version is necessary when squashing
-      return ""; //TODO: Activate again, once i is used for iteration
+      /*
+      NOTE:
+      No sorting by version is necessary when squashing. Also sorting by i is not necessary in that case, because startI / endI are
+      used instead of a start offset & limit.
+       */
+      return ""; //TODO: Ensure proper paging when nextPageToken is being used
 
     if( event.getBranchPath() == null || event.getBranchPath().isEmpty() )
      return "ORDER BY ${schema}.${table}.version, id";

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/IterateChangesetsBuilder.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/IterateChangesetsBuilder.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2017-2026 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.xyz.psql.query;
+
+import static com.here.xyz.models.hub.Ref.HEAD;
+
+import com.here.xyz.FeatureChange.Operation;
+import com.here.xyz.events.ContextAwareEvent.SpaceContext;
+import com.here.xyz.events.IterateChangesetsEvent;
+import com.here.xyz.models.hub.Ref;
+import com.here.xyz.psql.query.IterateChangesetsBuilder.IterateChangesetsInput;
+import com.here.xyz.util.db.SQLQuery;
+import java.util.Map;
+
+public class IterateChangesetsBuilder extends XyzQueryBuilder<IterateChangesetsInput>{
+
+
+  @Override
+  protected SQLQuery buildQuery(IterateChangesetsInput input) throws QueryBuildingException {
+    /*
+    TODO: Provide the possibility to specify the following via the input:
+    - the parts of the page token separately & in plain form
+    - the desired operation (e.g. inserted, updated, deleted) to be returned
+     */
+
+    //TODO: Remove that workaround when refactoring is complete
+    IterateChangesetsEvent event = new IterateChangesetsEvent()
+        .withSpace(input.spaceId)
+        .withConnectorParams(input.connectorParams)
+        .withParams(input.spaceParams)
+        .withVersionsToKeep(input.versionsToKeep)
+        .withContext(input.context)
+        .withRef(input.ref)
+        .withMinVersion(input.minVersion)
+        .withStartTime(input.startTime)
+        .withEndTime(input.endTime)
+        .withOperation(input.operation)
+        .withSquashed(input.squashed);
+
+    //TODO: Use nextPageToken once it supports also an upper I-bound instead of a limit
+
+
+    event.ignoreLimit = true;
+
+    return null;
+  }
+
+  public record IterateChangesetsInput(
+      String spaceId,
+      Map<String, Object> connectorParams,
+      Map<String, Object> spaceParams,
+      SpaceContext context,
+      int versionsToKeep,
+      long minVersion,
+      Ref ref,
+
+      long startTime, //optional instead of ref
+      long endTime, //optional instead of ref
+      boolean squashed,
+
+      Operation operation //Optional: Only return changes with the specified operation
+  ) {
+    public IterateChangesetsInput {
+      if (ref == null)
+        ref = new Ref(HEAD);
+    }
+  }
+}

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/IterateChangesetsBuilder.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/IterateChangesetsBuilder.java
@@ -33,7 +33,7 @@ public class IterateChangesetsBuilder extends XyzQueryBuilder<IterateChangesetsI
 
 
   @Override
-  protected SQLQuery buildQuery(IterateChangesetsInput input) throws QueryBuildingException {
+  public SQLQuery buildQuery(IterateChangesetsInput input) throws QueryBuildingException {
     /*
     TODO: Provide the possibility to specify the following via the input:
     - the parts of the page token separately & in plain form

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/IterateChangesetsBuilder.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/IterateChangesetsBuilder.java
@@ -40,8 +40,7 @@ public class IterateChangesetsBuilder extends XyzQueryBuilder<IterateChangesetsI
   public SQLQuery buildQuery(IterateChangesetsInput input) throws QueryBuildingException {
     /*
     TODO: Provide the possibility to specify the following via the input:
-    - the parts of the page token separately & in plain form
-    - the desired operation (e.g. inserted, updated, deleted) to be returned
+    - the parts of the page token separately & in plain form (dataset still missing, for the time being the I-range is calculated "globally" outside - in the step impl)
      */
 
     //TODO: Remove that workaround when refactoring is complete
@@ -56,10 +55,9 @@ public class IterateChangesetsBuilder extends XyzQueryBuilder<IterateChangesetsI
         .withStartTime(input.startTime)
         .withEndTime(input.endTime)
         .withOperation(input.operation)
-        .withSquashed(input.squashed);
-
-    //TODO: Use nextPageToken once it supports also an upper I-bound instead of a limit
-
+        .withSquashed(input.squashed)
+        .withStartI(input.startI)
+        .withEndI(input.endI);
 
     event.ignoreLimit = true;
 
@@ -99,7 +97,10 @@ public class IterateChangesetsBuilder extends XyzQueryBuilder<IterateChangesetsI
       long endTime, //optional instead of ref
       boolean squashed,
 
-      Operation operation //Optional: Only return changes with the specified operation
+      Operation operation, //Optional: Only return changes with the specified operation
+
+      long startI, //Optional: Only return changes with i >= startI
+      long endI //Optional: Only return changes with i <= endI
   ) {
     public IterateChangesetsInput {
       if (ref == null)

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/IterateChangesetsBuilder.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/IterateChangesetsBuilder.java
@@ -22,11 +22,15 @@ package com.here.xyz.psql.query;
 import static com.here.xyz.models.hub.Ref.HEAD;
 
 import com.here.xyz.FeatureChange.Operation;
+import com.here.xyz.connectors.ErrorResponseException;
 import com.here.xyz.events.ContextAwareEvent.SpaceContext;
 import com.here.xyz.events.IterateChangesetsEvent;
+import com.here.xyz.models.geojson.implementation.FeatureCollection;
 import com.here.xyz.models.hub.Ref;
 import com.here.xyz.psql.query.IterateChangesetsBuilder.IterateChangesetsInput;
+import com.here.xyz.responses.XyzResponse;
 import com.here.xyz.util.db.SQLQuery;
+import java.sql.SQLException;
 import java.util.Map;
 
 public class IterateChangesetsBuilder extends XyzQueryBuilder<IterateChangesetsInput>{
@@ -59,7 +63,27 @@ public class IterateChangesetsBuilder extends XyzQueryBuilder<IterateChangesetsI
 
     event.ignoreLimit = true;
 
-    return null;
+    try {
+      return ((IterateChangesetsQR) new IterateChangesetsQR<FeatureCollection>(event)
+          .withDataSourceProvider(getDataSourceProvider()))
+          .buildQuery(event);
+    }
+    catch (SQLException | ErrorResponseException e) {
+      throw new QueryBuildingException(e);
+    }
+  }
+
+  protected static class IterateChangesetsQR<R extends XyzResponse> extends IterateChangesets<R> {
+
+
+    public IterateChangesetsQR(IterateChangesetsEvent event) throws SQLException, ErrorResponseException {
+      super(event);
+    }
+
+    @Override
+    protected SQLQuery buildQuery(IterateChangesetsEvent event) throws SQLException, ErrorResponseException {
+      return super.buildQuery(event);
+    }
   }
 
   public record IterateChangesetsInput(

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/IterateFeatures.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/IterateFeatures.java
@@ -73,7 +73,7 @@ public class IterateFeatures<E extends IterateFeaturesEvent, R extends XyzRespon
 
   protected SQLQuery buildOffsetFilterFragment(IterateFeaturesEvent event, int dataset) {
     if (event.getStartI() >= 0 || event.getEndI() >= 0) {
-      SQLQuery iPagingFragment = new SQLQuery("${{pagingStartI}} ${{pagingEndI}} ")
+      return new SQLQuery("${{pagingStartI}} ${{pagingEndI}} ")
           .withQueryFragment("pagingStartI", event.getStartI() >= 0
               ? new SQLQuery("AND i >= #{startI}")
               .withNamedParameter("startI", event.getStartI())

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/IterateFeatures.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/IterateFeatures.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2025 HERE Europe B.V.
+ * Copyright (C) 2017-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,6 +72,17 @@ public class IterateFeatures<E extends IterateFeaturesEvent, R extends XyzRespon
   }
 
   protected SQLQuery buildOffsetFilterFragment(IterateFeaturesEvent event, int dataset) {
+    if (event.getStartI() >= 0 || event.getEndI() >= 0) {
+      SQLQuery iPagingFragment = new SQLQuery("${{pagingStartI}} ${{pagingEndI}} ")
+          .withQueryFragment("pagingStartI", event.getStartI() >= 0
+              ? new SQLQuery("AND i >= #{startI}")
+              .withNamedParameter("startI", event.getStartI())
+              : new SQLQuery(""))
+          .withQueryFragment("pagingEndI", event.getEndI() >= 0
+              ? new SQLQuery("AND i <= #{endI}").withNamedParameter("endI", event.getEndI())
+              : new SQLQuery(""));
+    }
+
     if (event.getNextPageToken() == null)
       return new SQLQuery("");
 

--- a/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/branching/HistoryManager.java
+++ b/xyz-psql-connector/src/main/java/com/here/xyz/psql/query/branching/HistoryManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2025 HERE Europe B.V.
+ * Copyright (C) 2017-2026 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,7 +83,7 @@ public class HistoryManager {
           //.withParams(); //TODO:
 
       try {
-        changesets = new IterateChangesets(event)
+        changesets = (ChangesetCollection) new IterateChangesets(event)
             .withDataSourceProvider(branchManager.dataSourceProvider)
             .run();
       }


### PR DESCRIPTION
- Also enhance IterateChangesets QR to support squashing & filtering by operation
- Also support defining startI / endI paging limits for IterateFeatures QR
- Enhance ExportSpaceToFiles step to support exporting changesets
- Introduce #versionRef property on Changeset & ChangesetCollection responses in favor of the single version
    - as now a single Changeset could be also a squashed changeset that spans across a version range
    - Improve response handling in ChangesetApi accordingly
