### PR TITLE
Increase SFN execution timeout and import step thread count

### DIFF
--- a/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/execution/GraphTransformer.java
+++ b/xyz-jobs/xyz-job-service/src/main/java/com/here/xyz/jobs/steps/execution/GraphTransformer.java
@@ -56,7 +56,7 @@ public class GraphTransformer {
 
   private static final String LAMBDA_INVOKE_RESOURCE = "arn:aws:states:::lambda:invoke";
   private static final String EMR_INVOKE_RESOURCE = "arn:aws:states:::emr-serverless:startJobRun.sync";
-  private static final int STATE_MACHINE_EXECUTION_TIMEOUT_SECONDS = 36 * 3600; //36h
+  private static final int STATE_MACHINE_EXECUTION_TIMEOUT_SECONDS = 7 * 24 * 3600; //7d
   private static final int EMR_EXECUTION_TIMEOUT_MINUTES = 12 * 60; //6h
   private static final int MIN_STEP_TIMEOUT_SECONDS = 5 * 60;
   private static final int STEP_EXECUTION_HEARTBEAT_TIMEOUT_SECONDS = 3 * 60; //3min

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/TaskedImportFilesToSpace.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/TaskedImportFilesToSpace.java
@@ -72,8 +72,8 @@ public class TaskedImportFilesToSpace extends TaskedSpaceBasedStep<TaskedImportF
   public static final String STATISTICS = "statistics";
 
   {
-    //Use 11 Threads as default for import tasks
-    threadCount = 11;
+    //Use 15 Threads as default for import tasks
+    threadCount = 15;
     addOutputSets(List.of(new OutputSet(STATISTICS, USER, true)));
   }
 

--- a/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/TaskedSpaceBasedStep.java
+++ b/xyz-jobs/xyz-job-steps/src/main/java/com/here/xyz/jobs/steps/impl/transport/TaskedSpaceBasedStep.java
@@ -99,7 +99,7 @@ public abstract class TaskedSpaceBasedStep<T extends TaskedSpaceBasedStep, I ext
   /** Maximum number of retry attempts, for a server side killed single, before failing retry handling. */
   public static final Integer MAX_TASK_RETRY_ATTEMPTS = 3;
   /** Hard ceiling for the concurrency of a single step, regardless of its configured {@link #threadCount}. */
-  public static final int MAX_THREAD_COUNT = 10;
+  public static final int MAX_THREAD_COUNT = 15;
   /** Number of tasks a step is allowed to run concurrently right after it was started or resumed. */
   public static final int INITIAL_THREAD_COUNT = 1;
   /** Time that has to pass before the concurrency limit is raised again. */


### PR DESCRIPTION
- Set SFN state machine execution timeout to 7 days
- Set threadCount=15 in TaskedImportFilesToSpace
- Set TaskedSpaceBasedStep#MAX_THREAD_COUNT=15